### PR TITLE
Fielded credential attribute entry

### DIFF
--- a/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
@@ -27,6 +27,16 @@
     </template>
     <template #empty> No records found. </template>
     <template #loading> Loading data. Please wait... </template>
+    <Column :sortable="false" header="Actions">
+      <template #body="{ data }">
+        <Button
+          title="Delete Contact"
+          icon="pi pi-times-circle"
+          class="p-button-rounded p-button-icon-only p-button-text"
+          @click="deleteContact($event, data)"
+        />
+      </template>
+    </Column>
     <Column :sortable="true" field="alias" header="Name" />
     <Column field="role" header="Role" />
     <Column field="status" header="Status" />
@@ -45,17 +55,17 @@ import { onMounted } from 'vue';
 import Button from 'primevue/button';
 import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
-
+import { useConfirm } from 'primevue/useconfirm';
+import { useToast } from 'vue-toastification';
 // State
 import { useContactsStore } from '@/store';
 import { storeToRefs } from 'pinia';
-// Other imports
-import { useToast } from 'vue-toastification';
 // Other components
 import AcceptInvitation from './acceptInvitation/AcceptInvitation.vue';
 import CreateContact from './createContact/CreateContact.vue';
 import { formatDateLong } from '@/helpers';
 
+const confirm = useConfirm();
 const toast = useToast();
 
 const contactsStore = useContactsStore();
@@ -72,7 +82,29 @@ const loadTable = async () => {
 onMounted(async () => {
   loadTable();
 });
-// -----------------------------------------------/Loading contacts
+
+const deleteContact = (event: any, schema: any) => {
+  confirm.require({
+    target: event.currentTarget,
+    message: 'Are you sure you want to delete this contact?',
+    header: 'Confirmation',
+    icon: 'pi pi-exclamation-triangle',
+    accept: () => {
+      doDelete(schema);
+    },
+  });
+};
+const doDelete = (schema: any) => {
+  contactsStore
+    .deleteContact(schema)
+    .then(() => {
+      toast.success(`Contact successfully deleted`);
+    })
+    .catch((err) => {
+      console.error(err);
+      toast.error(`Failure: ${err}`);
+    });
+};
 </script>
 
 <style scoped>

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/EnterCredentialValues.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/EnterCredentialValues.vue
@@ -1,0 +1,157 @@
+<template>
+  <Button
+    icon="pi pi-arrow-left"
+    class="p-button-rounded p-button-text mr-2 pt-3"
+    @click="$emit('back')"
+  />
+  <strong>{{ props.header }}</strong>
+
+  <br />
+  {{ credentialValuesJson }}
+  <br />
+  {{ credentialValuesRaw }}
+
+  <div class="field mt-5">
+    <!-- Label/toggle -->
+    <div class="flex justify-content-between">
+      <div class="flex justify-content-start">
+        <label for="credentialValuesEdit">
+          <strong>Credential Field Values</strong>
+        </label>
+      </div>
+      <div class="flex justify-content-end">
+        JSON
+        <InputSwitch v-model="showRawJson" @input="toggleJson" class="ml-1" />
+      </div>
+    </div>
+
+    <!-- Raw JSON input mode -->
+    <div v-show="showRawJson">
+      <Textarea
+        id="credentialValuesEdit"
+        v-model="credentialValuesJson"
+        :auto-resize="true"
+        rows="20"
+        cols="60"
+        class="w-full mt-1"
+      />
+
+      <div class="flex justify-content-end">
+        <small>
+          Schema: {{ schemaForSelectedCred.schema_name }} Version:
+          {{ schemaForSelectedCred.version }}
+        </small>
+      </div>
+    </div>
+
+    <!-- Dynamic Attribute field list -->
+    <div v-show="!showRawJson">
+      <div
+        class="field"
+        v-for="(item, index) in credentialValuesRaw"
+        :key="item.name"
+      >
+        <label :for="item.name">
+          {{ item.name }}
+        </label>
+        <InputText
+          :id="item.name"
+          v-model="credentialValuesRaw[index].value"
+          class="w-full"
+        />
+      </div>
+    </div>
+
+    <Button label="Save" class="mt-5 w-full" @click="saveCredValues" />
+  </div>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { onMounted, ref } from 'vue';
+// PrimeVue / Validation
+import Button from 'primevue/button';
+import InputSwitch from 'primevue/inputswitch';
+import InputText from 'primevue/inputtext';
+import Textarea from 'primevue/textarea';
+import { useToast } from 'vue-toastification';
+
+const toast = useToast();
+
+// Props
+interface Props {
+  existingCredentialValues?: { name: string; value: string }[];
+  header: String;
+  schemaForSelectedCred: any;
+}
+const props = defineProps<Props>();
+
+// Fields
+const credentialValuesJson = ref('');
+const credentialValuesRaw = ref([] as { name: string; value: string }[]);
+
+const showRawJson = ref(false);
+
+// TODO: util function file
+function _tryParseJson(jsonString: string) {
+  try {
+    var o = JSON.parse(jsonString);
+    if (o && typeof o === 'object') {
+      return o;
+    }
+  } catch (e) {}
+
+  return false;
+}
+
+const toggleJson = () => {
+  debugger;
+  if (showRawJson.value) {
+    // Convert over to the json from what was entered on the fields
+    credentialValuesJson.value = JSON.stringify(
+      credentialValuesRaw.value,
+      undefined,
+      2
+    );
+  } else {
+    // Parse the entered JSON into fields, or ignore and warn if invalid syntax
+    const parsed = _tryParseJson(credentialValuesJson.value);
+    if (parsed) {
+      credentialValuesRaw.value = JSON.parse(credentialValuesJson.value);
+    } else {
+      toast.warning('The JSON you inputted has invalid syntax');
+    }
+  }
+};
+
+const saveCredValues = () => {
+  
+}
+
+// Whnen the component is intialized set up the fields and raw JSON based
+// on the supplied schema and if there is existing values already
+onMounted(() => {
+  // Popuplate cred editor if it's not already been edited
+  if (!props.existingCredentialValues?.length) {
+    const schemaFillIn = props.schemaForSelectedCred.attributes.map(
+      (a: string) => {
+        return {
+          name: `${a}`,
+          value: '',
+        };
+      }
+    );
+
+    console.log(schemaFillIn);
+    credentialValuesRaw.value = schemaFillIn;
+  } else {
+    credentialValuesRaw.value = props.existingCredentialValues;
+  }
+  debugger;
+  credentialValuesJson.value = JSON.stringify(
+    credentialValuesRaw.value,
+    undefined,
+    2
+  );
+});
+</script>

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
@@ -10,6 +10,7 @@
       v-model:visible="displayModal"
       header="Offer Credential"
       :modal="true"
+      :style="{width: '500px'}"
       @update:visible="handleClose"
     >
       <OfferCredentialForm @success="$emit('success')" @closed="handleClose" />

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
@@ -10,7 +10,7 @@
       v-model:visible="displayModal"
       header="Offer Credential"
       :modal="true"
-      :style="{width: '500px'}"
+      :style="{ width: '500px' }"
       @update:visible="handleClose"
     >
       <OfferCredentialForm @success="$emit('success')" @closed="handleClose" />

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredentialForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredentialForm.vue
@@ -14,8 +14,8 @@
 
           <AutoComplete
             id="selectedCred"
-            class="w-full"
             v-model="v$.selectedCred.$model"
+            class="w-full"
             :disabled="credsLoading"
             :suggestions="filteredCreds"
             :dropdown="true"
@@ -40,8 +40,8 @@
 
           <AutoComplete
             id="selectedContact"
-            class="w-full"
             v-model="v$.selectedContact.$model"
+            class="w-full"
             :disabled="contactLoading"
             :suggestions="filteredContacts"
             :dropdown="true"
@@ -109,6 +109,7 @@
           :header="formFields.selectedCred.label"
           :schema-for-selected-cred="schemaForSelectedCred"
           @back="showEditCredValues = false"
+          @save="saveCredValues"
         />
       </div>
     </form>
@@ -209,8 +210,9 @@ const editCredentialValues = () => {
   // Open the editor
   showEditCredValues.value = true;
 };
-const saveCredValues = () => {
-  // credentialValuesRaw.value = JSON.parse(formFields.credentialValuesEditing);
+const saveCredValues = (credEmitted: { name: string; value: string }[]) => {
+  console.log(credEmitted);
+  credentialValuesRaw.value = credEmitted;
   formFields.credentialValuesPretty = '';
   credentialValuesRaw.value.forEach((c: any) => {
     formFields.credentialValuesPretty += `${c.name}: ${c.value} \n`;

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -116,6 +116,40 @@ export const useContactsStore = defineStore('contacts', () => {
     return accepted_data;
   }
 
+  async function deleteContact(payload: any = {}) {
+    console.log('> contactsStore.deleteContact');
+
+    const contactId = payload.contact_id;
+
+    error.value = null;
+    loading.value = true;
+
+    let result = null;
+
+    await tenantApi
+      .deleteHttp(`/tenant/v1/contacts/${contactId}`, payload)
+      .then((res) => {
+        result = res.data.item;
+      })
+      .then(() => {
+        listContacts(); // Refresh table
+      })
+      .catch((err) => {
+        error.value = err;
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< contactsStore.deleteContact');
+
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return result;
+  }
+
   // private functions
 
   const contactLabelValue = (item: any) => {
@@ -139,6 +173,7 @@ export const useContactsStore = defineStore('contacts', () => {
     listContacts,
     createInvitation,
     acceptInvitation,
+    deleteContact,
   };
 });
 


### PR DESCRIPTION
When entering cred values dynamically display input fields.
Allow a JSON editor as well to drop in the raw **attribute** JSON block (the same thing the control had before). You can toggle back and forth and the 2 modes will update themselves. If the JSON entered has invalid syntax (no nice schema validation or anything, this is power user mode) then toast a warning and don't update anything.

Also add delete contact.

![image](https://user-images.githubusercontent.com/17445138/189578326-c3eb0b10-28c0-463d-af60-0db23c16271e.png)

![image](https://user-images.githubusercontent.com/17445138/189578380-ba97bfcc-de67-43ad-83ad-625d75c62513.png)

![image](https://user-images.githubusercontent.com/17445138/189578407-86ee885a-338d-46ee-b80c-44393d1cbd7a.png)

![image](https://user-images.githubusercontent.com/17445138/189578427-9e6927d3-f793-40bb-b01e-d818a5a0cd65.png)

![image](https://user-images.githubusercontent.com/17445138/189578462-388d7eec-d04a-48d1-9b60-56db6d7b4ead.png)
