### PR TITLE
Enable history mode server-side

### DIFF
--- a/services/tenant-ui/frontend/src/store/configStore.ts
+++ b/services/tenant-ui/frontend/src/store/configStore.ts
@@ -33,7 +33,7 @@ export const useConfigStore = defineStore('config', () => {
     error.value = null;
     loading.value = true;
     await axios
-      .get('config')
+      .get('/config')
       .then((res) => {
         console.log(res);
         config.value = res.data;

--- a/services/tenant-ui/package-lock.json
+++ b/services/tenant-ui/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "body-parser": "^1.20.0",
         "config": "^3.3.7",
+        "connect-history-api-fallback": "^2.0.0",
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "http-proxy-middleware": "^2.0.6",
@@ -19,6 +20,7 @@
       },
       "devDependencies": {
         "@types/config": "^0.0.41",
+        "@types/connect-history-api-fallback": "^1.3.5",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/helmet": "^4.0.0",
@@ -256,6 +258,16 @@
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "devOptional": true,
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect-history-api-fallback": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
+      "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+      "dev": true,
+      "dependencies": {
+        "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
     },
@@ -921,6 +933,14 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/connect-history-api-fallback": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+      "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/content-disposition": {
@@ -3195,6 +3215,16 @@
         "@types/node": "*"
       }
     },
+    "@types/connect-history-api-fallback": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
+      "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/cors": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -3669,6 +3699,11 @@
       "requires": {
         "json5": "^2.1.1"
       }
+    },
+    "connect-history-api-fallback": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+      "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA=="
     },
     "content-disposition": {
       "version": "0.5.4",

--- a/services/tenant-ui/package.json
+++ b/services/tenant-ui/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "body-parser": "^1.20.0",
     "config": "^3.3.7",
+    "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "http-proxy-middleware": "^2.0.6",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@types/config": "^0.0.41",
+    "@types/connect-history-api-fallback": "^1.3.5",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/helmet": "^4.0.0",

--- a/services/tenant-ui/src/index.ts
+++ b/services/tenant-ui/src/index.ts
@@ -11,7 +11,10 @@ const APIROOT: string = config.get("server.apiPath");
 const PROXYROOT: string = config.get("server.proxyPath");
 const STATIC_FILES_PATH: string = config.get("server.staticFiles");
 
+import history from "connect-history-api-fallback";
+
 const app = express();
+app.use(history());
 app.use(cors());
 app.use(express.json());
 // app.use(bodyParser.json());


### PR DESCRIPTION
Fall back to serve the vue app if a non-defined route is hit. This enables Vue Router history mode https://router.vuejs.org/guide/essentials/history-mode.html#html5-mode

Added a very light commonly used middleware lib for this on the backend https://www.npmjs.com/package/connect-history-api-fallback
Also recommended on Vue Router docs (https://router.vuejs.org/guide/essentials/history-mode.html#express-with-node-js)

So what happens now is you can refresh on the front end and it will go back to the route rather than 404ing. But the token in state is lost so you get bounced through login again.
 This is a starter for the final behaviour we'll want but want to get the PR in for this functionality. More improvements can be:
- Keeping your token locally so refreshing doesn't kill your login session
- Nav gaurds for the vue routes to go to login if token is invalidated
- Proper front end 404 pages

Tested this with

- Local dev mode
- Local start mode
- Docker container
- OCP route

Signed-off-by: Lucas ONeil <lucasoneil@gmail.com>