### PR TITLE
make v1 tenant model and update v1 tenant admin routes to use v1 responses

### DIFF
--- a/services/traction/api/endpoints/models/v1/base.py
+++ b/services/traction/api/endpoints/models/v1/base.py
@@ -59,9 +59,8 @@ class Link(BaseModel):
 class Item(GenericModel, Generic[StatusType, StateType]):
     """Item.
 
-    Base class for any individual object/resource.
+    Base class for any individual object/resource with status/state.
     Concrete classes will specify the exact classes to use for Status and State.
-
 
     Attributes:
       status: Represents a business level status for the object

--- a/services/traction/api/endpoints/models/v1/tenant.py
+++ b/services/traction/api/endpoints/models/v1/tenant.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from api.endpoints.models.v1.base import GetResponse
+
+
+class IssuerStatus(str, Enum):
+    none = "N/A"
+    requested = "Requested"
+    active = "Active"
+
+
+class PublicDIDStatus(str, Enum):
+    none = "N/A"
+    private = "Private"
+    requested = "Requested"
+    endorsed = "Endorsed"
+    published = "Published"
+    public = "Public"
+
+
+class TenantItem(BaseModel):
+    tenant_id: UUID
+    wallet_id: UUID
+    name: str
+    public_did: str | None = None
+    public_did_status: PublicDIDStatus | None = PublicDIDStatus.none
+    issuer: bool
+    issuer_status: IssuerStatus | None = IssuerStatus.none
+    deleted: bool = False
+    created_at: datetime
+    updated_at: datetime
+
+
+class TenantGetResponse(GetResponse[TenantItem]):
+    pass

--- a/services/traction/api/endpoints/routes/v1/tenant/admin/issuer.py
+++ b/services/traction/api/endpoints/routes/v1/tenant/admin/issuer.py
@@ -1,40 +1,35 @@
 import logging
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import APIRouter
+
 from starlette import status
 
 from api.endpoints.dependencies.tenant_security import get_from_context
-from api.endpoints.dependencies.db import get_db
-from api.services.tenant_workflows import create_workflow
 
-from api.db.repositories.tenant_issuers import TenantIssuersRepository
+from api.endpoints.models.v1.tenant import TenantGetResponse
 
-from api.endpoints.models.tenant_workflow import TenantWorkflowTypeType
-from api.endpoints.models.v1.admin import AdminTenantIssueRead
+from api.services.v1 import tenant_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
 @router.post(
-    "/make-issuer", status_code=status.HTTP_200_OK, response_model=AdminTenantIssueRead
+    "/make-issuer", status_code=status.HTTP_200_OK, response_model=TenantGetResponse
 )
-async def init_issuer(db: AsyncSession = Depends(get_db)) -> AdminTenantIssueRead:
-    # TODO: update to use a v1 style response, not v0 classes
+async def initialize_issuer() -> TenantGetResponse:
     """
     If the innkeeper has authorized your tenant to become an issuer, initialize
     here to write a endorsed public did the configured Hyperledger-Indy service
     """
     wallet_id = get_from_context("TENANT_WALLET_ID")
-    issuer_repo = TenantIssuersRepository(db_session=db)
-    # create workflow and update issuer record
-    await create_workflow(
-        wallet_id,
-        TenantWorkflowTypeType.issuer,
-        db,
-    )
-    # get updated issuer info (should have workflow id and connection_id)
-    tenant_issuer = await issuer_repo.get_by_wallet_id(wallet_id)
+    tenant_id = get_from_context("TENANT_ID")
 
-    return tenant_issuer
+    item = await tenant_service.make_issuer(
+        tenant_id,
+        wallet_id,
+    )
+
+    links = []  # TODO: determine useful links for /make-issuer
+
+    return TenantGetResponse(item=item, links=links)

--- a/services/traction/api/services/v1/issuer_service.py
+++ b/services/traction/api/services/v1/issuer_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 from acapy_client.api.revocation_api import RevocationApi
 from acapy_client.model.revoke_request import RevokeRequest
 from api.endpoints.models.v1.governance import TemplateStatusType
-from api.services.v1.governance_service import get_public_did
+from api.services.v1 import tenant_service
 
 from acapy_client.api.issue_credential_v1_0_api import IssueCredentialV10Api
 from api.db.models.v1.contact import Contact
@@ -185,7 +185,7 @@ async def offer_new_credential(
 
     """
     # see if we are an issuer...
-    await get_public_did(db, tenant_id)
+    await tenant_service.is_issuer(tenant_id, wallet_id, True)
 
     # need to find the contact/connection
     # need to find the credential template/cred def

--- a/services/traction/api/services/v1/tenant_service.py
+++ b/services/traction/api/services/v1/tenant_service.py
@@ -1,0 +1,134 @@
+import logging
+from uuid import UUID
+
+from api.db.errors import DoesNotExist
+from api.db.models.tenant import TenantRead
+from api.db.models.tenant_issuer import TenantIssuerRead
+from api.db.repositories.tenant_issuers import TenantIssuersRepository
+from api.db.repositories.tenants import TenantsRepository
+from api.db.session import async_session
+from api.endpoints.models.tenant_workflow import TenantWorkflowTypeType
+from api.endpoints.models.v1.admin import PublicDIDStateType
+from api.endpoints.models.v1.errors import IncorrectStatusError, NotAnIssuerError
+from api.endpoints.models.v1.tenant import TenantItem, IssuerStatus, PublicDIDStatus
+from api.services.tenant_workflows import create_workflow
+
+logger = logging.getLogger(__name__)
+
+
+def db_to_tenant_item(
+    db_tenant: TenantRead, tenant_issuer: TenantIssuerRead | None = None
+) -> TenantItem:
+    logger.info(db_tenant)
+    logger.info(tenant_issuer)
+    result = TenantItem(
+        tenant_id=db_tenant.id,
+        wallet_id=db_tenant.wallet_id,
+        created_at=db_tenant.created_at,
+        updated_at=db_tenant.updated_at,
+        name=db_tenant.name,
+        deleted=not db_tenant.is_active,
+        issuer=False,
+        issuer_status=IssuerStatus.none,
+        public_did=None,
+        public_did_status=PublicDIDStatus.none,
+    )
+
+    if tenant_issuer:
+        # for now, base this on the public did state
+        # when we change up the workflow
+        # (tenant can request public did, tenant requests issuer)
+        # this will get simplified, right now mashup of v0 stuff...
+        result.public_did = tenant_issuer.public_did
+        if PublicDIDStateType.public == tenant_issuer.public_did_state:
+            result.issuer = True
+            result.issuer_status = IssuerStatus.active
+            result.public_did_status = PublicDIDStatus.public
+        elif PublicDIDStateType.requested == tenant_issuer.public_did_state:
+            result.issuer_status = IssuerStatus.requested
+            result.public_did_status = PublicDIDStatus.requested
+        elif PublicDIDStateType.endorsed == tenant_issuer.public_did_state:
+            result.issuer_status = IssuerStatus.endorsed
+            result.public_did_status = PublicDIDStatus.endorsed
+        elif PublicDIDStateType.published == tenant_issuer.public_did_state:
+            result.issuer_status = IssuerStatus.active
+            result.public_did_status = PublicDIDStatus.published
+
+    return result
+
+
+async def get_tenant(
+    tenant_id: UUID,
+    wallet_id: UUID,
+    deleted: bool | None = False,
+) -> TenantItem:
+    """Get Tenant.
+
+    Find and return a Traction Tenant by ID.
+
+    Args:
+      tenant_id: Traction ID of tenant making the call
+      deleted: When True, return Tenant if marked as deleted
+
+    Returns: The Traction Tenant
+
+    Raises:
+      NotFoundError: if the Tenant cannot be found by ID and deleted flag
+    """
+    async with async_session() as db:
+        tenant_repo = TenantsRepository(db_session=db)
+        db_tenant = await tenant_repo.get_by_id(tenant_id)
+        tenant_issuer = None
+        try:
+            issuer_repo = TenantIssuersRepository(db_session=db)
+            tenant_issuer = await issuer_repo.get_by_tenant_id(tenant_id)
+        except DoesNotExist:
+            # this is ok, they haven't started the v0 issuer process
+            pass
+
+    item = db_to_tenant_item(db_tenant, tenant_issuer)
+
+    return item
+
+
+async def make_issuer(
+    tenant_id: UUID,
+    wallet_id: UUID,
+) -> TenantItem:
+    async with async_session() as db:
+        try:
+            issuer_repo = TenantIssuersRepository(db_session=db)
+            tenant_issuer = await issuer_repo.get_by_wallet_id(wallet_id)
+        except DoesNotExist:
+            # raise an error, let caller know that innkeeper hasn't started the flow yet
+            raise IncorrectStatusError(
+                code="tenant.issuer.innkeeper-not-approved",
+                title="Tenant Issuer - Innkeeper not approved",
+                detail="Innkeeper has to approve the Issuer process before tenant can make themselves an issuer.",  # noqa: E501
+            )
+
+        # create workflow and update issuer record
+        await create_workflow(
+            tenant_issuer.wallet_id,
+            TenantWorkflowTypeType.issuer,
+            db,
+        )
+
+    return await get_tenant(tenant_id, wallet_id)
+
+
+async def is_issuer(
+    tenant_id: UUID, wallet_id: UUID, raise_error: bool | None = False
+) -> str:
+    tenant = await get_tenant(tenant_id, wallet_id)
+    public_did = tenant.public_did
+
+    if raise_error and tenant.public_did_status is not PublicDIDStatus.public:
+        raise NotAnIssuerError(
+            code="tenant.issuer.not-allowed",
+            title="Tenant is not an Issuer",
+            detail="Tenant is not an Issuer and cannot write schemas or credential definitions to the ledger.",  # noqa: E501
+            links=[],  # TODO: add link to make issuer
+        )
+
+    return public_did

--- a/services/traction/bdd-tests/features/set-tenant-as-issuer.feature
+++ b/services/traction/bdd-tests/features/set-tenant-as-issuer.feature
@@ -4,6 +4,10 @@ Feature: innkeeper tenant management
         And we have "1" traction tenants
         | name  | role    |
         | alice | issuer |
-        When "alice" is allowed to be an issuer by the innkeeper
+        Then "alice" is not an issuer
+        And "alice" cannot register as an issuer
+        Then "alice" is allowed to be an issuer by the innkeeper
         And "alice" registers as an issuer
+        And we sadly wait for 10 seconds because we have not figured out how to listen for events
         Then "alice" will have a public did
+        And "alice" is an issuer

--- a/services/traction/bdd-tests/features/steps/innkeeper.py
+++ b/services/traction/bdd-tests/features/steps/innkeeper.py
@@ -2,8 +2,8 @@ import json
 import requests
 from behave import *
 from starlette import status
-from steps.setup import _hard_delete_tenant
-
+from setup import _hard_delete_tenant
+import time
 
 @given('"{tenant}" is allowed to be an issuer by the innkeeper')
 @when('"{tenant}" is allowed to be an issuer by the innkeeper')
@@ -15,6 +15,8 @@ def step_impl(context, tenant: str):
         headers=context.config.userdata["innkeeper_auth_headers"],
     )
     assert response.status_code == status.HTTP_200_OK, response.__dict__
+    # wait for endorser signatures and ledger writes
+    time.sleep(20)
 
 
 @then('"{tenant}" will have a public did')

--- a/services/traction/bdd-tests/features/steps/innkeeper.py
+++ b/services/traction/bdd-tests/features/steps/innkeeper.py
@@ -5,8 +5,7 @@ from starlette import status
 from setup import _hard_delete_tenant
 import time
 
-@given('"{tenant}" is allowed to be an issuer by the innkeeper')
-@when('"{tenant}" is allowed to be an issuer by the innkeeper')
+@step('"{tenant}" is allowed to be an issuer by the innkeeper')
 def step_impl(context, tenant: str):
     response = requests.post(
         context.config.userdata.get("traction_host")

--- a/services/traction/bdd-tests/features/steps/tenant_issuer.py
+++ b/services/traction/bdd-tests/features/steps/tenant_issuer.py
@@ -94,6 +94,7 @@ def step_impl(context, tenant):
     context.execute_steps(
         f"""
     Given "{tenant}" is allowed to be an issuer by the innkeeper
+    And we sadly wait for {10} seconds because we have not figured out how to listen for events
     And "{tenant}" registers as an issuer
     And we sadly wait for {5} seconds because we have not figured out how to listen for events
     And "{tenant}" will have a public did   

--- a/services/traction/bdd-tests/features/steps/v1_api.py
+++ b/services/traction/bdd-tests/features/steps/v1_api.py
@@ -202,3 +202,18 @@ def delete_message(context, tenant, item_id):
         headers=context.config.userdata[tenant]["auth_headers"],
     )
     return response
+
+
+def get_tenant_self(context, tenant):
+    response = requests.get(
+        context.config.userdata.get("traction_host") + "/tenant/v1/admin/self",
+        headers=context.config.userdata[tenant]["auth_headers"],
+    )
+    return response
+
+def tenant_make_issuer(context, tenant: str):
+    response = requests.post(
+        context.config.userdata.get("traction_host") + "/tenant/v1/admin/make-issuer",
+        headers=context.config.userdata[tenant]["auth_headers"],
+    )
+    return response


### PR DESCRIPTION
Still uses the v0 workflow.
Basically cosmetic changes for consistency in v1 api for right now.

Return a better response when the Tenant calls make-issuer before Innkeeper

Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>