### PR TITLE
Add i18n translations as locale json files

### DIFF
--- a/services/tenant-ui/README.md
+++ b/services/tenant-ui/README.md
@@ -63,3 +63,15 @@ Build and run a docker image (example shows using environment variable to point 
 docker build . -t local/traction-ui
 docker run --env SERVER_TRACTION_URL=https://traction-api-test.apps.silver.devops.gov.bc.ca/ -p 8080:8080 -d local/traction-ui
 ```
+
+## Internationalization
+
+The Tenant UI uses [Vue I18n](https://vue-i18n.intlify.dev/) to handle internationalization for the Vue app. 
+
+When developing, review the [documentation](https://vue-i18n.intlify.dev/guide/essentials/syntax.html) for the basic syntax for that library quickly to understand the localization features used. Internatonalization settings are handled in the `i18n` folder and translations are kept in `json` files for each language there.
+
+When developing the Tenant UI, adhere to localization best practices including
+- Do not handle any localization logic or translations in the components themselves. The frontend code should only deal with message string names, and all localizations should be handled exclusively in the language `json` files.
+- Use proper responsive design principles, and do not space UI components based on english language text lengths. Translated UI elements might end up shorter or much longer, so overflows of text should always work accordingly.
+
+Currently localization is handled at the Tenant UI frontend level, but data that returns to the frontend from the Traction and AcaPy APIs may not include localization of text and status codes, etc. As such, full localization is a work in progress and will require some future work in integrating with Traction and AcaPy.

--- a/services/tenant-ui/frontend/src/components/common/LocaleSwitcher.vue
+++ b/services/tenant-ui/frontend/src/components/common/LocaleSwitcher.vue
@@ -8,7 +8,7 @@ import { useI18n } from 'vue-i18n';
 
 const { locale } = useI18n({ useScope: 'global' });
 
-const localeList = ['en', 'fr'];
+const localeList = ['en', 'fr', 'jp'];
 </script>
 
 <style lang="scss" scoped>

--- a/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3 class="mt-0">Contacts</h3>
+  <h3 class="mt-0">{{ t('contact.contacts') }}</h3>
 
   <DataTable
     v-model:selection="selectedContact"
@@ -82,9 +82,11 @@ import { formatDateLong } from '@/helpers';
 import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';
 import EditContact from './editContact/EditContact.vue';
+import { useI18n } from 'vue-i18n';
 
 const confirm = useConfirm();
 const toast = useToast();
+const { t } = useI18n();
 
 const contactsStore = useContactsStore();
 

--- a/services/tenant-ui/frontend/src/components/contacts/acceptInvitation/AcceptInvitation.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/acceptInvitation/AcceptInvitation.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <Button label="Accept Invitation" icon="pi pi-plus" @click="openModal" />
+    <Button :label="t('contact.accept')" icon="pi pi-plus" @click="openModal" />
     <Dialog
       v-model:visible="displayModal"
-      header="Accept Invitation"
+      :header="t('contact.accept')"
       :modal="true"
       @update:visible="handleClose"
     >
@@ -18,22 +18,15 @@ import { ref } from 'vue';
 // PrimeVue
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
-// State
-
 // Custom Components
 import AcceptInviteForm from './AcceptInviteForm.vue';
 // Other Imports
-import { useToast } from 'vue-toastification';
+import { useI18n } from 'vue-i18n';
 
-// State setup
-
-const toast = useToast();
+const { t } = useI18n();
 
 defineEmits(['success']);
 
-// -----------------------------------------------------------------------
-// Display popup
-// ---------------------------------------------------------------------
 const displayModal = ref(false);
 const openModal = async () => {
   // Kick of the loading asyncs (if needed)
@@ -43,5 +36,4 @@ const handleClose = async () => {
   // some logic... maybe we shouldn't close?
   displayModal.value = false;
 };
-// ---------------------------------------------------------------/display
 </script>

--- a/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <Button label="Create Contact" icon="pi pi-plus" @click="openModal" />
+    <Button :label="t('contact.create')" icon="pi pi-plus" @click="openModal" />
     <Dialog
       v-model:visible="displayModal"
-      header="Create Contact"
+      :header=" t('contact.create')"
       :modal="true"
       @update:visible="handleClose"
     >
@@ -23,17 +23,13 @@ import Dialog from 'primevue/dialog';
 // Custom Components
 import CreateContactForm from './CreateContactForm.vue';
 // Other Imports
-import { useToast } from 'vue-toastification';
+import { useI18n } from 'vue-i18n';
 
-// State setup
-
-const toast = useToast();
+const { t } = useI18n();
 
 defineEmits(['success']);
 
-// -----------------------------------------------------------------------
 // Display popup
-// ---------------------------------------------------------------------
 const displayModal = ref(false);
 const openModal = async () => {
   // Kick of the loading asyncs (if needed)
@@ -43,5 +39,4 @@ const handleClose = async () => {
   // some logic... maybe we shouldn't close?
   displayModal.value = false;
 };
-// ---------------------------------------------------------------/display
 </script>

--- a/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
@@ -3,7 +3,7 @@
     <Button :label="t('contact.create')" icon="pi pi-plus" @click="openModal" />
     <Dialog
       v-model:visible="displayModal"
-      :header=" t('contact.create')"
+      :header="t('contact.create')"
       :modal="true"
       @update:visible="handleClose"
     >

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <Button label="Check-In Tenant" icon="pi pi-plus" @click="openModal" />
+    <Button :label="t('tenants.checkIn')" icon="pi pi-plus" @click="openModal" />
     <Dialog
       v-model:visible="displayModal"
-      header="Check-In Tenant"
+      :header="t('tenants.checkIn')"
       :modal="true"
       :closable="allowClose"
     >
@@ -23,7 +23,10 @@ import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 // Custom Components
 import CheckInTenantForm from './CheckInTenantForm.vue';
+// Other Imports
+import { useI18n } from 'vue-i18n';
 
+const { t } = useI18n();
 const emit = defineEmits(['success']);
 
 // Open popup

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/CheckInTenant.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <Button :label="t('tenants.checkIn')" icon="pi pi-plus" @click="openModal" />
+    <Button
+      :label="t('tenants.checkIn')"
+      icon="pi pi-plus"
+      @click="openModal"
+    />
     <Dialog
       v-model:visible="displayModal"
       :header="t('tenants.checkIn')"

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3 class="mt-0">Tenants</h3>
+  <h3 class="mt-0">{{ t('tenants.tenants') }}</h3>
 
   <DataTable
     v-model:expandedRows="expandedRows"
@@ -64,8 +64,10 @@ import { storeToRefs } from 'pinia';
 import CheckInTenant from './CheckInTenant.vue';
 import { formatDateLong } from '@/helpers';
 import RowExpandData from '@/components/common/RowExpandData.vue';
+import { useI18n } from 'vue-i18n';
 
 const toast = useToast();
+const { t } = useI18n();
 
 const innkeeperTenantsStore = useInnkeeperTenantsStore();
 

--- a/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3 class="mt-0">Issued/Offered Credentials</h3>
+  <h3 class="mt-0">{{ t('issue.credentials') }}</h3>
 
   <DataTable
     v-model:selection="selectedCredential"
@@ -89,9 +89,11 @@ import OfferCredential from './offerCredential/OfferCredential.vue';
 import RowExpandData from '../common/RowExpandData.vue';
 import { formatDateLong } from '@/helpers';
 import StatusChip from '../common/StatusChip.vue';
+import { useI18n } from 'vue-i18n';
 
 const toast = useToast();
 const confirm = useConfirm();
+const { t } = useI18n();
 
 const issuerStore = useIssuerStore();
 // use the loading state from the store to disable the button...

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
@@ -2,13 +2,13 @@
   <div>
     <Button
       :disabled="!isIssuer"
-      label="Offer Credential"
+      :label="t('issue.offer')"
       icon="pi pi-arrow-up-right"
       @click="openModal"
     />
     <Dialog
       v-model:visible="displayModal"
-      header="Offer Credential"
+      :header="t('issue.offer')"
       :modal="true"
       :style="{ width: '500px' }"
       @update:visible="handleClose"
@@ -35,12 +35,14 @@ import { storeToRefs } from 'pinia';
 import OfferCredentialForm from './OfferCredentialForm.vue';
 // Other Imports
 import { useToast } from 'vue-toastification';
+import { useI18n } from 'vue-i18n';
 
 // State setup
 const contactsStore = useContactsStore();
 const governanceStore = useGovernanceStore();
 
 const toast = useToast();
+const { t } = useI18n();
 
 const { isIssuer } = storeToRefs(useTenantStore());
 

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="traction-sidebar">
-    {{ someProperty }}
     <h1 v-if="tenant" class="sidebar-app-title">{{ tenant.name }}</h1>
     <!--<h1 class="sidebar-app-title">{{ config.ux.sidebarTitle }}</h1>-->
     <PanelMenu :model="items" class="mt-5" />
@@ -8,7 +7,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import PanelMenu from 'primevue/panelmenu';
 import { storeToRefs } from 'pinia';
 import { useTenantStore } from '../../store';
@@ -32,22 +31,19 @@ const items = ref([
   },
 
   {
-    label: 'Issuance',
-    label: () => t('home.dashboard'),
+    label: () => t('issue.issuance'),
     icon: 'pi pi-fw pi-wallet',
     to: { name: 'MyIssuedCredentials' },
   },
 
   {
-    label: 'Verification',
-    label: () => t('home.dashboard'),
+    label: () => t('verify.verification'),
     icon: 'pi pi-fw pi-check-square',
     to: { name: 'MyPresentations' },
   },
 
   {
-    label: 'Holder',
-    label: () => t('home.dashboard'),
+    label: () => t('holder.holder'),
     icon: 'pi pi-fw pi-id-card',
     to: { name: 'MyHeldCredentials' },
   },
@@ -59,26 +55,22 @@ const items = ref([
   },
 
   {
-    label: 'Configuration',
-    label: () => t('home.dashboard'),
+    label: () => t('configuration.configuration'),
     icon: 'pi pi-fw pi-file',
     items: [
       {
-        label: 'Schemas',
-        label: () => t('home.dashboard'),
+        label: () => t('configuration.schemasCreds.schemas'),
         to: { name: 'Schemas' },
       },
       {
-        label: 'Presentation Templates',
-        label: () => t('home.dashboard'),
+        label: () => t('configuration.presentationTemplates.templates'),
         to: { name: 'PresentationTemplates' },
       },
     ],
   },
 
   {
-    label: 'About',
-    label: () => t('home.dashboard'),
+    label: () => t('about.about'),
     icon: 'pi pi-fw pi-question-circle',
     to: { name: 'About' },
   },

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -49,7 +49,7 @@ const items = ref([
   },
 
   {
-    label: 'Messages',
+    label: () => t('messages.messages'),
     icon: 'pi pi-fw pi-envelope',
     to: { name: 'MyMessages' },
   },

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="traction-sidebar">
+    {{ someProperty }}
     <h1 v-if="tenant" class="sidebar-app-title">{{ tenant.name }}</h1>
     <!--<h1 class="sidebar-app-title">{{ config.ux.sidebarTitle }}</h1>-->
     <PanelMenu :model="items" class="mt-5" />
@@ -7,40 +8,46 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import PanelMenu from 'primevue/panelmenu';
 import { storeToRefs } from 'pinia';
 import { useTenantStore } from '../../store';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 // tenant should be loaded by login...
 const { tenant } = storeToRefs(useTenantStore());
 
 const items = ref([
   {
-    label: 'Dashboard',
+    label: () => t('home.dashboard'),
     icon: 'pi pi-fw pi-chart-bar',
     to: { name: 'Dashboard' },
   },
   {
-    label: 'Contacts',
+    label: () => t('contact.contacts'),
     icon: 'pi pi-fw pi-users',
     to: { name: 'MyContacts' },
   },
 
   {
     label: 'Issuance',
+    label: () => t('home.dashboard'),
     icon: 'pi pi-fw pi-wallet',
     to: { name: 'MyIssuedCredentials' },
   },
 
   {
     label: 'Verification',
+    label: () => t('home.dashboard'),
     icon: 'pi pi-fw pi-check-square',
     to: { name: 'MyPresentations' },
   },
 
   {
     label: 'Holder',
+    label: () => t('home.dashboard'),
     icon: 'pi pi-fw pi-id-card',
     to: { name: 'MyHeldCredentials' },
   },
@@ -53,14 +60,17 @@ const items = ref([
 
   {
     label: 'Configuration',
+    label: () => t('home.dashboard'),
     icon: 'pi pi-fw pi-file',
     items: [
       {
         label: 'Schemas',
+        label: () => t('home.dashboard'),
         to: { name: 'Schemas' },
       },
       {
         label: 'Presentation Templates',
+        label: () => t('home.dashboard'),
         to: { name: 'PresentationTemplates' },
       },
     ],
@@ -68,6 +78,7 @@ const items = ref([
 
   {
     label: 'About',
+    label: () => t('home.dashboard'),
     icon: 'pi pi-fw pi-question-circle',
     to: { name: 'About' },
   },

--- a/services/tenant-ui/frontend/src/components/layout/innkeeper/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/innkeeper/Sidebar.vue
@@ -8,15 +8,18 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import PanelMenu from 'primevue/panelmenu';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 const items = ref([
   {
-    label: 'Tenants',
+    label: () => t('tenants.tenants'),
     icon: 'pi pi-fw pi-users',
     to: { name: 'InnkeeperTenants' },
   },
   {
-    label: 'About',
+    label: () => t('about.about'),
     icon: 'pi pi-fw pi-question-circle',
     to: { name: 'InnkeeperAbout' },
   },

--- a/services/tenant-ui/frontend/src/i18n/i18n.ts
+++ b/services/tenant-ui/frontend/src/i18n/i18n.ts
@@ -1,94 +1,18 @@
 import { createI18n } from 'vue-i18n';
 
 // The Locale message resources
-// TODO: This should probably be reorganized into JSON files and set up in this method instead
-// but how we want to organize our languages is coming after this proof of concept so TBD
-// Probably see https://vue-i18n.intlify.dev/guide/advanced/optimization.html#how-to-configure
 function loadLocaleMessages() {
-  // one json file per language probably best in the future
-  const messages = {
-    en: {
-      home: {
-        greeting: 'Powered by Traction',
-        dashboard: 'Dashboard',
-        login: {
-          id: 'Wallet ID',
-          secret: 'Wallet Secret',
-          submit: 'Sign-In',
-        },
-      },
-      user: {
-        profile: 'Profile',
-        settings: 'Settings',
-        logout: 'Logout',
-      },
-      contact: {
-        contacts: 'Contacts',
-        create: 'Create Contact',
-        accept: 'Accept Invitation',
-      },
-      issue: {
-
-      },
-      verify: {
-
-      },
-      holder: {
-
-      },
-      schemasCreds: {
-
-      },
-      tenants: {
-
-      },
-      about: {
-        about: 'About'
-      }
-    },
-    fr: {
-      home: {
-        greeting: 'Propulsé par Traction',
-        dashboard: 'Dashboard <FR>',
-        login: {
-          id: 'Wallet ID <FR>',
-          secret: 'Wallet Secret <FR>',
-          submit: 'Sign-In <FR>',
-        },
-      },
-      user: {
-        profile: 'Profile <FR>',
-        settings: 'Settings <FR>',
-        logout: 'Logout <FR>',
-      },
-      contact: {
-        contacts: 'Contacts <FR>',
-        create: 'Create Contact <FR>',
-        accept: 'Accept Invitation <FR>',
-      },
-    },
-    jp: {
-      home: {
-        greeting: 'トラクションを搭載',
-        dashboard: 'Dashboard <JP>',
-        login: {
-          id: 'Wallet ID <JP>',
-          secret: 'Wallet Secret <JP>',
-          submit: 'Sign-In <JP>',
-        },
-      },
-      user: {
-        profile: 'Profile <JP>',
-        settings: 'Settings <JP>',
-        logout: 'Logout <JP>',
-      },
-      contact: {
-        contacts: 'Contacts <JP>',
-        create: 'Create Contact <JP>',
-        accept: 'Accept Invitation <JP>',
-      },
-    },
-  };
+  // Load messages from any json files in the locales folder
+  const modules = import.meta.glob('./locales/*.json');
+  const messages: any = {}
+  for (const path in modules) {
+    // For each file found, build the message object
+    // with the file NAME as the top level key
+    modules[path]().then((mod: any) => {
+      const loc = path.match(/[ \w-]+?(?=\.)/i)![0];
+      messages[loc] = mod;
+    })
+  }
   return messages;
 }
 

--- a/services/tenant-ui/frontend/src/i18n/i18n.ts
+++ b/services/tenant-ui/frontend/src/i18n/i18n.ts
@@ -27,6 +27,24 @@ function loadLocaleMessages() {
         create: 'Create Contact',
         accept: 'Accept Invitation',
       },
+      issue: {
+
+      },
+      verify: {
+
+      },
+      holder: {
+
+      },
+      schemasCreds: {
+
+      },
+      tenants: {
+
+      },
+      about: {
+        about: 'About'
+      }
     },
     fr: {
       home: {
@@ -47,6 +65,27 @@ function loadLocaleMessages() {
         contacts: 'Contacts <FR>',
         create: 'Create Contact <FR>',
         accept: 'Accept Invitation <FR>',
+      },
+    },
+    jp: {
+      home: {
+        greeting: 'トラクションを搭載',
+        dashboard: 'Dashboard <JP>',
+        login: {
+          id: 'Wallet ID <JP>',
+          secret: 'Wallet Secret <JP>',
+          submit: 'Sign-In <JP>',
+        },
+      },
+      user: {
+        profile: 'Profile <JP>',
+        settings: 'Settings <JP>',
+        logout: 'Logout <JP>',
+      },
+      contact: {
+        contacts: 'Contacts <JP>',
+        create: 'Create Contact <JP>',
+        accept: 'Accept Invitation <JP>',
       },
     },
   };

--- a/services/tenant-ui/frontend/src/i18n/i18n.ts
+++ b/services/tenant-ui/frontend/src/i18n/i18n.ts
@@ -4,14 +4,16 @@ import { createI18n } from 'vue-i18n';
 function loadLocaleMessages() {
   // Load messages from any json files in the locales folder
   const modules = import.meta.glob('./locales/*.json');
-  const messages: any = {}
+  const messages: any = {};
   for (const path in modules) {
     // For each file found, build the message object
     // with the file NAME as the top level key
     modules[path]().then((mod: any) => {
-      const loc = path.match(/[ \w-]+?(?=\.)/i)![0];
-      messages[loc] = mod;
-    })
+      const matches = path.match(/[ \w-]+?(?=\.)/i);
+      if (matches && matches.length) {
+        messages[matches[0]] = mod;
+      }
+    });
   }
   return messages;
 }

--- a/services/tenant-ui/frontend/src/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/i18n/locales/en.json
@@ -47,7 +47,8 @@
     "messages": "Messages"
   },
   "tenants": {
-    "tenants": "Tenants"
+    "tenants": "Tenants",
+    "checkIn": "Check-In Tenant"
   },
   "about": {
     "about": "About"

--- a/services/tenant-ui/frontend/src/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/i18n/locales/en.json
@@ -1,0 +1,55 @@
+{
+  "home": {
+    "greeting": "Powered by Traction",
+    "dashboard": "Dashboard",
+    "login": {
+      "id": "Wallet ID",
+      "secret": "Wallet Secret",
+      "submit": "Sign-In"
+    }
+  },
+  "user": {
+    "profile": "Profile",
+    "settings": "Settings",
+    "logout": "Logout"
+  },
+  "contact": {
+    "contacts": "Contacts",
+    "create": "Create Contact",
+    "accept": "Accept Invitation"
+  },
+  "issue": {
+    "issuance": "Issuance",
+    "credentials": "Issued/Offered Credentials",
+    "offer": "Offer Credential"
+  },
+  "verify": {
+    "verification": "Verification",
+    "verifications": "Verifications",
+    "createRequest": "Create Presentation Requests"
+  },
+  "holder": {
+    "holder": "Holder",
+    "credentials": "Credentials"
+  },
+  "configuration": {
+    "configuration": "Configuration",
+    "schemasCreds": {
+      "schemas": "Schemas",
+      "create": "Create Schema",
+      "copy": "Copy Schema"
+    },
+    "presentationTemplates": {
+      "templates": "Presentation Templates"
+    }
+  },
+  "messages": {
+    "messages": "Messages"
+  },
+  "tenants": {
+    "tenants": "Tenants"
+  },
+  "about": {
+    "about": "About"
+  }
+}

--- a/services/tenant-ui/frontend/src/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/i18n/locales/fr.json
@@ -18,12 +18,39 @@
     "create": "Create Contact <FR>",
     "accept": "Accept Invitation <FR>"
   },
-  "issue": {},
-  "verify": {},
-  "holder": {},
-  "schemasCreds": {},
-  "tenants": {},
+  "issue": {
+    "issuance": "Issuance <FR>",
+    "credentials": "Issued/Offered Credentials <FR>",
+    "offer": "Offer Credential <FR>"
+  },
+  "verify": {
+    "verification": "Verification <FR>",
+    "verifications": "Verifications <FR>",
+    "createRequest": "Create Presentation Requests <FR>"
+  },
+  "holder": {
+    "holder": "Holder <FR>",
+    "credentials": "Credentials <FR>"
+  },
+  "configuration": {
+    "configuration": "Configuration <FR>",
+    "schemasCreds": {
+      "schemas": "Schemas <FR>",
+      "create": "Create Schema <FR>",
+      "copy": "Copy Schema <FR>"
+    },
+    "presentationTemplates": {
+      "templates": "Presentation Templates <FR>"
+    }
+  },
+  "messages": {
+    "messages": "Messages <FR>"
+  },
+  "tenants": {
+    "tenants": "Tenants <FR>",
+    "checkIn": "Check-In Tenant <FR>"
+  },
   "about": {
-    "about": "About"
+    "about": "About <FR>"
   }
 }

--- a/services/tenant-ui/frontend/src/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/i18n/locales/fr.json
@@ -1,0 +1,29 @@
+{
+  "home": {
+    "greeting": "Propulsé par Traction",
+    "dashboard": "Dashboard <FR>",
+    "login": {
+      "id": "Wallet ID <FR>",
+      "secret": "Wallet Secret <FR>",
+      "submit": "Sign-In <FR>"
+    }
+  },
+  "user": {
+    "profile": "Profile <FR>",
+    "settings": "Settings <FR>",
+    "logout": "Logout <FR>"
+  },
+  "contact": {
+    "contacts": "Contacts <FR>",
+    "create": "Create Contact <FR>",
+    "accept": "Accept Invitation <FR>"
+  },
+  "issue": {},
+  "verify": {},
+  "holder": {},
+  "schemasCreds": {},
+  "tenants": {},
+  "about": {
+    "about": "About"
+  }
+}

--- a/services/tenant-ui/frontend/src/i18n/locales/jp.json
+++ b/services/tenant-ui/frontend/src/i18n/locales/jp.json
@@ -1,29 +1,56 @@
 {
-    "home": {
-      "greeting": "トラクションを搭載",
-      "dashboard": "Dashboard",
-      "login": {
-        "id": "Wallet ID",
-        "secret": "Wallet Secret",
-        "submit": "Sign-In"
-      }
-    },
-    "user": {
-      "profile": "Profile",
-      "settings": "Settings",
-      "logout": "Logout"
-    },
-    "contact": {
-      "contacts": "Contacts",
-      "create": "Create Contact",
-      "accept": "Accept Invitation"
-    },
-    "issue": {},
-    "verify": {},
-    "holder": {},
-    "schemasCreds": {},
-    "tenants": {},
-    "about": {
-      "about": "About"
+  "home": {
+    "greeting": "トラクションを搭載",
+    "dashboard": "Dashboard <JP>",
+    "login": {
+      "id": "Wallet ID <JP>",
+      "secret": "Wallet Secret <JP>",
+      "submit": "Sign-In <JP>"
     }
+  },
+  "user": {
+    "profile": "Profile <JP>",
+    "settings": "Settings <JP>",
+    "logout": "Logout <JP>"
+  },
+  "contact": {
+    "contacts": "Contacts <JP>",
+    "create": "Create Contact <JP>",
+    "accept": "Accept Invitation <JP>"
+  },
+  "issue": {
+    "issuance": "Issuance <JP>",
+    "credentials": "Issued/Offered Credentials <JP>",
+    "offer": "Offer Credential <JP>"
+  },
+  "verify": {
+    "verification": "Verification <JP>",
+    "verifications": "Verifications <JP>",
+    "createRequest": "Create Presentation Requests <JP>"
+  },
+  "holder": {
+    "holder": "Holder <JP>",
+    "credentials": "Credentials <JP>"
+  },
+  "configuration": {
+    "configuration": "Configuration <JP>",
+    "schemasCreds": {
+      "schemas": "Schemas <JP>",
+      "create": "Create Schema <JP>",
+      "copy": "Copy Schema <JP>"
+    },
+    "presentationTemplates": {
+      "templates": "Presentation Templates <JP>"
+    }
+  },
+  "messages": {
+    "messages": "Messages <JP>"
+  },
+  "tenants": {
+    "tenants": "Tenants <JP>",
+    "checkIn": "Check-In Tenant <JP>"
+  },
+  "about": {
+    "about": "About <JP>"
   }
+}

--- a/services/tenant-ui/frontend/src/i18n/locales/jp.json
+++ b/services/tenant-ui/frontend/src/i18n/locales/jp.json
@@ -1,0 +1,29 @@
+{
+    "home": {
+      "greeting": "トラクションを搭載",
+      "dashboard": "Dashboard",
+      "login": {
+        "id": "Wallet ID",
+        "secret": "Wallet Secret",
+        "submit": "Sign-In"
+      }
+    },
+    "user": {
+      "profile": "Profile",
+      "settings": "Settings",
+      "logout": "Logout"
+    },
+    "contact": {
+      "contacts": "Contacts",
+      "create": "Create Contact",
+      "accept": "Accept Invitation"
+    },
+    "issue": {},
+    "verify": {},
+    "holder": {},
+    "schemasCreds": {},
+    "tenants": {},
+    "about": {
+      "about": "About"
+    }
+  }

--- a/services/tenant-ui/tsconfig.json
+++ b/services/tenant-ui/tsconfig.json
@@ -49,7 +49,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "dist/src",                                /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -99,5 +99,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": [
+    "frontend"
+  ]
 }


### PR DESCRIPTION
Move message resources for localization to individual json files.

I discovered that our current build situation was using the tsc configuration for the toplevel of the app (IE the node backend) and transpiling the frontend each time it build the backend too. Think I set this up at the very beginning and we've been going with it so far.
This caused me an error when using a newer Vite-based import technique because the Node typescript setup can't do that esbuild stuff yet. So had to make a tweak to ignore the FE when building the BE. (then the FE is built separately as before with its own tsconfig)
Think there's some more work to do to have the tenant UI building be the best way it can be... so can discuss later on. But it works for now locally and with Helm.

Please review:
https://github.com/bcgov/traction/pull/322/files#diff-2d4fc84d8f16d51ce5e9c816b09c5588f1877bd8284b20356004e0530cd282bf
https://github.com/bcgov/traction/pull/322/files#diff-ebaa196949c5f7f225ce3bdbd650bb2312381d82611535c1cb80cd759bd0bc6d
https://github.com/bcgov/traction/pull/322/files#diff-ebaa196949c5f7f225ce3bdbd650bb2312381d82611535c1cb80cd759bd0bc6d
https://github.com/bcgov/traction/pull/322/files#diff-d4bac62e0c2bd8318ed18a8c9b3614ca90f56ecbad569864e656a8496a19c2f5

(can ignore the rest if you want as they're just more translation examples being thrown into Vue components).