### PR TITLE
Default wallet scheme to MultiWalletSingleTableSharedPool

### DIFF
--- a/charts/traction/templates/acapy_deployment.yaml
+++ b/charts/traction/templates/acapy_deployment.yaml
@@ -46,7 +46,7 @@ spec:
            --wallet-storage-type 'postgres_storage' \
            --wallet-name 'mywallet' \
            --wallet-key '123' \
-           --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5}' \
+           --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5, \"wallet_scheme\":\"{{ .Values.acapy.service.walletScheme }}\"}' \
            --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \
            --seed \"$(WALLET_SEED)\" \
            --admin '0.0.0.0' {{ .Values.acapy.service.adminPort }} \

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -63,6 +63,7 @@ acapy:
     httpPort: 8030
     endorserAlias: endorser
     endorserPublicDID: AKaFAVGCZoDMZrydWtjUev
+    walletScheme: MultiWalletSingleTableSharedPool
 
   openshift:
     route:

--- a/scripts/.env-example
+++ b/scripts/.env-example
@@ -76,6 +76,7 @@ ACAPY_ADMIN_URL=http://traction-agent:8031
 ACAPY_WALLET_TYPE=postgres_storage
 ACAPY_WALLET_DATABASE=traction-wallet
 ACAPY_WALLET_ENCRYPTION_KEY=key
+ACAPY_WALLET_SCHEME=MultiWalletSingleTableSharedPool
 
 # ------------------------------------------------------------
 # Postgres Storage

--- a/services/aca-py/ngrok-wait.sh
+++ b/services/aca-py/ngrok-wait.sh
@@ -37,7 +37,7 @@ exec aca-py start \
     --wallet-name "${ACAPY_WALLET_DATABASE}" \
     --wallet-key "${ACAPY_WALLET_ENCRYPTION_KEY}" \
     --wallet-storage-type "${ACAPY_WALLET_STORAGE_TYPE}" \
-    --wallet-storage-config "{\"url\":\"${POSTGRESQL_HOST}:5432\",\"max_connections\":5}" \
+    --wallet-storage-config "{\"url\":\"${POSTGRESQL_HOST}:5432\",\"max_connections\":5, \"wallet_scheme\":\"${ACAPY_WALLET_SCHEME}\"}" \
     --wallet-storage-creds "{\"account\":\"${POSTGRESQL_USER}\",\"password\":\"${POSTGRESQL_PASSWORD}\",\"admin_account\":\"${POSTGRESQL_USER}\",\"admin_password\":\"${POSTGRESQL_PASSWORD}\"}" \
     --wallet-name traction-wallet  \
     --admin "0.0.0.0" ${ACAPY_ADMIN_PORT} \


### PR DESCRIPTION
For Traction we should be using the wallet scheme **MultiWalletSingleTableSharedPool** so that it's not creating databases for each tenant.
But allow this to be configurable by the Traction consumer.

Wallet schemes
https://github.com/hyperledger/indy-sdk/tree/master/experimental/plugins/postgres_storage#wallet-management-modes