### PR TITLE
Force plugins to use acapy 0.7.4

### DIFF
--- a/plugins/basicmessage_storage/poetry.lock
+++ b/plugins/basicmessage_storage/poetry.lock
@@ -90,7 +90,7 @@ yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "aries-cloudagent"
-version = "0.7.5"
+version = "0.7.4"
 description = ""
 category = "main"
 optional = false
@@ -865,7 +865,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "dc21abd47a7a81b4894f8bda213b2e735bf6343fc20da5e5ce8313cc712fdda2"
+content-hash = "e6e95bb093f7f995713a3345c78d584f67f0fca861478b551886c09d657f2e68"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/basicmessage_storage/pyproject.toml
+++ b/plugins/basicmessage_storage/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Jason Sherman <tools@usingtechnolo.gy>"]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "^0.7.4" }
+aries-cloudagent = { version = "0.7.4" }
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/plugins/multitenant_provider/poetry.lock
+++ b/plugins/multitenant_provider/poetry.lock
@@ -906,7 +906,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "cfae311946669abfde8ece73901fb775797b99ef4999eca4add571fcba2851ef"
+content-hash = "d510c6f98d1265898629ab2b40d811f1efc1d03d4a2933cb55abde9c0d4de961"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/multitenant_provider/pyproject.toml
+++ b/plugins/multitenant_provider/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "multitenant_provider"}]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "^0.7.4" }
+aries-cloudagent = { version = "0.7.4" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"

--- a/plugins/pyproject.toml
+++ b/plugins/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "^0.7.4" }
+aries-cloudagent = { version = "0.7.4" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"

--- a/plugins/traction_innkeeper/poetry.lock
+++ b/plugins/traction_innkeeper/poetry.lock
@@ -879,7 +879,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "8e6c6d7d4d998ca5aeb72d54dbd37b8224946ef53eaddd40e7821b17d038e672"
+content-hash = "9817bb438c283cb9742299401cbeddb4bb1477149a43932ef372b4a1a00c2ec2"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/traction_innkeeper/pyproject.toml
+++ b/plugins/traction_innkeeper/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "traction_innkeeper"}]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "^0.7.4" }
+aries-cloudagent = { version = "0.7.4" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"

--- a/plugins/traction_metadata/poetry.lock
+++ b/plugins/traction_metadata/poetry.lock
@@ -879,7 +879,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "8e6c6d7d4d998ca5aeb72d54dbd37b8224946ef53eaddd40e7821b17d038e672"
+content-hash = "9817bb438c283cb9742299401cbeddb4bb1477149a43932ef372b4a1a00c2ec2"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/traction_metadata/pyproject.toml
+++ b/plugins/traction_metadata/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "traction_metadata"}]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "^0.7.4" }
+aries-cloudagent = { version = "0.7.4" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"


### PR DESCRIPTION
Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>

One plugin was pulling in 0.7.5 which resulted in a payload error with an endorser running 0.7.4. Let's remain (and ensure we use) 0.7.4 in our plugins, thus our custom acapy agent image.