### PR TITLE
Port of event bus from aca-py

### DIFF
--- a/services/traction/api/core/config.py
+++ b/services/traction/api/core/config.py
@@ -6,6 +6,9 @@ from typing import Optional
 
 from pydantic import BaseSettings, PostgresDsn
 
+from api.core.event_bus import EventBus
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -81,6 +84,8 @@ class GlobalConfig(BaseSettings):
     JWT_SECRET_KEY = "09d25e094faa6ca2556c818166b7a9563b93f7099f6f0f4caa6cf63b88e8d3e7"
     JWT_ALGORITHM = "HS256"
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES = 300
+
+    EVENT_BUS: EventBus = EventBus()
 
     class Config:
         case_sensitive = True

--- a/services/traction/api/core/event_bus.py
+++ b/services/traction/api/core/event_bus.py
@@ -1,0 +1,200 @@
+"""A simple event bus."""
+
+import asyncio
+from contextlib import contextmanager
+import logging
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Match,
+    NamedTuple,
+    Optional,
+    Pattern,
+    TYPE_CHECKING,
+)
+from functools import partial
+
+if TYPE_CHECKING:  # To avoid circular import error
+    from core.profile import Profile
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Event:
+    """A simple event object."""
+
+    def __init__(self, topic: str, payload: Any = None):
+        """Create a new event."""
+        self._topic = topic
+        self._payload = payload
+
+    @property
+    def topic(self):
+        """Return this event's topic."""
+        return self._topic
+
+    @property
+    def payload(self):
+        """Return this event's payload."""
+        return self._payload
+
+    def __eq__(self, other):
+        """Test equality."""
+        if not isinstance(other, Event):
+            return False
+        return self._topic == other._topic and self._payload == other._payload
+
+    def __repr__(self):
+        """Return debug representation."""
+        return "<Event topic={}, payload={}>".format(self._topic, self._payload)
+
+    def with_metadata(self, metadata: "EventMetadata") -> "EventWithMetadata":
+        """Annotate event with metadata and return EventWithMetadata object."""
+        return EventWithMetadata(self.topic, self.payload, metadata)
+
+
+class EventMetadata(NamedTuple):
+    """Metadata passed alongside events to add context."""
+
+    pattern: Pattern
+    match: Match[str]
+
+
+class EventWithMetadata(Event):
+    """Event with metadata passed alongside events to add context."""
+
+    def __init__(self, topic: str, payload: Any, metadata: EventMetadata):
+        """Initialize event metadata."""
+        super().__init__(topic, payload)
+        self._metadata = metadata
+
+    @property
+    def metadata(self) -> EventMetadata:
+        """Return metadata."""
+        return self._metadata
+
+
+class EventBus:
+    """A simple event bus implementation."""
+
+    def __init__(self):
+        """Initialize Event Bus."""
+        self.topic_patterns_to_subscribers: Dict[Pattern, List[Callable]] = {}
+
+    async def notify(self, profile: "Profile", event: Event):
+        """Notify subscribers of event.
+
+        Args:
+            profile (Profile): context of the event
+            event (Event): event to emit
+
+        """
+        # TODO don't block notifier until subscribers have all been called?
+        # TODO trigger each processor but don't await?
+        # TODO log errors but otherwise ignore?
+
+        LOGGER.debug("Notifying subscribers: %s", event)
+
+        partials = []
+        for pattern, subscribers in self.topic_patterns_to_subscribers.items():
+            match = pattern.match(event.topic)
+
+            if not match:
+                continue
+
+            for subscriber in subscribers:
+                partials.append(
+                    partial(
+                        subscriber,
+                        profile,
+                        event.with_metadata(EventMetadata(pattern, match)),
+                    )
+                )
+
+        for processor in partials:
+            try:
+                await processor()
+            except Exception:
+                LOGGER.exception("Error occurred while processing event")
+
+    def subscribe(self, pattern: Pattern, processor: Callable):
+        """Subscribe to an event.
+
+        Args:
+            pattern (Pattern): compiled regular expression for matching topics
+            processor (Callable): async callable accepting profile and event
+
+        """
+        LOGGER.debug("Subscribed: topic %s, processor %s", pattern, processor)
+        if pattern not in self.topic_patterns_to_subscribers:
+            self.topic_patterns_to_subscribers[pattern] = []
+        self.topic_patterns_to_subscribers[pattern].append(processor)
+
+    def unsubscribe(self, pattern: Pattern, processor: Callable):
+        """Unsubscribe from an event.
+
+        This method is idempotent. Repeated calls to unsubscribe will not
+        result in errors.
+
+        Args:
+            pattern (Pattern): regular expression used to subscribe the processor
+            processor (Callable): processor to unsubscribe
+
+        """
+        if pattern in self.topic_patterns_to_subscribers:
+            try:
+                index = self.topic_patterns_to_subscribers[pattern].index(processor)
+            except ValueError:
+                return
+            del self.topic_patterns_to_subscribers[pattern][index]
+            if not self.topic_patterns_to_subscribers[pattern]:
+                del self.topic_patterns_to_subscribers[pattern]
+            LOGGER.debug("Unsubscribed: topic %s, processor %s", pattern, processor)
+
+    @contextmanager
+    def wait_for_event(
+        self,
+        waiting_profile: "Profile",
+        pattern: Pattern,
+        cond: Optional[Callable[[Event], bool]] = None,
+    ) -> Iterator[Awaitable[Event]]:
+        """Capture an event and retrieve its value."""
+        future = asyncio.get_event_loop().create_future()
+
+        async def _handle_single_event(profile, event):
+            """Handle the single event."""
+            LOGGER.debug(
+                "wait_for_event event listener with event %s and profile %s",
+                event,
+                profile,
+            )
+            if cond is not None and not cond(event):
+                return
+
+            if waiting_profile == profile:
+                future.set_result(event)
+                self.unsubscribe(pattern, _handle_single_event)
+
+        self.subscribe(pattern, _handle_single_event)
+
+        yield future
+
+        if not future.done():
+            future.cancel()
+
+
+class MockEventBus(EventBus):
+    """A mock EventBus for testing."""
+
+    def __init__(self):
+        """Initialize MockEventBus."""
+        super().__init__()
+        self.events = []
+
+    async def notify(self, profile: "Profile", event: Event):
+        """Append the event to MockEventBus.events."""
+        self.events.append((profile, event))

--- a/services/traction/api/core/profile.py
+++ b/services/traction/api/core/profile.py
@@ -1,0 +1,32 @@
+"""Classes for managing profile information within a request context."""
+
+import logging
+
+from abc import ABC
+from typing import Any
+
+from api.core.config import settings
+from api.core.event_bus import Event
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Profile(ABC):
+    """Base abstraction for handling identity-related state."""
+
+    def __init__(
+        self,
+        wallet_id: str,
+    ):
+        """Initialize a base profile."""
+        self._wallet_id = wallet_id
+
+    @property
+    def wallet_id(self):
+        """Return this event's wallet_id."""
+        return self._wallet_id
+
+    async def notify(self, topic: str, payload: Any):
+        """Signal an event."""
+        await settings.EVENT_BUS.notify(self, Event(topic, payload))

--- a/services/traction/api/endpoints/models/webhooks.py
+++ b/services/traction/api/endpoints/models/webhooks.py
@@ -1,0 +1,7 @@
+import re
+
+
+# the event id will be "traction::WEBHOOK::<topic>::<potentially some other id>"
+# ... and the event payload should contain the webhook payload
+WEBHOOK_EVENT_PREFIX = "traction::WEBHOOK::"
+WEBHOOK_LISTENER_PATTERN = re.compile(f"^{WEBHOOK_EVENT_PREFIX}(.*)?$")

--- a/services/traction/api/tenant_main.py
+++ b/services/traction/api/tenant_main.py
@@ -1,17 +1,21 @@
+import logging
+
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm, OAuth2PasswordBearer
 from starlette.middleware import Middleware
 from starlette_context import plugins
 from starlette_context.middleware import RawContextMiddleware
 
+from api.core.config import settings
 from api.endpoints.routes.tenant_api import tenant_router
 from api.endpoints.dependencies.jwt_security import AccessToken, create_access_token
-from api.core.config import settings
 from api.endpoints.dependencies.tenant_security import (
     JWTTFetchingMiddleware,
     authenticate_tenant,
 )
 
+
+logger = logging.getLogger(__name__)
 
 middleware = [
     Middleware(


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Allows traction to setup handlers for events, e.g. receipt of certain types of webhooks
