### PR TITLE
Missing query resolver .all() on some list queries. 

### DIFF
--- a/services/traction/api/db/models/v1/governance.py
+++ b/services/traction/api/db/models/v1/governance.py
@@ -225,7 +225,7 @@ class SchemaTemplate(StatefulModel, TimestampModel, table=True):
 
         q = select(cls).where(cls.tenant_id == tenant_id).order_by(desc(cls.updated_at))
         q_result = await db.execute(q)
-        db_recs = q_result.scalars()
+        db_recs = q_result.scalars().all()
         return db_recs
 
 
@@ -472,7 +472,7 @@ class CredentialTemplate(StatefulModel, TimestampModel, table=True):
 
         q = select(cls).filter(*filters).order_by(desc(cls.updated_at))
         q_result = await db.execute(q)
-        db_recs = q_result.scalars()
+        db_recs = q_result.scalars().all()
         return db_recs
 
     @classmethod
@@ -499,7 +499,7 @@ class CredentialTemplate(StatefulModel, TimestampModel, table=True):
             .order_by(desc(cls.created_at))
         )
         q_result = await db.execute(q)
-        db_recs = q_result.scalars()
+        db_recs = q_result.scalars().all()
         return db_recs
 
     @classmethod
@@ -519,5 +519,5 @@ class CredentialTemplate(StatefulModel, TimestampModel, table=True):
 
         q = select(cls).where(cls.tenant_id == tenant_id).order_by(desc(cls.updated_at))
         q_result = await db.execute(q)
-        db_recs = q_result.scalars()
+        db_recs = q_result.scalars().all()
         return db_recs

--- a/services/traction/api/services/v1/contacts_service.py
+++ b/services/traction/api/services/v1/contacts_service.py
@@ -259,7 +259,7 @@ async def list_contacts(
     results_q = base_q.limit(limit).offset(skip).order_by(desc(Contact.updated_at))
 
     results_q_recs = await db.execute(results_q)
-    db_contacts = results_q_recs.scalars()
+    db_contacts = results_q_recs.scalars().all()
 
     items = []
     for db_contact in db_contacts:

--- a/services/traction/api/services/v1/governance_service.py
+++ b/services/traction/api/services/v1/governance_service.py
@@ -122,7 +122,7 @@ async def list_schema_templates(
     )
 
     results_q_recs = await db.execute(results_q)
-    db_recs = results_q_recs.scalars()
+    db_recs = results_q_recs.scalars().all()
 
     items = []
     for db_rec in db_recs:
@@ -485,7 +485,7 @@ async def list_credential_templates(
     )
 
     results_q_recs = await db.execute(results_q)
-    db_recs = results_q_recs.scalars()
+    db_recs = results_q_recs.scalars().all()
 
     items = []
     for db_rec in db_recs:

--- a/services/traction/api/services/v1/invitations_service.py
+++ b/services/traction/api/services/v1/invitations_service.py
@@ -152,7 +152,7 @@ async def list_invitations(
     )
 
     results_q_recs = await db.execute(results_q)
-    db_items = results_q_recs.scalars()
+    db_items = results_q_recs.scalars().all()
 
     items = []
     for db_item in db_items:

--- a/services/traction/api/services/v1/issuer_service.py
+++ b/services/traction/api/services/v1/issuer_service.py
@@ -156,7 +156,7 @@ async def list_issuer_credentials(
     )
 
     results_q_recs = await db.execute(results_q)
-    db_items = results_q_recs.scalars()
+    db_items = results_q_recs.scalars().all()
 
     items = []
     for db_item in db_items:

--- a/services/traction/api/services/v1/messages_service.py
+++ b/services/traction/api/services/v1/messages_service.py
@@ -170,7 +170,7 @@ async def list_messages(
 
     async with async_session() as db:
         results_q_recs = await db.execute(results_q)
-    db_items = results_q_recs.scalars()
+    db_items = results_q_recs.scalars().all()
 
     items = []
     for db_item in db_items:

--- a/services/traction/api/services/v1/verifier_service.py
+++ b/services/traction/api/services/v1/verifier_service.py
@@ -152,7 +152,6 @@ async def list_presentation_requests(
     count_q = select([func.count()]).select_from(base_q)
 
     async with async_session() as db:
-
         count_q_rec = await db.execute(count_q)
         total_count = count_q_rec.scalar()
 
@@ -167,7 +166,7 @@ async def list_presentation_requests(
         )
 
         results_q_recs = await db.execute(results_q)
-        db_verifier_presentations = results_q_recs.scalars()
+        db_verifier_presentations = results_q_recs.scalars().all()
 
     items = []
     for db_verifier_presentation in db_verifier_presentations:


### PR DESCRIPTION
If you use the scalar result, it will resolve to the obj's JIT for some operations, but it is not the result, when returning that result, force resolution to list by using .all(). 

If not resolved properly, code will crash (expects list of data, but gets a query_result object). 

Signed-off-by: Jason Sy <jasyrotuck@gmail.com>