### PR TITLE
Feature/presentation details claims order

### DIFF
--- a/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
@@ -16,37 +16,33 @@
         <li>Contact Alias: {{ presentation.contact.alias }}</li>
         <hr />
       </div>
-      <div v-if="presentation.acapy.presentation_exchange.presentation">
-        <!-- PRESENTATION RECEIVED-->
-        <!-- requested_attributes using 'names' list -> revealed attribute groups -->
-        <li
-          v-for="(value, attr, index) in props.presentation.acapy
-            .presentation_exchange.presentation.requested_proof
-            .revealed_attr_groups"
-          :key="index"
-        >
-          <h4>{{ attr }}:</h4>
-          <span
-            v-for="(val, attr_name, i) in value.values"
-            :key="i"
-            class="presentation-attr-value"
-          >
-            <strong>{{ attr_name }}</strong> : {{ val.raw }}
-            <br />
-          </span>
+      <!-- PRESENTATION RECEIVED-->
+      <!-- requested_attributes using 'names' list -> revealed attribute groups -->
+      <div
+        v-if="presentation.acapy.presentation_exchange.presentation"
+        v-for="(value, attr, index) in requested_attribute_groups()"
+        :key="index"
+      >
+        <li v-for="name in value.names" class="presentation-attr-value">
+          <strong>{{ name }}</strong> :
+          {{
+            test_object.acapy.presentation_exchange.presentation.requested_proof
+              .revealed_attr_groups[attr].values[name].raw
+          }}
+          <br />
         </li>
         <!-- requested_attributes using 'name' string w/ restrictions -> revealed attributes -->
         <li
-          v-for="(val, attr_name, i) in presentation.acapy.presentation_exchange
-            .presentation.requested_proof.revealed_attrs"
+          v-for="(val, attr_name, i) in requested_single_attributes()"
           :key="i"
           class="presentation-attr-value"
         >
-          <strong>{{
-            presentation.acapy.presentation_exchange.presentation_request
-              .requested_attributes[attr_name].name
-          }}</strong>
-          : {{ val.raw }}
+          <strong>{{ val.name }}</strong>
+          :
+          {{
+            props.presentation.acapy.presentation_exchange.presentation
+              .requested_proof.revealed_attrs[attr_name].raw
+          }}
         </li>
         <!-- requested_attribute using 'name' string w/o restrictions -> revealed self-attested values -->
         <!-- requested_predicates -> unrevealed attributes -->
@@ -80,6 +76,28 @@ const props = defineProps({
     default: true,
   },
 });
+
+const requested_attribute_groups = () => {
+  return Object.fromEntries(
+    Object.entries(
+      test_object.acapy.presentation_exchange.presentation_request
+        .requested_attributes
+    ).filter(([key, ra]) => {
+      return 'names' in ra && 'restrictions' in ra;
+    })
+  );
+};
+
+const requested_single_attributes = () => {
+  return Object.fromEntries(
+    Object.entries(
+      props.presentation.acapy.presentation_exchange.presentation_request
+        .requested_attributes
+    ).filter(([key, ra]) => {
+      return 'name' in ra && 'restrictions' in ra;
+    })
+  );
+};
 </script>
 
 <style>

--- a/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
@@ -18,19 +18,20 @@
       </div>
       <!-- PRESENTATION RECEIVED-->
       <!-- requested_attributes using 'names' list -> revealed attribute groups -->
-      <div
-        v-if="presentation.acapy.presentation_exchange.presentation"
-        v-for="(value, attr, index) in requested_attribute_groups()"
-        :key="index"
-      >
-        <li v-for="name in value.names" class="presentation-attr-value">
-          <strong>{{ name }}</strong> :
-          {{
-            test_object.acapy.presentation_exchange.presentation.requested_proof
-              .revealed_attr_groups[attr].values[name].raw
-          }}
-          <br />
-        </li>
+      <div v-if="presentation.acapy.presentation_exchange.presentation">
+        <div
+          v-for="(value, attr, index) in requested_attribute_groups()"
+          :key="index"
+        >
+          <li v-for="name in value.names" class="presentation-attr-value">
+            <strong>{{ name }}</strong> :
+            {{
+              props.presentation.acapy.presentation_exchange.presentation
+                .requested_proof.revealed_attr_groups[attr].values[name].raw
+            }}
+            <br />
+          </li>
+        </div>
         <!-- requested_attributes using 'name' string w/ restrictions -> revealed attributes -->
         <li
           v-for="(val, attr_name, i) in requested_single_attributes()"
@@ -80,7 +81,7 @@ const props = defineProps({
 const requested_attribute_groups = () => {
   return Object.fromEntries(
     Object.entries(
-      test_object.acapy.presentation_exchange.presentation_request
+      props.presentation.acapy.presentation_exchange.presentation_request
         .requested_attributes
     ).filter(([key, ra]) => {
       return 'names' in ra && 'restrictions' in ra;

--- a/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
@@ -78,6 +78,8 @@ const props = defineProps({
   },
 });
 
+// four different payload locations for the provided claims based on these filters.
+
 const requested_attribute_groups = () => {
   return Object.fromEntries(
     Object.entries(
@@ -99,6 +101,22 @@ const requested_single_attributes = () => {
     })
   );
 };
+
+// const requested_self_attested_attributes = () => {
+//   return Object.fromEntries(
+//     Object.entries(
+//       props.presentation.acapy.presentation_exchange.presentation_request
+//         .requested_attributes
+//     ).filter(([key, ra]) => {
+//       return 'name' in ra && !'restrictions' in ra;
+//     })
+//   );
+// };
+
+// const requested_predicates_attributes = () => {
+//   return props.presentation.acapy.presentation_exchange.presentation_request
+//     .requested_predicates;
+// };
 </script>
 
 <style>

--- a/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
@@ -102,6 +102,7 @@ const requested_single_attributes = () => {
   );
 };
 
+// to be used in upcoming UX Designed component
 // const requested_self_attested_attributes = () => {
 //   return Object.fromEntries(
 //     Object.entries(


### PR DESCRIPTION
Preserve claims order by using the request order instead of the presentation order. Add clean getters to separate the 4 cases. 