### PR TITLE
Fix Tenant UI qr code bug and add structure for AIP compatibility page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Overview of the traction architecture:
 
 [Architecture](./docs/ARCHITECTURE.md)
 
+Aries Interop Profile status:
+
+[Traction AIP](./docs/AIP.md)
+
 Source code for Traction API:
 
 [Traction](./services/traction/README.md)

--- a/docs/AIP.md
+++ b/docs/AIP.md
@@ -1,0 +1,122 @@
+# traction aries interop profile
+
+For details about AIP specifics see the [Aries RFC documentation](https://github.com/hyperledger/aries-rfcs/tree/main/concepts/0302-aries-interop-profile).
+
+This page will document progress of supporting specific AIP RFCs in Traction.
+
+Legend
+
+:white_check_mark: - Supported
+
+:hourglass_flowing_sand: - To be added, or in progress
+
+:question: - Unknown
+
+:no_entry_sign: - Will not support
+
+** under construction **
+
+## AIP 1.0
+
+[Link to 1.0](https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0302-aries-interop-profile/README.md#aries-interop-profile-version-10
+)
+
+
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Concept | [0003-protocols](https://github.com/hyperledger/aries-rfcs/tree/9b7ab9814f2e7d1108f74aca6f3d2e5d62899473/concepts/0003-protocols) | :question: | -
+Concept | [0004-agents](https://github.com/hyperledger/aries-rfcs/tree/f1e420f76abd9ff4af5c15d375fa6cf8c2cacb33/concepts/0004-agents) | :question: | -
+Concept | [0005-didcomm](https://github.com/hyperledger/aries-rfcs/tree/f1e420f76abd9ff4af5c15d375fa6cf8c2cacb33/concepts/0005-didcomm) | :question: | -
+Concept | [0008-message-id-and-threading](https://github.com/hyperledger/aries-rfcs/tree/64e5e55c123b2efaf38f4b0911a71a1c40a7f29d/concepts/0008-message-id-and-threading) | :question: | -
+Concept | [0011-decorators](https://github.com/hyperledger/aries-rfcs/tree/965a975f953d72e370d2b6fb28eec538ec756c6d/concepts/0011-decorators) | :question: | -
+Concept | [0017-attachments](https://github.com/hyperledger/aries-rfcs/tree/64e5e55c123b2efaf38f4b0911a71a1c40a7f29d/concepts/0017-attachments) | :question: | -
+Concept | [0020-message-types](https://github.com/hyperledger/aries-rfcs/tree/64e5e55c123b2efaf38f4b0911a71a1c40a7f29d/concepts/0020-message-types) | :question: | -
+Concept | [0046-mediators-and-relays](https://github.com/hyperledger/aries-rfcs/tree/64e5e55c123b2efaf38f4b0911a71a1c40a7f29d/concepts/0046-mediators-and-relays) | :question: | -
+Concept | [0047-json-LD-compatibility](https://github.com/hyperledger/aries-rfcs/tree/53c2e7accc8394c9c7b09563c0eec3c564c133c6/concepts/0047-json-ld-compatibility) | :question: | -
+Concept | [0050-wallets](https://github.com/hyperledger/aries-rfcs/tree/64e5e55c123b2efaf38f4b0911a71a1c40a7f29d/concepts/0050-wallets) | :question: | -
+Concept | [0094-cross-domain messaging](https://github.com/hyperledger/aries-rfcs/tree/64e5e55c123b2efaf38f4b0911a71a1c40a7f29d/concepts/0094-cross-domain-messaging) | :question: | -
+Feature | [0015-acks](https://github.com/hyperledger/aries-rfcs/tree/5cc750f0fe18e3918401489066566f22474e25a8/features/0015-acks) | :question: | -
+Feature | [0019-encryption-envelope](https://github.com/hyperledger/aries-rfcs/tree/9b0aaa39df7e8bd434126c4b33c097aae78d65bf/features/0019-encryption-envelope) | :question: | -
+Feature | [0160-connection-protocol](https://github.com/hyperledger/aries-rfcs/tree/4d9775490359e234ab8d1c152bca6f534e92a38d/features/0160-connection-protocol) | :white_check_mark: | Note here
+Feature | [0025-didcomm-transports](https://github.com/hyperledger/aries-rfcs/tree/b490ebe492985e1be9804fc0763119238b2e51ab/features/0025-didcomm-transports) | :question: | -
+Feature | [0035-report-problem](https://github.com/hyperledger/aries-rfcs/tree/89d14c15ab35b667e7a9d04fe42d4d48b10468cf/features/0035-report-problem) | :question: | -
+Feature | [0036-issue-credential](https://github.com/hyperledger/aries-rfcs/tree/bb42a6c35e0d5543718fb36dd099551ab192f7b0/features/0036-issue-credential) | :white_check_mark: | Note here
+Feature | [0037-present-proof](https://github.com/hyperledger/aries-rfcs/tree/4fae574c03f9f1013db30bf2c0c676b1122f7149/features/0037-present-proof) | :question: | -
+Feature | [0056-service-decorator](https://github.com/hyperledger/aries-rfcs/tree/527849ec3aa2a8fd47a7bb6c57f918ff8bcb5e8c/features/0056-service-decorator) | :question: | -
+
+
+## AIP 2.0
+
+[Link to 2.0](https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0302-aries-interop-profile/README.md#aip-20-clarification-changelog
+)
+
+#### Base Requirements
+
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Concept | [0003-protocols](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/concepts/0003-protocols) | :question: | -
+Concept | [0004-agents](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/concepts/0004-agents) | :question: | -
+Concept | [0005-didcomm](https://github.com/hyperledger/aries-rfcs/tree/1b4b014246d19c865c9b5520b97fe0376a86d8c4/concepts/0005-didcomm) | :question: | -
+Concept | [0008-message-id-and-threading](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/concepts/0008-message-id-and-threading) | :question: | -
+Concept | [0011-decorators](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/concepts/0011-decorators) | :question: | -
+Concept | [0017-attachments](https://github.com/hyperledger/aries-rfcs/tree/7759addb1506d107fddec692403bbc9e55fe491f/concepts/0017-attachments) | :question: | -
+Concept | [0020-message-types](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/concepts/0020-message-types) | :question: | -
+Concept | [0046-mediators-and-relays](https://github.com/hyperledger/aries-rfcs/tree/45b4233fcffda14f1339380ae2233289f21296b0/concepts/0046-mediators-and-relays) | :question: | -
+Concept | [0047-json-LD-compatibility](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/concepts/0047-json-ld-compatibility) | :question: | -
+Concept | [0050-wallets](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/concepts/0050-wallets) | :question: | -
+Concept | [0094-cross-domain messaging](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/concepts/0094-cross-domain-messaging) | :question: | -
+Concept | [0519-goal-codes](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/concepts/0519-goal-codes) | :question: | -
+Feature | [0015-acks](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0015-acks) | :question: | -
+Feature | [0019-encryption-envelope](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/features/0019-encryption-envelope) | :question: | -
+Feature | [0023-did-exchange](https://github.com/hyperledger/aries-rfcs/tree/bf3d796cc33ce78ed7cde7f5422b10719a68be21/features/0023-did-exchange) | :question: | -
+Feature | [0025-didcomm-transports](https://github.com/hyperledger/aries-rfcs/tree/f39481e92ad1a10dbc499cd4931a08c3497cee3f/features/0025-didcomm-transports) | :question: | -
+Feature | [0035-report-problem](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0035-report-problem) | :question: | -
+Feature | [0044-didcomm-file-and-mime-types](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0044-didcomm-file-and-mime-types) | :question: | -
+Feature | [0048-trust-ping](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/features/0048-trust-ping) | :question: | -
+Feature | [0183-revocation-notification](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/features/0183-revocation-notification) | :question: | -
+Feature | [0360-use-did-key](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/features/0360-use-did-key) | :question: | -
+Feature | [0434-outofband](https://github.com/hyperledger/aries-rfcs/tree/2bc7db66d15a55d70ce5bd16b2513a853c9d5749/features/0434-outofband) | :question: | -
+Feature | [0453-issue-credential-v2](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0453-issue-credential-v2) | :question: | -
+Feature | [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0454-present-proof-v2) | :question: | -
+Feature | [0557-discover-features-v2](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0557-discover-features-v2) | :question: | -
+Feature | [0627-static-peer-dids](https://github.com/hyperledger/aries-rfcs/tree/4739fbf6de07a54c3fee072bd85741422730b3cd/features/0627-static-peer-dids)  | :question: | -
+Feature | [0317-please-ack](https://github.com/hyperledger/aries-rfcs/tree/9ff2cab45487a1f6f74254abc9134419f2ad5858/features/0317-please-ack)  | :question: | -
+
+#### MEDIATE: Mediator Coordination
+
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Feature | [0211-route-coordination](https://github.com/hyperledger/aries-rfcs/tree/55e1e1c6e339ef0843268b4f3349b95cb7bd49a5/features/0211-route-coordination) | :question: | -
+Feature | [0092-transport-return-route](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0092-transport-return-route) | :question: | -
+
+#### INDYCRED: Indy Based Credentials
+
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Feature | [0592-indy-attachments](https://github.com/hyperledger/aries-rfcs/tree/26344513082af4d76c77b8b4f5064e72d0a83b58/features/0592-indy-attachments) | :question: | -
+Concept | [0441-present-proof-best-practices](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/concepts/0441-present-proof-best-practices) | :question: | -
+
+#### LDCRED: JSON-LD Based Credentials
+
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Feature | [0593-json-ld-cred-attach](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0593-json-ld-cred-attach) | :question: | -
+Feature | [0510-dif-pres-exch-attach](https://github.com/hyperledger/aries-rfcs/tree/7a44f650d3cebf5b3047c1680618978393a497d5/features/0510-dif-pres-exch-attach) | :question: | -
+
+#### BBSCRED: BBS+ Based Credentials
+
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Feature | [0593-json-ld-cred-attach](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0593-json-ld-cred-attach) | :question: | -
+Feature | [0646-bbs-credentials](https://github.com/hyperledger/aries-rfcs/blob/7a44f650d3cebf5b3047c1680618978393a497d5/features/0646-bbs-credentials/README.md) | :question: | -
+Feature | [0510-dif-pres-exch-attach](https://github.com/hyperledger/aries-rfcs/tree/7a44f650d3cebf5b3047c1680618978393a497d5/features/0510-dif-pres-exch-attach) | :question: | -
+
+#### DIDCOMMV2PREP: DIDComm v2 Prep
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Feature | [0587-encryption-envelope-v2](https://github.com/hyperledger/aries-rfcs/tree/4e78319e5f79df2003ddf37f8f497d0fae20cc63/features/0587-encryption-envelope-v2) | :question: | -
+
+#### CHAT: Chat related features
+ RFC Type | RFC/Link to RFC Version | Traction Support | Details
+--- | --- | --- | ---
+Feature | [0095-basic-message](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0095-basic-message) | :question: | -

--- a/services/grip/frontend/.env.production
+++ b/services/grip/frontend/.env.production
@@ -1,1 +1,1 @@
-VITE_TRACTION_ENDPOINT=http://localhost:5100
+VITE_TRACTION_ENDPOINT=https://traction-api-prod.apps.silver.devops.gov.bc.ca:5100

--- a/services/grip/frontend/.env.production
+++ b/services/grip/frontend/.env.production
@@ -1,1 +1,1 @@
-VITE_TRACTION_ENDPOINT=https://traction-api-prod.apps.silver.devops.gov.bc.ca:5100
+VITE_TRACTION_ENDPOINT=http://localhost:5100

--- a/services/grip/frontend/src/components/CreateContact.vue
+++ b/services/grip/frontend/src/components/CreateContact.vue
@@ -5,7 +5,6 @@ import Button from "primevue/button";
 import { useToast } from "vue-toastification";
 import axios from "axios";
 import QRCode from "./common/QRCode.vue";
-import QrcodeVue from "qrcode.vue";
 
 // To store credentials
 const create_contact_alias = ref("");
@@ -38,7 +37,7 @@ const submit_new_contact = () => {
     },
   })
     .then((res) => {
-      invitation_url = res.data.invitation_url;
+      invitation_url.value = res.data.invitation_url;
       console.log(`invitation_url: ${invitation_url}`);
       processing.value = false; // enable button
       toast(`Contact Created!`);
@@ -76,12 +75,6 @@ const submit_new_contact = () => {
     ></Button>
   </div>
 </template>
-
-<script lang="ts">
-export default {
-  name: "CreateContact",
-};
-</script>
 
 <style scoped>
 .create-contact {


### PR DESCRIPTION
1. Fix an issue causing the QR code to not show in `npm run dev` mode (ref needs to set value). Not sure why it worked in `build` mode but still does.
2. Add the structure for the AIP compatibility page. See https://github.com/bcgov/traction/pull/219/files#diff-9852fb872af0af579b0f5fe635e7d6eea4638580a09dbcd4cfe4f911216b505a. Just basic structure now, then we can edit it in GH without needing to do PRs as we go on