### PR TITLE
PR delete OC objects by selector

### DIFF
--- a/.github/workflows/on_pr_closed.yaml
+++ b/.github/workflows/on_pr_closed.yaml
@@ -33,8 +33,8 @@ jobs:
       
       - name: Remove Openshift Objects 
         run: |
-          oc delete secret pr-${{ github.event.number }}-traction-acapy          
-          oc delete pvc data-pr-${{ github.event.number }}-traction-0
+          oc delete secret,pvc --selector "app.kubernetes.io/instance"=pr-${{ github.event.number }}-traction
+
 
 
 


### PR DESCRIPTION
Signed-off-by: usingtechnology <tools@usingtechnolo.gy>

Manifest/config repo updated, this `oc delete` command can be used now due to proper labels.