### PR TITLE
Return cred templates with schema template (optional)

### DIFF
--- a/services/tenant-ui/frontend/src/components/issuance/Schemas.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/Schemas.vue
@@ -85,12 +85,9 @@ const toast = useToast();
 
 const governanceStore = useGovernanceStore();
 // use the loading state from the store to disable the button...
-const {
-  loading,
-  schemaTemplates,
-  selectedSchemaTemplate,
-  schemaTemplateFilters,
-} = storeToRefs(useGovernanceStore());
+const { loading, schemaTemplates, selectedSchemaTemplate } = storeToRefs(
+  useGovernanceStore()
+);
 
 const loadTable = async () => {
   governanceStore.listSchemaTemplates().catch((err) => {

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
@@ -54,6 +54,7 @@ const openModal = async () => {
   Promise.all([
     contactsStore.listContacts(),
     governanceStore.listSchemaTemplates(),
+    governanceStore.listCredentialTemplates(),
   ]).catch((err) => {
     console.error(err);
     toast.error(

--- a/services/tenant-ui/frontend/src/store/utils/fetchList.ts
+++ b/services/tenant-ui/frontend/src/store/utils/fetchList.ts
@@ -13,15 +13,15 @@ export async function fetchList(
   list.value = null;
   error.value = null;
   loading.value = true;
-  console.log(params);
+  //console.log(params);
   params = { ...params, page_num: 1, page_size: 100 };
-  console.log(params);
+  //console.log(params);
   await tenantApi
     .getHttp(url, params)
     .then((res) => {
-      console.log(res);
+      //console.log(res);
       list.value = res.data.items;
-      console.log(list.value);
+      //console.log(list.value);
     })
     .catch((err) => {
       error.value = err;

--- a/services/tenant-ui/frontend/src/store/utils/index.ts
+++ b/services/tenant-ui/frontend/src/store/utils/index.ts
@@ -1,4 +1,5 @@
 export { fetchList } from './fetchList';
+export { fetchItem } from './fetchItem';
 
 /**
  * Filter, Map and Sort a list.

--- a/services/traction/api/endpoints/models/v1/governance.py
+++ b/services/traction/api/endpoints/models/v1/governance.py
@@ -60,6 +60,7 @@ class SchemaTemplateListParameters(
     name: str | None = None
     schema_id: str | None = None
     schema_template_id: uuid.UUID | None = None
+    credential_templates: bool | None = False
 
 
 class CredentialTemplateListParameters(
@@ -80,43 +81,6 @@ class CredentialTemplateListParameters(
     credential_template_id: uuid.UUID | None = None
     schema_id: str | None = None
     schema_template_id: uuid.UUID | None = None
-
-
-class SchemaTemplateItem(TagsItem[TemplateStatusType, EndorserStateType]):
-    """SchemaTemplateItem.
-
-    Inherits from Item.
-    Representation for the SchemaTemplate database record.
-
-    Attributes:
-      schema_template_id: Traction ID for the schema template
-      schema_id: This will be the ledger schema id - this is not a UUID
-      tenant_id: Traction Tenant ID, owner of this Contact
-      name: a "pretty" name for the schema, this can be different than the name on the
-        ledger (schema_name).
-      status: current state of the Schema - Pending, In Progress, Completed, Deleted
-      tags: Set by tenant for arbitrary grouping of their Schemas
-      deleted: Schema/Tenant "soft" delete indicator.
-      imported: When True, this tenant imported the schema, otherwise they created it
-      version: version, on ledger
-      attributes: list of attribute names, on ledger
-
-    """
-
-    schema_template_id: uuid.UUID
-    tenant_id: UUID
-    schema_id: str | None = None
-    name: str
-    imported: bool
-
-    # ledger data ---
-    schema_name: str
-    version: str
-    attributes: List[str] | None = []
-
-
-class SchemaTemplateTimelineItem(TimelineItem[TemplateStatusType, EndorserStateType]):
-    pass
 
 
 class CredentialTemplateItem(TagsItem[TemplateStatusType, EndorserStateType]):
@@ -152,6 +116,45 @@ class CredentialTemplateItem(TagsItem[TemplateStatusType, EndorserStateType]):
     # ledger data ---
     attributes: List[str] | None = []
     tag: str | None = None
+
+
+class SchemaTemplateItem(TagsItem[TemplateStatusType, EndorserStateType]):
+    """SchemaTemplateItem.
+
+    Inherits from Item.
+    Representation for the SchemaTemplate database record.
+
+    Attributes:
+      schema_template_id: Traction ID for the schema template
+      schema_id: This will be the ledger schema id - this is not a UUID
+      tenant_id: Traction Tenant ID, owner of this Contact
+      name: a "pretty" name for the schema, this can be different than the name on the
+        ledger (schema_name).
+      status: current state of the Schema - Pending, In Progress, Completed, Deleted
+      tags: Set by tenant for arbitrary grouping of their Schemas
+      deleted: Schema/Tenant "soft" delete indicator.
+      imported: When True, this tenant imported the schema, otherwise they created it
+      version: version, on ledger
+      attributes: list of attribute names, on ledger
+
+    """
+
+    schema_template_id: uuid.UUID
+    tenant_id: UUID
+    schema_id: str | None = None
+    name: str
+    imported: bool
+
+    # ledger data ---
+    schema_name: str
+    version: str
+    attributes: List[str] | None = []
+
+    credential_templates: List[CredentialTemplateItem] | None = []
+
+
+class SchemaTemplateTimelineItem(TimelineItem[TemplateStatusType, EndorserStateType]):
+    pass
 
 
 class CredentialTemplateTimelineItem(

--- a/services/traction/api/endpoints/routes/v1/tenant/governance/schema_template.py
+++ b/services/traction/api/endpoints/routes/v1/tenant/governance/schema_template.py
@@ -29,6 +29,7 @@ async def get_schema_template(
     schema_template_id: UUID,
     deleted: bool | None = False,
     timeline: bool | None = False,
+    credential_templates: bool | None = False,
     db: AsyncSession = Depends(get_db),
 ) -> SchemaTemplateGetResponse:
     wallet_id = get_from_context("TENANT_WALLET_ID")
@@ -40,6 +41,7 @@ async def get_schema_template(
         wallet_id,
         schema_template_id=schema_template_id,
         deleted=deleted,
+        credential_templates=credential_templates,
     )
 
     links = build_item_links(str(request.url), item)

--- a/services/traction/api/endpoints/routes/v1/tenant/governance/schema_templates.py
+++ b/services/traction/api/endpoints/routes/v1/tenant/governance/schema_templates.py
@@ -41,6 +41,7 @@ async def list_schema_templates(
     status: TemplateStatusType | None = None,
     tags: str | None = None,
     deleted: bool | None = False,
+    credential_templates: bool | None = False,
     db: AsyncSession = Depends(get_db),
 ) -> SchemaTemplateListResponse:
     wallet_id = get_from_context("TENANT_WALLET_ID")
@@ -56,6 +57,7 @@ async def list_schema_templates(
         schema_template_id=schema_template_id,
         status=status,
         tags=tags,
+        credential_templates=credential_templates,
     )
     items, total_count = await governance_service.list_schema_templates(
         db, tenant_id, wallet_id, parameters

--- a/services/traction/bdd-tests/features/steps/schema_templates.py
+++ b/services/traction/bdd-tests/features/steps/schema_templates.py
@@ -76,6 +76,18 @@ def step_impl(context, tenant: str, count: int):
     assert resp_json["total"] == count, resp_json
 
 
+@step('"{tenant}" will list schema template(s) with credential templates')
+def step_impl(context, tenant: str):
+    params = {"credential_templates": True}
+    response = list_schema_templates(context, tenant, params)
+    assert response.status_code == status.HTTP_200_OK, response.__dict__
+    resp_json = json.loads(response.content)
+    count = 0
+    for s in resp_json["items"]:
+        count = count + len(s["credential_templates"])
+    assert count > 0, resp_json["items"]
+
+
 @then('"{tenant}" will have {count:d} credential template(s)')
 def step_impl(context, tenant: str, count: int):
     params = {}

--- a/services/traction/bdd-tests/features/v1-schema-templates-crud.feature
+++ b/services/traction/bdd-tests/features/v1-schema-templates-crud.feature
@@ -14,6 +14,7 @@ Feature: schema templates crud functionality
         | bdd-schema-with-cred | 0.0 | first,last | default    | 1                  |
         Then "faber" will have 2 schema template(s)
         And "faber" will have 1 credential template(s)
+        And "faber" will list schema template(s) with credential templates
 
     Scenario: issuer cannot create a bad schema template
         Given "faber" creates schema template(s)


### PR DESCRIPTION
Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>

Address issues in tenant UI where we need the list of credential templates for each schema template. We were calling list schemas and list credential templates and merging the lists.

Update the traction API to optionally return credential templates per schema template.
Update tenant UI to make the single call and ask the API to return credential templates.

This is a pre-cursor PR so we can refactor tenant UI row expand logic - reduce a bunch of duplicated code. Schema/Credential Template was the only operation that required logic in the UI to build the result set. Now that the API call returns the complete result set, we can do a refactor.