### PR TITLE
basicmessages_storage - list sort by created_at desc

### DIFF
--- a/services/tenant-ui/frontend/src/components/messages/Messages.vue
+++ b/services/tenant-ui/frontend/src/components/messages/Messages.vue
@@ -61,6 +61,7 @@ const messageStore = useMessageStore();
 const { loading, messages, selectedMessage } = storeToRefs(useMessageStore());
 
 const loadTable = async () => {
+  // should return latest message first
   messageStore.listMessages().catch((err: any) => {
     toast.error(`Failure: ${err}`);
   });


### PR DESCRIPTION
Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>

Make default sort be on `created-at` descending, do not factor in `state` or `connection_id`