### PR TITLE
Add row data expand for holder and issuer credentials

### DIFF
--- a/services/tenant-ui/frontend/src/components/holder/CredentialRowExpandData.vue
+++ b/services/tenant-ui/frontend/src/components/holder/CredentialRowExpandData.vue
@@ -1,0 +1,27 @@
+<template>
+  <RowExpandData :loading="loading" :data="item"> </RowExpandData>
+</template>
+
+<script async setup lang="ts">
+// Vue
+import { PropType } from 'vue';
+// PrimeVue
+// State
+// Other components
+import RowExpandData from '../common/RowExpandData.vue';
+import useGetCredential from '@/composables/useGetCredential';
+
+const props = defineProps({
+  row: {
+    type: null as unknown as PropType<any>,
+    required: true,
+  },
+});
+
+const { loading, item, fetchItemWithAcapy } = useGetCredential();
+
+// ok, let's load up the row with acapy data...
+fetchItemWithAcapy(props.row.holder_credential_id);
+</script>
+
+<style scoped></style>

--- a/services/tenant-ui/frontend/src/components/holder/Credentials.vue
+++ b/services/tenant-ui/frontend/src/components/holder/Credentials.vue
@@ -3,11 +3,13 @@
 
   <DataTable
     v-model:selection="selectedCredential"
+    v-model:expandedRows="expandedRows"
     :loading="loading"
     :value="credentials"
     :paginator="true"
     :rows="10"
     selection-mode="single"
+    data-key="holder_credential_id"
   >
     <template #header>
       <div class="flex justify-content-between">
@@ -24,6 +26,7 @@
     </template>
     <template #empty> No records found. </template>
     <template #loading> Loading data. Please wait... </template>
+    <Column :expander="true" header-style="width: 3rem" />
     <Column :sortable="true" field="alias" header="Name" />
     <Column field="status" header="Status" />
     <Column field="created_at" header="Created at">
@@ -32,12 +35,15 @@
       </template>
     </Column>
     <Column field="contact.alias" header="Contact Name" />
+    <template #expansion="{ data }">
+      <CredentialRowExpandData :row="data" />
+    </template>
   </DataTable>
 </template>
 
 <script setup lang="ts">
 // Vue
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 // PrimeVue
 import Button from 'primevue/button';
 import Column from 'primevue/column';
@@ -46,6 +52,7 @@ import { useToast } from 'vue-toastification';
 
 import { useHolderStore } from '../../store';
 import { storeToRefs } from 'pinia';
+import CredentialRowExpandData from './CredentialRowExpandData.vue';
 
 import { formatDateLong } from '@/helpers';
 
@@ -67,6 +74,8 @@ const loadTable = async () => {
 onMounted(async () => {
   loadTable();
 });
+// necessary for expanding rows, we don't do anything with this
+const expandedRows = ref([]);
 </script>
 <style scoped>
 .p-datatable-header input {

--- a/services/tenant-ui/frontend/src/components/issuance/IssuedCredentialRowExpandData.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/IssuedCredentialRowExpandData.vue
@@ -1,0 +1,27 @@
+<template>
+  <RowExpandData :loading="loading" :data="item"> </RowExpandData>
+</template>
+
+<script async setup lang="ts">
+// Vue
+import { PropType } from 'vue';
+// PrimeVue
+// State
+// Other components
+import RowExpandData from '../common/RowExpandData.vue';
+import useGetIssuedCredential from '@/composables/useGetIssuedCredential';
+
+const props = defineProps({
+  row: {
+    type: null as unknown as PropType<any>,
+    required: true,
+  },
+});
+
+const { loading, item, fetchItemWithAcapy } = useGetIssuedCredential();
+
+// ok, let's load up the row with acapy data...
+fetchItemWithAcapy(props.row.issuer_credential_id);
+</script>
+
+<style scoped></style>

--- a/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
@@ -3,11 +3,13 @@
 
   <DataTable
     v-model:selection="selectedCredential"
+    v-model:expandedRows="expandedRows"
     :loading="loading"
     :value="credentials"
     :paginator="true"
     :rows="10"
     selection-mode="single"
+    data-key="issuer_credentials_id"
   >
     <template #header>
       <div class="flex justify-content-between">
@@ -22,6 +24,7 @@
     </template>
     <template #empty> No records found. </template>
     <template #loading> Loading data. Please wait... </template>
+    <Column :expander="true" header-style="width: 3rem" />
     <Column
       :sortable="true"
       field="credential_template.name"
@@ -35,12 +38,15 @@
       </template>
     </Column>
     <Column field="revoked" header="Revoked?" />
+    <template #expansion="{ data }">
+      <IssuedCredentialRowExpandData :row="data" />
+    </template>
   </DataTable>
 </template>
 
 <script setup lang="ts">
 // Vue
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 
 // State
 import { useIssuerStore } from '../../store';
@@ -53,6 +59,7 @@ import DataTable from 'primevue/datatable';
 
 // Other Components
 import OfferCredential from './offerCredential/OfferCredential.vue';
+import IssuedCredentialRowExpandData from './IssuedCredentialRowExpandData.vue';
 import { formatDateLong } from '@/helpers';
 
 // Other Imports
@@ -76,4 +83,6 @@ const loadTable = async () => {
 onMounted(async () => {
   await loadTable();
 });
+// necessary for expanding rows, we don't do anything with this
+const expandedRows = ref([]);
 </script>

--- a/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
@@ -9,7 +9,7 @@
     :paginator="true"
     :rows="10"
     selection-mode="single"
-    data-key="issuer_credentials_id"
+    data-key="issuer_credential_id"
   >
     <template #header>
       <div class="flex justify-content-between">

--- a/services/tenant-ui/frontend/src/composables/useGetCredential.ts
+++ b/services/tenant-ui/frontend/src/composables/useGetCredential.ts
@@ -1,0 +1,33 @@
+import { ref } from 'vue';
+import { GetItem } from '../types';
+import { useHolderStore } from '../store';
+
+export default function useGetCredential(): GetItem {
+  const store = useHolderStore();
+
+  const item = ref();
+  const loading: any = ref(false);
+
+  async function fetchItem(id: string, params: any = {}) {
+    try {
+      // call store
+      loading.value = true;
+      item.value = await store.getCredential(id, params);
+    } catch (error) {
+      item.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function fetchItemWithAcapy(id: string) {
+    return fetchItem(id, { acapy: true });
+  }
+
+  return {
+    item,
+    loading,
+    fetchItem,
+    fetchItemWithAcapy,
+  };
+}

--- a/services/tenant-ui/frontend/src/composables/useGetIssuedCredential.ts
+++ b/services/tenant-ui/frontend/src/composables/useGetIssuedCredential.ts
@@ -1,0 +1,33 @@
+import { ref } from 'vue';
+import { GetItem } from '../types';
+import { useIssuerStore } from '../store';
+
+export default function useGetIssuedCredential(): GetItem {
+  const store = useIssuerStore();
+
+  const item = ref();
+  const loading: any = ref(false);
+
+  async function fetchItem(id: string, params: any = {}) {
+    try {
+      // call store
+      loading.value = true;
+      item.value = await store.getCredential(id, params);
+    } catch (error) {
+      item.value = null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function fetchItemWithAcapy(id: string) {
+    return fetchItem(id, { acapy: true });
+  }
+
+  return {
+    item,
+    loading,
+    fetchItem,
+    fetchItemWithAcapy,
+  };
+}

--- a/services/tenant-ui/frontend/src/store/holderStore.ts
+++ b/services/tenant-ui/frontend/src/store/holderStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import { fetchItem } from './utils/fetchItem';
 import { fetchList } from './utils/fetchList.js';
 
 export const useHolderStore = defineStore('holder', () => {
@@ -35,6 +36,28 @@ export const useHolderStore = defineStore('holder', () => {
     );
   }
 
+  async function getCredential(id: string, params: any = {}) {
+    const getloading: any = ref(false);
+    return fetchItem(
+      '/tenant/v1/holder/credentials/',
+      id,
+      error,
+      getloading,
+      params
+    );
+  }
+
+  async function getPresentation(id: string, params: any = {}) {
+    const getloading: any = ref(false);
+    return fetchItem(
+      '/tenant/v1/holder/presentations/',
+      id,
+      error,
+      getloading,
+      params
+    );
+  }
+
   return {
     credentials,
     presentations,
@@ -44,6 +67,8 @@ export const useHolderStore = defineStore('holder', () => {
     error,
     listCredentials,
     listPresentations,
+    getCredential,
+    getPresentation,
   };
 });
 

--- a/services/tenant-ui/frontend/src/store/issuerStore.ts
+++ b/services/tenant-ui/frontend/src/store/issuerStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { fetchList } from './utils/fetchList.js';
 import { useTenantApi } from './tenantApi';
+import { fetchItem } from './utils/fetchItem';
 
 export const useIssuerStore = defineStore('issuer', () => {
   const tenantApi = useTenantApi();
@@ -59,6 +60,17 @@ export const useIssuerStore = defineStore('issuer', () => {
     return result;
   }
 
+  async function getCredential(id: string, params: any = {}) {
+    const getloading: any = ref(false);
+    return fetchItem(
+      '/tenant/v1/issuer/credentials/',
+      id,
+      error,
+      getloading,
+      params
+    );
+  }
+
   return {
     credentials,
     selectedCredential,
@@ -66,6 +78,7 @@ export const useIssuerStore = defineStore('issuer', () => {
     error,
     listCredentials,
     offerCredential,
+    getCredential,
   };
 });
 


### PR DESCRIPTION
Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>

Added in row expand for tables that were missing them.
Will refactor in a subsequent ticket... had something going just passing in the URL to fetch but getting schemas is actually two API calls :( 