### PR TITLE
Feature/pretty presentation request

### DIFF
--- a/services/showcase/frontend/src/components/alice/Credentials.vue
+++ b/services/showcase/frontend/src/components/alice/Credentials.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card>
-    <v-card-title> My Active Connections and Credentials</v-card-title>
+    <v-card-title> My Credentials</v-card-title>
     <v-card-text v-if="credentials && credentials.length">
       <v-card v-for="c in credentials" :key="c.id" class="ma-3">
         <v-card-title class="grey lighten-3 mb-3">{{
@@ -38,9 +38,7 @@
         </v-card-text>
       </v-card>
     </v-card-text>
-    <v-card-text v-else>
-      There are no active connections or credentials to show
-    </v-card-text>
+    <v-card-text v-else> There are no credentials to show </v-card-text>
   </v-card>
 </template>
 
@@ -48,7 +46,7 @@
 import { mapGetters, mapActions } from 'vuex';
 
 export default {
-  name: 'AliceConnections',
+  name: 'AliceCredentials',
   data() {
     return {
       loading: false,

--- a/services/showcase/frontend/src/components/alice/PresentationRequests.vue
+++ b/services/showcase/frontend/src/components/alice/PresentationRequests.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="presentationRequests && presentationRequests.length">
-    <v-card>
+    <v-card class="pa-3">
       <v-card-title> Pending Presentation Requests</v-card-title>
       <v-card
         v-for="pr in pendingPresentationRequests"
@@ -8,25 +8,50 @@
         class="ma-3"
       >
         <!-- this is not accurate, you will not know what the credential request is for... only in this specific demo -->
-        <v-card-title class="grey lighten-3 mb-3">{{ currentSandbox.governance.schema_def.name }}</v-card-title>
+        <v-card-title class="grey lighten-3 mb-3">{{
+          currentSandbox.governance.schema_def.name
+        }}</v-card-title>
         <v-card-text>
-          <template v-for="(value, key) in pr.presentation">
-            <div :key="key">
-              <b>{{ key }}:</b> {{ value }}
+          <div><b>Verifier: </b> {{ connection_label(pr.connection_id) }}</div>
+          <div
+            v-for="key in ['connection_id', 'created_at', 'present_state']"
+            :key="key"
+          >
+            <b>{{ key | keyToLabel }}: </b> {{ pr.presentation[key] }}
+          </div>
+          <hr />
+          <b>Requested Data:</b>
+          <ul>
+            <div
+              v-for="attr in JSON.parse(pr.presentation.present_request)
+                .requested_attributes"
+              :key="attr.name"
+            >
+              <li>
+                <b>{{ attr.name | keyToLabel }} </b>
+                <br /><i>RESTRICTIONS:</i> <br />
+                <div class="ml-2">
+                  <ul>
+                    <li>
+                      cred_def_id ==
+                      {{ attr.restrictions[0].cred_def_id }}
+                    </li>
+                  </ul>
+                </div>
+              </li>
             </div>
-          </template>
-          <!-- <v-expansion-panels>
+          </ul>
+
+          <v-expansion-panels>
             <v-expansion-panel>
               <v-expansion-panel-header> Details </v-expansion-panel-header>
               <v-expansion-panel-content>
-                <template v-for="(value, key) in co.credential">
-                  <div :key="key">
-                    <b>{{ key }}:</b> {{ value }}
-                  </div>
-                </template>
+                <div v-for="(value, key) in pr.presentation" :key="key">
+                  <b>{{ key | keyToLabel }}: </b> {{ value }}
+                </div>
               </v-expansion-panel-content>
             </v-expansion-panel>
-          </v-expansion-panels> -->
+          </v-expansion-panels>
         </v-card-text>
         <v-btn
           small
@@ -77,6 +102,10 @@ export default {
       'acceptPresentationRequest',
       'rejectPresentationRequest',
     ]),
+    connection_label() {
+      // This needs to take connection_id and map it through the store
+      return 'Acme';
+    },
     async accept(pres_req_id) {
       await this.acceptPresentationRequest(pres_req_id);
       await new Promise((r) => setTimeout(r, 1000)).then(() => {

--- a/services/showcase/frontend/src/views/Alice.vue
+++ b/services/showcase/frontend/src/views/Alice.vue
@@ -29,9 +29,9 @@
           <User />
         </v-col>
         <v-col cols="12" sm="8" md="6">
-          <CredentialOffers class="mb-4"/>
-          <PresentationRequests class="mb-4"/>
-          <Connections />
+          <CredentialOffers class="mb-4" />
+          <PresentationRequests class="mb-4" />
+          <Credentials />
         </v-col>
         <v-col cols="12" sm="4" md="3">
           <Messages />
@@ -49,7 +49,7 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 
-import Connections from '@/components/alice/Connections.vue';
+import Credentials from '@/components/alice/Credentials.vue';
 import CredentialOffers from '../components/alice/CredentialOffers.vue';
 import Messages from '@/components/alice/Messages.vue';
 import User from '@/components/alice/User.vue';
@@ -58,7 +58,7 @@ import PresentationRequests from '../components/alice/PresentationRequests.vue';
 export default {
   name: 'Alice',
   components: {
-    Connections,
+    Credentials,
     Messages,
     User,
     CredentialOffers,


### PR DESCRIPTION
Changing view for presenations requests.

renames connection component to credential component as that's what it actually does. Currently no 'connection management' in alice 'portal'

![image](https://user-images.githubusercontent.com/5376854/160194215-b390b497-cdd5-43be-8efa-bf68295a732f.png)
