### PR TITLE
Presentation Details demo tweak

### DIFF
--- a/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
@@ -16,6 +16,21 @@
         <li>Contact Alias: {{ presentation.contact.alias }}</li>
         <hr />
       </div>
+
+      <!-- VERIFIED Meaning-->
+      <div v-if="props.show_information && presentation.status == 'verified'">
+        <span class="pi pi-check"></span
+        ><span
+          >Credential is held by
+          <strong>{{ presentation.contact.alias }}</strong></span
+        ><br />
+        <span class="pi pi-check"></span><span>Credential is valid</span><br />
+        <span class="pi pi-check"></span><span>Credential is tamper-free </span
+        ><br />
+        <span class="pi pi-check"></span
+        ><span>All attribute restrictions were statisfied</span><br />
+      </div>
+      <hr />
       <!-- PRESENTATION RECEIVED-->
       <!-- requested_attributes using 'names' list -> revealed attribute groups -->
       <div v-if="presentation.acapy.presentation_exchange.presentation">
@@ -53,6 +68,21 @@
         <!-- requested_attribute using 'name' string w/o restrictions -> revealed self-attested values -->
         <!-- requested_predicates -> unrevealed attributes -->
       </div>
+      <hr />
+      <!-- Identifiers -->
+      <Accordion>
+        <AccordionTab
+          v-bind:header="`Identifier_${index + 1}`"
+          v-for="(item, index) in props.presentation.acapy.presentation_exchange
+            .presentation.identifiers"
+        >
+          <ul>
+            <li v-for="(val, attr_name, i) in item" :key="i">
+              <strong>{{ attr_name }}</strong> : {{ val }}
+            </li>
+          </ul>
+        </AccordionTab>
+      </Accordion>
     </ul>
     <Accordion>
       <AccordionTab header="View Raw Content">
@@ -80,6 +110,11 @@ const props = defineProps({
     type: Boolean as PropType<boolean>,
     required: false,
     default: true,
+  },
+  show_information: {
+    type: Boolean as PropType<boolean>,
+    required: false,
+    default: false,
   },
 });
 
@@ -128,5 +163,11 @@ const requested_single_attributes = (): any => {
 <style>
 .presentation-attr-value {
   padding-left: 1em;
+}
+
+.pi.pi-check {
+  font-size: 18px;
+  color: green;
+  margin-right: 5px;
 }
 </style>

--- a/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/PresentationDetails.vue
@@ -18,7 +18,7 @@
       </div>
 
       <!-- VERIFIED Meaning-->
-      <div v-if="props.show_information && presentation.status == 'verified'">
+      <div v-if="props.showInformation && presentation.status == 'verified'">
         <span class="pi pi-check"></span
         ><span
           >Credential is held by
@@ -72,9 +72,10 @@
       <!-- Identifiers -->
       <Accordion>
         <AccordionTab
-          v-bind:header="`Identifier_${index + 1}`"
           v-for="(item, index) in props.presentation.acapy.presentation_exchange
             .presentation.identifiers"
+          :key="index"
+          :header="`Identifier_${index + 1}`"
         >
           <ul>
             <li v-for="(val, attr_name, i) in item" :key="i">
@@ -111,7 +112,7 @@ const props = defineProps({
     required: false,
     default: true,
   },
-  show_information: {
+  showInformation: {
     type: Boolean as PropType<boolean>,
     required: false,
     default: false,

--- a/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
@@ -42,7 +42,7 @@
         <PresentationDetails
           :presentation="presentationDetailDict[data.verifier_presentation_id]"
           :header="false"
-          :show_information="true"
+          :showInformation="true"
         />
       </template>
     </DataTable>

--- a/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
@@ -42,6 +42,7 @@
         <PresentationDetails
           :presentation="presentationDetailDict[data.verifier_presentation_id]"
           :header="false"
+          :show_information="true"
         />
       </template>
     </DataTable>


### PR DESCRIPTION
Some contextual information on what the user is looking at
![image](https://user-images.githubusercontent.com/5376854/188705323-ad9ff02c-78df-4bba-91af-df1fc3ae8fd2.png)

Add an accordion below data for 'identifiers' which include cred_defs and schema_ids. 
![image](https://user-images.githubusercontent.com/5376854/188705378-f18724b1-871c-4a4c-98af-56f512e03f9c.png)

Signed-off-by: Jason Sy <jasyrotuck@gmail.com>