### PR TITLE
Better Issuer Button feedback 495

### DIFF
--- a/services/tenant-ui/frontend/src/components/common/Issuance.vue
+++ b/services/tenant-ui/frontend/src/components/common/Issuance.vue
@@ -84,7 +84,7 @@ const label = () => {
     !pending.value
   ) {
     return 'Approve Issuer Permissions'; // Already approved, but not an issuer
-  } else if (pending) {
+  } else if (pending.value) {
     return 'Check Issuer Status'; // Requested, but not approved
   } else {
     return 'Request Issuer Permissions'; // Not approved yet

--- a/services/tenant-ui/frontend/src/components/common/Issuance.vue
+++ b/services/tenant-ui/frontend/src/components/common/Issuance.vue
@@ -45,6 +45,7 @@ const requestAccess = async () => {
     );
   } else {
     await tenantStore.getSelf();
+    toast.info('You are now an issuer!');
   }
   loading.value = false; // Remove the spinner
 };

--- a/services/tenant-ui/frontend/src/components/common/Issuance.vue
+++ b/services/tenant-ui/frontend/src/components/common/Issuance.vue
@@ -69,11 +69,11 @@ const requestAccess = async () => {
  */
 const label = () => {
   if (issuer.value) {
-    return 'Issuer';
+    return 'Issuer'; // Already an issuer
   } else if (!issuer.value && tenant.value.issuer_status === 'Approved') {
-    return 'Approve Issuer Permissions';
+    return 'Approve Issuer Permissions'; // Already approved, but not an issuer
   } else {
-    return 'Request Issuer Permissions';
+    return 'Request Issuer Permissions'; // Not approved yet
   }
 };
 </script>

--- a/services/tenant-ui/frontend/src/components/common/Issuance.vue
+++ b/services/tenant-ui/frontend/src/components/common/Issuance.vue
@@ -25,6 +25,9 @@ const toast = useToast();
 // For monitoring the state of the request
 const loading = ref(false);
 
+// Flag for pending requests
+const pending = ref(false);
+
 // Get the tenant store
 const tenantStore = useTenantStore();
 
@@ -57,7 +60,12 @@ const requestAccess = async () => {
     );
   } else {
     await tenantStore.getSelf(); // Reload profile data
-    toast.success('You are now an issuer!');
+    if (pending.value === false) {
+      toast.success(
+        'Successfully sent approval request! Check back later for status.'
+      );
+    }
+    pending.value = true;
   }
   loading.value = false; // Remove the spinner
 };
@@ -70,8 +78,14 @@ const requestAccess = async () => {
 const label = () => {
   if (issuer.value) {
     return 'Issuer'; // Already an issuer
-  } else if (!issuer.value && tenant.value.issuer_status === 'Approved') {
+  } else if (
+    !issuer.value &&
+    tenant.value.issuer_status === 'Approved' &&
+    !pending.value
+  ) {
     return 'Approve Issuer Permissions'; // Already approved, but not an issuer
+  } else if (pending) {
+    return 'Check Issuer Status'; // Requested, but not approved
   } else {
     return 'Request Issuer Permissions'; // Not approved yet
   }


### PR DESCRIPTION
The Accept/Request issuer button now provides feedback if the user is approved.
1. There is a notification:
![Screenshot from 2022-10-05 12-44-40](https://user-images.githubusercontent.com/479074/194642225-b4823adb-6770-40f9-ad91-ecf6ceb87138.png)
1. And the button deactivates and shows the user is currently an issuer:
![Screenshot from 2022-10-05 12-20-09](https://user-images.githubusercontent.com/479074/194642334-b859b0f0-d8c9-463b-9bb2-006aab747c2b.png)
This is all done without having to refresh the page.

Notes:
- The Issuer state was being disconnected when converting the store into refs.
- Lots of debugging to try and get Pinia to maintain state between the button and the store.
- Eventual solution was to create a local ref and update it by listening to mutations to the store.