### PR TITLE
allow caller to specify invitation protocol

### DIFF
--- a/services/traction/acapy_client/api/connection_api.py
+++ b/services/traction/acapy_client/api/connection_api.py
@@ -457,9 +457,9 @@ class ConnectionApi(object):
                 "allowed_values": {},
                 "openapi_types": {
                     "alias": (str,),
-                    "auto_accept": (bool,),
-                    "multi_use": (bool,),
-                    "public": (bool,),
+                    "auto_accept": (bool, str,),
+                    "multi_use": (bool, str,),
+                    "public": (bool, str,),
                     "body": (CreateInvitationRequest,),
                 },
                 "attribute_map": {

--- a/services/traction/api/endpoints/models/v1/contacts.py
+++ b/services/traction/api/endpoints/models/v1/contacts.py
@@ -133,7 +133,7 @@ class CreateInvitationPayload(BaseModel):
     """
 
     alias: str = Field(...)
-    invitation_type: ConnectionProtocolType = ConnectionProtocolType.DIDExchange
+    invitation_type: ConnectionProtocolType = ConnectionProtocolType.Connections
 
 
 class CreateInvitationResponse(GetResponse[ContactItem]):

--- a/services/traction/api/endpoints/models/v1/invitations.py
+++ b/services/traction/api/endpoints/models/v1/invitations.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from api.endpoints.models.connections import (
     ConnectionStateType,
+    ConnectionProtocolType,
 )
 from api.endpoints.models.v1.base import (
     AcapyItem,
@@ -97,11 +98,13 @@ class CreateReusableInvitationPayload(BaseModel):
 
     Attributes:
       name: required, must be unique. A name/label for the Invitation
+      invitation_type: what type of invitation to create
       tags: list of tags added to any resulting connections
 
     """
 
     name: str = Field(...)
+    invitation_type: ConnectionProtocolType = ConnectionProtocolType.Connections
     tags: Optional[List[str]] | None = None
 
 

--- a/services/traction/api/protocols/v1/connection/reusable_invitation_processor.py
+++ b/services/traction/api/protocols/v1/connection/reusable_invitation_processor.py
@@ -39,10 +39,11 @@ class ReusableInvitationProcessor(DefaultConnectionProtocol):
                 profile.db.add(db_contact)
                 await profile.db.commit()
 
-    async def on_active(self, profile: Profile, payload: dict):
-        self.logger.debug(f"on_active({profile.wallet_id} {payload})")
+    async def on_response(self, profile: Profile, payload: dict):
+        self.logger.debug(f"on_response({profile.wallet_id} {payload})")
 
-        # now that the connection is active, update the alias, connection alias...
+        # now that the connection is far enough along
+        # update the alias, connection alias...
         label = payload["their_label"]
         values = {"alias": label, "connection_alias": label}
         stmt = (

--- a/services/traction/api/services/connections.py
+++ b/services/traction/api/services/connections.py
@@ -111,8 +111,8 @@ def get_connection_with_alias(alias: str) -> Connection:
 def create_invitation(
     alias: str, invitation_type: ConnectionProtocolType, multi_use: bool | None = False
 ) -> Invitation:
+    multi_use_qs_val = "true" if multi_use else "false"
     if invitation_type == ConnectionProtocolType.DIDExchange:
-        multi_use_qs_val = "true" if multi_use else "false"
         data = {
             "alias": alias,
             "handshake_protocols": [
@@ -125,7 +125,7 @@ def create_invitation(
         connection = get_connection_with_alias(alias)
         invitation = inv_record_to_invitation(inv, connection.connection_id)
     else:
-        params = {"alias": alias}
+        params = {"alias": alias, "multi_use": multi_use_qs_val}
         inv = connection_api.connections_create_invitation_post(**params)
         invitation = inv_result_to_invitation(inv)
     return invitation

--- a/services/traction/api/services/v1/invitations_service.py
+++ b/services/traction/api/services/v1/invitations_service.py
@@ -27,7 +27,6 @@ from api.endpoints.models.v1.invitations import (
     InvitationAcapy,
     InvitationStatusType,
 )
-from api.endpoints.models.connections import ConnectionProtocolType
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ async def create_reusable_invitation(
 
     acapy_invitation = connections.create_invitation(
         alias=payload.name,
-        invitation_type=ConnectionProtocolType.DIDExchange,
+        invitation_type=payload.invitation_type,
         multi_use=True,
     )
     connection = connections.get_connection_with_alias(payload.name)


### PR DESCRIPTION
Set to connections/1.0 by default (for phones).
Change create-invitation to match (connections/1.0 by default)

Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>