### PR TITLE
Accept invitation screen and validation library

### DIFF
--- a/services/tenant-ui/.gitignore
+++ b/services/tenant-ui/.gitignore
@@ -5,6 +5,7 @@
 .venv
 .vscode
 .idea
+config/local.json
 
 # Temporary files
 *.log

--- a/services/tenant-ui/frontend/package-lock.json
+++ b/services/tenant-ui/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "tenant-ui-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@vuelidate/core": "^2.0.0-alpha.44",
+        "@vuelidate/validators": "^2.0.0-alpha.31",
         "axios": "^0.27.2",
         "pinia": "^2.0.19",
         "primeflex": "^3.2.1",
@@ -507,6 +509,72 @@
       "version": "3.2.37",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.37.tgz",
       "integrity": "sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw=="
+    },
+    "node_modules/@vuelidate/core": {
+      "version": "2.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@vuelidate/core/-/core-2.0.0-alpha.44.tgz",
+      "integrity": "sha512-3DlCe3E0RRXbB+OfPacUetKhLmXzmnjeHkzjnbkc03p06mKm6h9pXR5pd6Mv4s4tus4sieuKDb2YWNmKK6rQeA==",
+      "dependencies": {
+        "vue-demi": "^0.13.4"
+      }
+    },
+    "node_modules/@vuelidate/core/node_modules/vue-demi": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.10.tgz",
+      "integrity": "sha512-/R4QhdqGyGqSysOfhkxmYHKwdETZq2z6HAf/fjeGErdJX9cJifX5ijHJS+VjNblGIhjXz/yQTwe/t7Cip+/aJw==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuelidate/validators": {
+      "version": "2.0.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/@vuelidate/validators/-/validators-2.0.0-alpha.31.tgz",
+      "integrity": "sha512-+MFA9nZ7Y9zCpq383/voPDk/hiAmu6KqiJJhLOYB/FmrUPVoyKnuKnI9Bwiq8ok9GZlVkI8BnIrKPKGj9QpwiQ==",
+      "dependencies": {
+        "vue-demi": "^0.13.4"
+      }
+    },
+    "node_modules/@vuelidate/validators/node_modules/vue-demi": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.10.tgz",
+      "integrity": "sha512-/R4QhdqGyGqSysOfhkxmYHKwdETZq2z6HAf/fjeGErdJX9cJifX5ijHJS+VjNblGIhjXz/yQTwe/t7Cip+/aJw==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -3011,6 +3079,38 @@
       "version": "3.2.37",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.37.tgz",
       "integrity": "sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw=="
+    },
+    "@vuelidate/core": {
+      "version": "2.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@vuelidate/core/-/core-2.0.0-alpha.44.tgz",
+      "integrity": "sha512-3DlCe3E0RRXbB+OfPacUetKhLmXzmnjeHkzjnbkc03p06mKm6h9pXR5pd6Mv4s4tus4sieuKDb2YWNmKK6rQeA==",
+      "requires": {
+        "vue-demi": "^0.13.4"
+      },
+      "dependencies": {
+        "vue-demi": {
+          "version": "0.13.10",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.10.tgz",
+          "integrity": "sha512-/R4QhdqGyGqSysOfhkxmYHKwdETZq2z6HAf/fjeGErdJX9cJifX5ijHJS+VjNblGIhjXz/yQTwe/t7Cip+/aJw==",
+          "requires": {}
+        }
+      }
+    },
+    "@vuelidate/validators": {
+      "version": "2.0.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/@vuelidate/validators/-/validators-2.0.0-alpha.31.tgz",
+      "integrity": "sha512-+MFA9nZ7Y9zCpq383/voPDk/hiAmu6KqiJJhLOYB/FmrUPVoyKnuKnI9Bwiq8ok9GZlVkI8BnIrKPKGj9QpwiQ==",
+      "requires": {
+        "vue-demi": "^0.13.4"
+      },
+      "dependencies": {
+        "vue-demi": {
+          "version": "0.13.10",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.10.tgz",
+          "integrity": "sha512-/R4QhdqGyGqSysOfhkxmYHKwdETZq2z6HAf/fjeGErdJX9cJifX5ijHJS+VjNblGIhjXz/yQTwe/t7Cip+/aJw==",
+          "requires": {}
+        }
+      }
     },
     "acorn": {
       "version": "8.8.0",

--- a/services/tenant-ui/frontend/package.json
+++ b/services/tenant-ui/frontend/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint --ext .ts,vue --ignore-path .gitignore ."
   },
   "dependencies": {
+    "@vuelidate/core": "^2.0.0-alpha.44",
+    "@vuelidate/validators": "^2.0.0-alpha.31",
     "axios": "^0.27.2",
     "pinia": "^2.0.19",
     "primeflex": "^3.2.1",

--- a/services/tenant-ui/frontend/src/components/contacts/AcceptInvite.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/AcceptInvite.vue
@@ -1,0 +1,61 @@
+<template>
+    <h3 class="mt-0 mb-5">Accept Invitation</h3>
+    <div class="form-demo">
+        <form @submit.prevent="handleSubmit(!v$.$invalid)">
+            <div class="field">
+                <div class="p-float-label">
+                    <Textarea id="inviteUrl" v-model="v$.inviteUrl.$model"
+                        :class="{ 'p-invalid': v$.inviteUrl.$invalid && submitted }" :autoResize="true" rows="1"
+                        cols="100" />
+                    <label for="inviteUrl" :class="{ 'p-error': v$.inviteUrl.$invalid && submitted }">Invitation
+                        Url*</label>
+                </div>
+                <small v-if="v$.inviteUrl.$invalid && submitted" class="p-error">{{
+                        v$.inviteUrl.required.$message.replace('Value', 'Invitation URL')
+                }}</small>
+            </div>
+            <Button type="submit" label="Accept" class="mt-1" />
+        </form>
+    </div>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { reactive, ref } from 'vue';
+
+// PrimeVue
+import Button from "primevue/button";
+import Textarea from 'primevue/textarea';
+
+// Other imports
+import { required } from "@vuelidate/validators";
+import { useVuelidate } from "@vuelidate/core";
+import { useToast } from 'vue-toastification';
+
+const toast = useToast();
+
+// ----------------------------------------------------------------
+// Accept Invite form
+// ----------------------------------------------------------------
+// Validation
+const formFields = reactive({
+    inviteUrl: ''
+})
+const rules = {
+    inviteUrl: { required }
+}
+const v$ = useVuelidate(rules, formFields)
+
+// Form submission
+const submitted = ref(false);
+const handleSubmit = (isFormValid: boolean) => {
+    submitted.value = true;
+
+    if (!isFormValid) {
+        return;
+    }
+
+    alert('form sub');
+}
+// ---------------------------------------------------/accept form
+</script>

--- a/services/tenant-ui/frontend/src/components/contacts/AcceptInvite.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/AcceptInvite.vue
@@ -2,6 +2,7 @@
     <h3 class="mt-0 mb-5">Accept Invitation</h3>
     <div class="form-demo">
         <form @submit.prevent="handleSubmit(!v$.$invalid)">
+            <!-- Invitation URL -->
             <div class="field">
                 <div class="p-float-label">
                     <Textarea id="inviteUrl" v-model="v$.inviteUrl.$model"
@@ -14,6 +15,18 @@
                         v$.inviteUrl.required.$message.replace('Value', 'Invitation URL')
                 }}</small>
             </div>
+
+            <!-- Alias -->
+            <div class="field">
+                <div class="p-float-label">
+                    <InputText id="alias" v-model="v$.alias.$model"
+                        :class="{ 'p-invalid': v$.alias.$invalid && submitted }" />
+                    <label for="alias" :class="{ 'p-error': v$.alias.$invalid && submitted }">Alias</label>
+                </div>
+                <small v-if="v$.alias.$invalid && submitted" class="p-error">{{
+                        v$.alias.maxLengthValue.$message.replace('Value', 'Alias')
+                }}</small>
+            </div>
             <Button type="submit" label="Accept" class="mt-1" />
         </form>
     </div>
@@ -23,39 +36,53 @@
 // Vue
 import { reactive, ref } from 'vue';
 
+// State
+import { useContactsStore } from '../../store';
+
 // PrimeVue
 import Button from "primevue/button";
+import InputText from "primevue/inputtext";
 import Textarea from 'primevue/textarea';
 
 // Other imports
-import { required } from "@vuelidate/validators";
+import { maxLength, required } from "@vuelidate/validators";
 import { useVuelidate } from "@vuelidate/core";
 import { useToast } from 'vue-toastification';
 
 const toast = useToast();
+const contactsStore = useContactsStore();
 
 // ----------------------------------------------------------------
 // Accept Invite form
 // ----------------------------------------------------------------
 // Validation
 const formFields = reactive({
-    inviteUrl: ''
+    inviteUrl: '',
+    alias: ''
 })
 const rules = {
-    inviteUrl: { required }
+    inviteUrl: { required },
+    alias: { maxLengthValue: maxLength(255) }
 }
 const v$ = useVuelidate(rules, formFields)
 
 // Form submission
 const submitted = ref(false);
-const handleSubmit = (isFormValid: boolean) => {
+const handleSubmit = async (isFormValid: boolean) => {
     submitted.value = true;
 
     if (!isFormValid) {
         return;
     }
 
-    alert('form sub');
+    try {
+        await contactsStore.acceptInvitation(formFields.inviteUrl, formFields.alias);
+        toast.info('Invitation Accepted');
+    } catch (error) {
+        toast.error(`Failure: ${error}`);
+    } finally {
+        submitted.value = false
+    }
 }
 // ---------------------------------------------------/accept form
 </script>

--- a/services/tenant-ui/frontend/src/components/contacts/AcceptInvite.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/AcceptInvite.vue
@@ -11,8 +11,12 @@
                     <label for="inviteUrl" :class="{ 'p-error': v$.inviteUrl.$invalid && submitted }">Invitation
                         Url*</label>
                 </div>
-                <small v-if="v$.inviteUrl.$invalid && submitted" class="p-error">{{
-                        v$.inviteUrl.required.$message.replace('Value', 'Invitation URL')
+                <span v-if="v$.inviteUrl.$error && submitted">
+                    <span v-for="(error, index) of v$.inviteUrl.$errors" :key="index">
+                        <small class="p-error">{{ error.$message }}</small>
+                    </span>
+                </span>
+                <small v-else-if="v$.inviteUrl.$invalid && submitted" class="p-error">{{ v$.inviteUrl.required.$message
                 }}</small>
             </div>
 
@@ -23,11 +27,13 @@
                         :class="{ 'p-invalid': v$.alias.$invalid && submitted }" />
                     <label for="alias" :class="{ 'p-error': v$.alias.$invalid && submitted }">Alias</label>
                 </div>
-                <small v-if="v$.alias.$invalid && submitted" class="p-error">{{
-                        v$.alias.maxLengthValue.$message.replace('Value', 'Alias')
-                }}</small>
+                <span v-if="v$.alias.$error && submitted">
+                    <span v-for="(error, index) of v$.alias.$errors" :key="index">
+                        <small class="p-error">{{ error.$message }}</small>
+                    </span>
+                </span>
             </div>
-            <Button type="submit" label="Accept" class="mt-1" />
+            <Button type="submit" label="Accept" class="mt-1" :disabled="loading" :loading="loading" />
         </form>
     </div>
 </template>
@@ -38,19 +44,23 @@ import { reactive, ref } from 'vue';
 
 // State
 import { useContactsStore } from '../../store';
+import { storeToRefs } from 'pinia';
 
-// PrimeVue
+// PrimeVue / Validation
 import Button from "primevue/button";
 import InputText from "primevue/inputtext";
 import Textarea from 'primevue/textarea';
+import { maxLength, required, url } from "@vuelidate/validators";
+import { useVuelidate } from "@vuelidate/core";
 
 // Other imports
-import { maxLength, required } from "@vuelidate/validators";
-import { useVuelidate } from "@vuelidate/core";
 import { useToast } from 'vue-toastification';
 
 const toast = useToast();
 const contactsStore = useContactsStore();
+
+// use the loading state from the store to disable the button...
+const { loading } = storeToRefs(useContactsStore());
 
 // ----------------------------------------------------------------
 // Accept Invite form
@@ -61,7 +71,7 @@ const formFields = reactive({
     alias: ''
 })
 const rules = {
-    inviteUrl: { required },
+    inviteUrl: { required, url },
     alias: { maxLengthValue: maxLength(255) }
 }
 const v$ = useVuelidate(rules, formFields)

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -59,7 +59,44 @@ export const useContactsStore = defineStore('contacts', () => {
     return invitation_data;
   }
 
-  return { contacts, selectedContact, loading, error, listContacts, createInvitation };
+  async function acceptInvitation(inviteUrl: string, alias: string) {
+    console.log('> contactsStore.acceptInvitation');
+    error.value = null;
+    loading.value = true;
+
+    let accepted_data = null;
+    // need the await here since the returned invitation_data is not one of our stored refs...
+    await tenantApi
+      .postHttp('/tenant/v1/contacts/receive-invitation', { alias: alias, inviteUrl: inviteUrl })
+      .then((res) => {
+        console.log(res);
+        // don't grab the item, there are other parts of the response data we need (invitation, invitation url)
+        accepted_data = res.data;
+        console.log(accepted_data);
+      })
+      .then(() => {
+        // do we want to automatically reload? or have the caller of this to load?
+        console.log('invitation accepted. the store calls load automatically, but do we want this done "manually"?');
+        listContacts();
+      })
+      .catch((err) => {
+        error.value = err;
+        //console.log(error.value);
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< contactsStore.acceptInvitation');
+
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return accepted_data;
+  }
+
+  return { contacts, selectedContact, loading, error, listContacts, createInvitation, acceptInvitation };
 });
 
 export default {

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -67,7 +67,7 @@ export const useContactsStore = defineStore('contacts', () => {
     let accepted_data = null;
     // need the await here since the returned invitation_data is not one of our stored refs...
     await tenantApi
-      .postHttp('/tenant/v1/contacts/receive-invitation', { alias: alias, inviteUrl: inviteUrl })
+      .postHttp('/tenant/v1/contacts/receive-invitation', { alias: alias, invitation_url: inviteUrl })
       .then((res) => {
         console.log(res);
         // don't grab the item, there are other parts of the response data we need (invitation, invitation url)

--- a/services/tenant-ui/frontend/src/views/connections/AcceptInvitation.vue
+++ b/services/tenant-ui/frontend/src/views/connections/AcceptInvitation.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+import AcceptInvite from "../../components/contacts/AcceptInvite.vue";
+</script>
+
 <template>
-  AcceptInvitation
+  <AcceptInvite />
 </template>
+


### PR DESCRIPTION
Simple accept invitation form with validation
![image](https://user-images.githubusercontent.com/17445138/186489656-f41bf009-f8db-47c9-a5e0-e3c11873aac4.png)

On submit/success it just does a info toast, could consider navigating back to the contacts list after as well... will wait for UX design and feedback from users/etc.

On the component did not use the onAction store handler, just try/catch the awaited pinia action, this pattern can be used for simple case components to keep the flow in one place. The subscrption (onAction) style will be useful for more complex callbacks or integrating multiple components.

Validation syntax is really verbose and I think there can be improvements there as we learn the PrimeVue/Vuelidate libraries and interactions better.