### PR TITLE
404 not found page

### DIFF
--- a/services/tenant-ui/frontend/src/router/index.ts
+++ b/services/tenant-ui/frontend/src/router/index.ts
@@ -12,14 +12,16 @@ import MyContacts from '@/views/connections/MyContacts.vue';
 import MyIssuedCredentials from '@/views/issuance/MyIssuedCredentials.vue';
 import Schemas from '@/views/issuance/Schemas.vue';
 // // Verifictation
-import CreatePresentation from '@/views/verification/CreatePresentation.vue';
 import MyPresentations from '@/views/verification/MyPresentations.vue';
 import PresentationTemplates from '@/views/verification/PresentationTemplates.vue';
 // // Holder
-import AcceptCredential from '@/views/holder/AcceptCredential.vue';
 import MyHeldCredentials from '@/views/holder/MyHeldCredentials.vue';
+// 404
+import NotFound from '@/views/NotFound.vue';
+
 
 const routes = [
+  { path: '/:pathMatch(.*)', component: NotFound },
   {
     path: '/',
     name: 'Dashboard',

--- a/services/tenant-ui/frontend/src/router/index.ts
+++ b/services/tenant-ui/frontend/src/router/index.ts
@@ -19,7 +19,6 @@ import MyHeldCredentials from '@/views/holder/MyHeldCredentials.vue';
 // 404
 import NotFound from '@/views/NotFound.vue';
 
-
 const routes = [
   { path: '/:pathMatch(.*)', component: NotFound },
   {

--- a/services/tenant-ui/frontend/src/views/NotFound.vue
+++ b/services/tenant-ui/frontend/src/views/NotFound.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="text-center">
+    <h1>404: Not Found</h1>
+    <router-link :to="{ name: 'Dashboard' }">
+      <Button label="Back to Dashboard" class="p-button-link"/>
+    </router-link>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button';
+</script>

--- a/services/tenant-ui/frontend/src/views/NotFound.vue
+++ b/services/tenant-ui/frontend/src/views/NotFound.vue
@@ -2,7 +2,7 @@
   <div class="text-center">
     <h1>404: Not Found</h1>
     <router-link :to="{ name: 'Dashboard' }">
-      <Button label="Back to Dashboard" class="p-button-link"/>
+      <Button label="Back to Dashboard" class="p-button-link" />
     </router-link>
   </div>
 </template>


### PR DESCRIPTION
Add a page to handle Not Found routes (UX can be adjusted later if needed).
So navigating to a route that is not found in the Vue Router will present this. Though if you're not logged in you will be bounced to the login page, so that we don't show the actual Tenant UI navigation and stuff to a wrong URL entered.

Tested that API call 404s don't do anything wierd, they still just return the expected 404 error to axios.

![image](https://user-images.githubusercontent.com/17445138/190522513-45cf8ef4-bb9e-4975-b768-c44118c5ad53.png)


Signed-off-by: Lucas ONeil <lucasoneil@gmail.com>