### PR TITLE
Tenant management in Innkeeper UI

### DIFF
--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
@@ -1,0 +1,13 @@
+<template>
+    <div>
+        Hi
+    </div>
+</template>
+
+<script setup lang="ts">
+
+</script>
+
+<style scoped>
+
+</style>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
@@ -1,13 +1,42 @@
 <template>
-    <div>
-        Hi
-    </div>
+  <div>
+    <Button label="Check-In Tenant" icon="pi pi-plus" @click="openModal" />
+    <Dialog
+      v-model:visible="displayModal"
+      header="Check-In Tenant"
+      :modal="true"
+      :closable="allowClose"
+    >
+      <CheckInTenantForm
+        @success="tenantCreated"
+        @closed="displayModal = false"
+      />
+    </Dialog>
+  </div>
 </template>
 
 <script setup lang="ts">
+// Vue
+import { ref } from 'vue';
+// PrimeVue
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
+// Custom Components
+import CheckInTenantForm from './CheckInTenantForm.vue';
 
+const emit = defineEmits(['success']);
+
+// Open popup
+const displayModal = ref(false);
+const openModal = async () => {
+  displayModal.value = true;
+};
+
+// Handle the successful check in and set a flag so that we can't close without our warn-prompt button
+const tenantCreated = async () => {
+  allowClose.value = false;
+  // Propagate the success up in case anyone else needs to pay attention (even if we're not closing this yet)
+  emit('success');
+};
+const allowClose = ref(true);
 </script>
-
-<style scoped>
-
-</style>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
@@ -29,6 +29,7 @@ const emit = defineEmits(['success']);
 // Open popup
 const displayModal = ref(false);
 const openModal = async () => {
+  allowClose.value = true;
   displayModal.value = true;
 };
 

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenantForm.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenantForm.vue
@@ -47,7 +47,7 @@
         </span>
       </div>
 
-      <Panel header="Wallet Access for Tenant" >
+      <Panel header="Wallet Access for Tenant">
         <p>Wallet ID: {{ checkinResponse.wallet_id }}</p>
 
         <p>Wallet Key: {{ checkinResponse.wallet_key }}</p>
@@ -128,7 +128,8 @@ const handleSubmit = async (isFormValid: boolean) => {
 const closeForm = (event: any) => {
   confirm.require({
     target: event.currentTarget,
-    message: 'Are you sure you want to Close? Make sure you have the Wallet Key!',
+    message:
+      'Are you sure you want to Close? Make sure you have the Wallet Key!',
     header: 'Confirmation',
     icon: 'pi pi-exclamation-triangle',
     accept: () => {

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenantForm.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenantForm.vue
@@ -1,0 +1,150 @@
+<template>
+  <form @submit.prevent="handleSubmit(!v$.$invalid)">
+    <!-- Form to create tenant -->
+    <div v-if="!checkinResponse">
+      <!-- Name -->
+      <div class="field">
+        <label
+          for="tenantName"
+          :class="{ 'p-error': v$.name.$invalid && submitted }"
+        >
+          Tenant Name
+        </label>
+        <InputText
+          v-model="v$.name.$model"
+          :class="{ 'p-invalid': v$.name.$invalid && submitted }"
+          type="text"
+          name="tenantName"
+          autofocus
+          :disabled="loading"
+        />
+        <small v-if="v$.name.$invalid && submitted" class="p-error"
+          >{{ v$.name.required.$message }}
+        </small>
+      </div>
+
+      <!-- Make Issuer -->
+      <p class="mb-1 mt-5">Allow Tenant to make themselves an issuer</p>
+      <InputSwitch v-model="v$.allowIssue.$model" :disabled="loading" />
+
+      <Button
+        type="submit"
+        label="Check-In"
+        class="mt-6 w-full"
+        :loading="loading"
+      />
+    </div>
+
+    <!-- Show the wallet ID and key after check in  -->
+    <div v-else>
+      <div class="wallet-key-text">
+        <i class="pi pi-exclamation-triangle" />
+        <span>
+          Please <strong>securely</strong> provide the following credentials to
+          the Tenant manager. <br />
+          Note that you will <strong>not</strong>
+          be able to access the key again after closing this.
+        </span>
+      </div>
+
+      <Panel header="Wallet Access for Tenant" >
+        <p>Wallet ID: {{ checkinResponse.wallet_id }}</p>
+
+        <p>Wallet Key: {{ checkinResponse.wallet_key }}</p>
+      </Panel>
+
+      <Button label="Close" class="mt-5 w-full" @click="closeForm" />
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { reactive, ref } from 'vue';
+// State
+import { useInnkeeperTenantsStore } from '@/store';
+import type { TenantResponseData } from '@/store/innkeeper/innkeeperTenantsStore';
+import { storeToRefs } from 'pinia';
+// PrimeVue / Validation
+import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
+import InputSwitch from 'primevue/inputswitch';
+import Panel from 'primevue/panel';
+import { useConfirm } from 'primevue/useconfirm';
+import { required } from '@vuelidate/validators';
+import { useVuelidate } from '@vuelidate/core';
+import { useToast } from 'vue-toastification';
+
+// state
+const innkeeperTenantsStore = useInnkeeperTenantsStore();
+const { loading } = storeToRefs(useInnkeeperTenantsStore());
+
+const toast = useToast();
+const confirm = useConfirm();
+
+// To store local data
+const checkinResponse = ref<TenantResponseData | null>(null);
+
+const emit = defineEmits(['closed', 'success']);
+
+// Validation
+const formFields = reactive({
+  name: '',
+  allowIssue: false,
+});
+const rules = {
+  name: { required },
+  allowIssue: {},
+};
+const v$ = useVuelidate(rules, formFields);
+
+// Form submission
+const submitted = ref(false);
+const handleSubmit = async (isFormValid: boolean) => {
+  submitted.value = true;
+  if (!isFormValid) {
+    return;
+  }
+  try {
+    // call store
+    const result = await innkeeperTenantsStore.checkInTenant(
+      formFields.name,
+      formFields.allowIssue
+    );
+    if (result != null) {
+      checkinResponse.value = result;
+      toast.info(`Tenant ${formFields.name} Checked In Successfully`);
+      emit('success');
+    }
+  } catch (error) {
+    toast.error(`Failure: ${error}`);
+  } finally {
+    submitted.value = false;
+  }
+};
+
+// Close the form after check in
+// Parent will not let the form close by other avenues once checked-in
+const closeForm = (event: any) => {
+  confirm.require({
+    target: event.currentTarget,
+    message: 'Are you sure you want to Close? Make sure you have the Wallet Key!',
+    header: 'Confirmation',
+    icon: 'pi pi-exclamation-triangle',
+    accept: () => {
+      emit('closed');
+    },
+  });
+};
+</script>
+
+<style lang="scss" scoped>
+.wallet-key-text {
+  display: flex;
+  margin-bottom: 2em;
+  .pi {
+    margin: 0.2em 0.7em 0 0;
+    font-size: 1.8em;
+  }
+}
+</style>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
@@ -9,8 +9,8 @@
     :rows="10"
     selection-mode="single"
     data-key="tenant_id"
-    sortField="created_at"
-    :sortOrder="-1"
+    sort-field="created_at"
+    :sort-order="-1"
   >
     <template #header>
       <div class="flex justify-content-between">

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
@@ -9,6 +9,8 @@
     :rows="10"
     selection-mode="single"
     data-key="tenant_id"
+    sortField="created_at"
+    :sortOrder="-1"
   >
     <template #header>
       <div class="flex justify-content-between">
@@ -40,9 +42,9 @@
     </Column>
     <Column :sortable="true" field="name" header="Name" />
     <Column :sortable="true" field="wallet_id" header="Name" />
-    <Column :sortable="true" field="public_did" header="Name" />
+    <Column :sortable="true" field="public_did" header="Public DID" />
     <Column :sortable="true" field="issuer" header="Is Issuer" />
-    <Column field="created_at" header="Created at">
+    <Column :sortable="true" field="created_at" header="Created at">
       <template #body="{ data }">
         {{ formatDateLong(data.created_at) }}
       </template>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
@@ -1,0 +1,108 @@
+<template>
+  <h3 class="mt-0">Tenants</h3>
+
+  <DataTable
+    v-model:expandedRows="expandedRows"
+    :loading="loading"
+    :value="tenants"
+    :paginator="true"
+    :rows="10"
+    selection-mode="single"
+    data-key="tenant_id"
+  >
+    <template #header>
+      <div class="flex justify-content-between">
+        <div class="flex justify-content-start">
+          <CheckInTenant />
+        </div>
+        <div class="flex justify-content-end">
+          <Button
+            icon="pi pi-refresh"
+            class="p-button-rounded p-button-outlined"
+            title="Refresh Table"
+            @click="loadTable"
+          />
+        </div>
+      </div>
+    </template>
+    <template #empty> No records found. </template>
+    <template #loading> Loading data. Please wait... </template>
+    <Column :expander="true" header-style="width: 3rem" />
+    <Column :sortable="false" header="Actions">
+      <template #body="{ data }">
+        <Button
+          title="Delete Contact"
+          icon="pi pi-times-circle"
+          class="p-button-rounded p-button-icon-only p-button-text"
+          @click="deleteTenant($event, data)"
+        />
+      </template>
+    </Column>
+    <Column :sortable="true" field="name" header="Name" />
+    <Column :sortable="true" field="wallet_id" header="Name" />
+    <Column :sortable="true" field="public_did" header="Name" />
+    <Column :sortable="true" field="issuer" header="Is Issuer" />
+    <Column field="created_at" header="Created at">
+      <template #body="{ data }">
+        {{ formatDateLong(data.created_at) }}
+      </template>
+    </Column>
+    <template #expansion="{ data }">
+      <RowExpandData :id="data.tenant_id" :url="'/innkeeper/v1/tenants/'" />
+    </template>
+  </DataTable>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { onMounted, ref } from 'vue';
+// PrimeVue
+import Button from 'primevue/button';
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
+import { useConfirm } from 'primevue/useconfirm';
+import { useToast } from 'vue-toastification';
+// State
+import { useInnkeeperTenantsStore } from '@/store';
+import { storeToRefs } from 'pinia';
+// Other components
+import CheckInTenant from './CheckInTenant.vue';
+import { formatDateLong } from '@/helpers';
+import RowExpandData from '@/components/common/RowExpandData.vue';
+
+const confirm = useConfirm();
+const toast = useToast();
+
+const innkeeperTenantsStore = useInnkeeperTenantsStore();
+
+const { loading, tenants } = storeToRefs(useInnkeeperTenantsStore());
+
+const loadTable = async () => {
+  innkeeperTenantsStore.listTenants().catch((err: any) => {
+    console.error(err);
+    toast.error(`Failure: ${err}`);
+  });
+};
+
+onMounted(async () => {
+  loadTable();
+});
+
+const deleteTenant = (event: any, tenant: any) => {
+  confirm.require({
+    target: event.currentTarget,
+    message: 'Are you sure you want to delete this Tenant?',
+    header: 'Confirmation',
+    icon: 'pi pi-exclamation-triangle',
+    accept: () => {
+      doDelete(tenant);
+    },
+  });
+};
+const doDelete = (tenant: any) => {
+  alert(`To be implemented ${JSON.stringify(tenant)}`);
+};
+
+// necessary for expanding rows, we don't do anything with this
+const expandedRows = ref([]);
+</script>

--- a/services/tenant-ui/frontend/src/store/index.ts
+++ b/services/tenant-ui/frontend/src/store/index.ts
@@ -9,3 +9,4 @@ export { useTokenStore } from './tokenStore';
 export { useVerifierStore } from './verifierStore';
 // Innkeeper
 export { useInnkeeperTokenStore } from './innkeeper/innkeeperTokenStore';
+export { useInnkeeperTenantsStore } from './innkeeper/innkeeperTenantsStore';

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -1,0 +1,69 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { useInnkeeperApi } from './innkeeperApi';
+import { fetchList } from '../utils';
+
+export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
+  // state
+  const tenants: any = ref(null);
+  const loading: any = ref(false);
+  const error: any = ref(null);
+
+  // getters
+
+  // actions
+
+  // grab the tenant api
+  const innkeeperApi = useInnkeeperApi();
+
+  async function listTenants() {
+    return fetchList('/innkeeper/v1/tenants/', tenants, error, loading);
+  }
+
+  async function checkInTenant(name: string, allowIssue: boolean) {
+    console.log('> innkeeperTenantsStore.checkInTenant');
+    error.value = null;
+    loading.value = true;
+
+    let tenant_data = null;
+    await innkeeperApi
+      .postHttp('/innkeeper/v1/tenants/check-in', {
+        name: name,
+        allow_issue_credentials: allowIssue,
+      })
+      .then((res) => {
+        tenant_data = res.data;
+      })
+      .then(() => {
+        // Tenant created, reload the list in state
+        listTenants();
+      })
+      .catch((err) => {
+        error.value = err;
+        console.error(error.value);
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< innkeeperTenantsStore.checkInTenant');
+
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return tenant_data;
+  }
+
+  return {
+    loading,
+    error,
+    tenants,
+    listTenants,
+    checkInTenant,
+  };
+});
+
+export default {
+  useInnkeeperTenantsStore,
+};

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -3,6 +3,13 @@ import { ref } from 'vue';
 import { useInnkeeperApi } from './innkeeperApi';
 import { fetchList } from '../utils';
 
+export interface TenantResponseData {
+  tenant_id?: string;
+  name?: string;
+  wallet_id: string;
+  wallet_key: string;
+}
+
 export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
   // state
   const tenants: any = ref(null);
@@ -25,14 +32,14 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
     error.value = null;
     loading.value = true;
 
-    let tenant_data = null;
+    let tenant_data: TenantResponseData | undefined;
     await innkeeperApi
       .postHttp('/innkeeper/v1/tenants/check-in', {
         name: name,
         allow_issue_credentials: allowIssue,
       })
       .then((res) => {
-        tenant_data = res.data;
+        tenant_data = res.data.item;
       })
       .then(() => {
         // Tenant created, reload the list in state

--- a/services/tenant-ui/frontend/src/views/innkeeper/InnkeeperTenants.vue
+++ b/services/tenant-ui/frontend/src/views/innkeeper/InnkeeperTenants.vue
@@ -1,3 +1,7 @@
-<template>Test this is innkeeper</template>
+<template>
+  <Tenants />
+</template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import Tenants from '@/components/innkeeper/tenants/Tenants.vue';
+</script>


### PR DESCRIPTION
In the Innkeeper UI, add the list of tenants and the ability to check in a new tenant.

Some of the is still waiting on UX so wording/layout subject to change in a future PR.

**Tenants list**
On the main section of innkeeper load the tenants with row expander for full details (will get feedback on columns to display here.
One note is the Innkeeper tenants endpoint doesn't seem to return results sorted by create date the way other endpoints do? I'm default sorting in the table to get this order then. Probably better to filter in the store, but possibly should just change the innkeeper endpoint in Traction? Will get feedback from team and create minor story to adjust (or leave the table default sorted if we think that's fine)

![image](https://user-images.githubusercontent.com/17445138/194477330-a0919126-8336-49f9-8122-2ce4d5498967.png)

**Check in**
Add tenant button/dialog/form.
Once checked-in, show the wallet id and key with a warning message (text up for feedback/revision). Once checked in, the parent dialog holder will get rid of the header X so you have to go through an "are you sure" button to close the dialog.

![image](https://user-images.githubusercontent.com/17445138/194477648-1eb87aff-f025-449f-ab80-b62ff54be490.png)

![image](https://user-images.githubusercontent.com/17445138/194477690-3d08d5f9-cd27-4a29-9947-ee474b890550.png)


Need UX so this is a first cut, might change some later.
