### PR TITLE
Move API Paths into constants.

### DIFF
--- a/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
@@ -57,7 +57,7 @@
     <template #expansion="{ data }">
       <RowExpandData
         :id="data.contact_id"
-        :url="'/tenant/v1/contacts/'"
+        :url="API_PATH.CONTACTS"
         :params="{ acapy: true }"
       />
     </template>
@@ -79,7 +79,7 @@ import { storeToRefs } from 'pinia';
 // Other components
 import AcceptInvitation from './acceptInvitation/AcceptInvitation.vue';
 import CreateContact from './createContact/CreateContact.vue';
-import { TABLE_OPT } from '@/helpers/constants';
+import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';

--- a/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
@@ -37,6 +37,7 @@ import { onMounted, reactive, ref, PropType } from 'vue';
 import { useContactsStore } from '../../../store';
 import useGetItem from '@/composables/useGetItem';
 import { formatDateLong } from '@/helpers';
+import { API_PATH } from '@/helpers/constants';
 // PrimeVue / Validation
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
@@ -88,7 +89,7 @@ const handleSubmit = async (isFormValid: boolean) => {
 };
 
 // Get the latest details about this contact when opening
-const { loading, item, fetchItem } = useGetItem('/tenant/v1/contacts/');
+const { loading, item, fetchItem } = useGetItem(API_PATH.CONTACTS);
 onMounted(async () => {
   try {
     await fetchItem(props.contactId);

--- a/services/tenant-ui/frontend/src/components/holder/Credentials.vue
+++ b/services/tenant-ui/frontend/src/components/holder/Credentials.vue
@@ -29,7 +29,7 @@
     <template #expansion="{ data }">
       <RowExpandData
         :id="data.holder_credential_id"
-        :url="'/tenant/v1/holder/credentials/'"
+        :url="API_PATH.HOLDER_CREDENTIALS"
         :params="{ acapy: true }"
       />
     </template>
@@ -90,7 +90,7 @@ import { useConfirm } from 'primevue/useconfirm';
 import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';
 
-import { TABLE_OPT } from '@/helpers/constants';
+import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 
 const toast = useToast();

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
@@ -45,7 +45,7 @@
       </template>
     </Column>
     <template #expansion="{ data }">
-      <RowExpandData :id="data.tenant_id" :url="'/innkeeper/v1/tenants/'" />
+      <RowExpandData :id="data.tenant_id" :url="API_PATH.INNKEEPER_TENANTS" />
     </template>
   </DataTable>
 </template>
@@ -63,7 +63,7 @@ import { useInnkeeperTenantsStore } from '@/store';
 import { storeToRefs } from 'pinia';
 // Other components
 import CheckInTenant from './CheckInTenant.vue';
-import { TABLE_OPT } from '@/helpers/constants';
+import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 import RowExpandData from '@/components/common/RowExpandData.vue';
 import { useI18n } from 'vue-i18n';

--- a/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
@@ -66,7 +66,7 @@
     <template #expansion="{ data }">
       <RowExpandData
         :id="data.issuer_credential_id"
-        :url="'/tenant/v1/issuer/credentials/'"
+        :url="API_PATH.ISSUER_CREDENTIALS"
         :params="{ acapy: true }"
       />
     </template>
@@ -88,7 +88,7 @@ import { useConfirm } from 'primevue/useconfirm';
 // Other Components
 import OfferCredential from './offerCredential/OfferCredential.vue';
 import RowExpandData from '../common/RowExpandData.vue';
-import { TABLE_OPT } from '@/helpers/constants';
+import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 import StatusChip from '../common/StatusChip.vue';
 import { useI18n } from 'vue-i18n';

--- a/services/tenant-ui/frontend/src/components/issuance/Schemas.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/Schemas.vue
@@ -61,7 +61,7 @@
     <template #expansion="{ data }">
       <RowExpandData
         :id="data.schema_template_id"
-        :url="'/tenant/v1/governance/schema_templates/'"
+        :url="API_PATH.GOVERNANCE_SCHEMA_TEMPLATES"
         :params="{ acapy: true, credential_templates: true }"
       />
     </template>
@@ -80,7 +80,7 @@ import CopySchema from './copySchema/CopySchema.vue';
 import CreateCredentialTemplate from './credentialtemplate/CreateCredentialTemplate.vue';
 import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';
-import { TABLE_OPT } from '@/helpers/constants';
+import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 
 import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from 'vue-toastification';

--- a/services/tenant-ui/frontend/src/components/verifier/PresentationRowExpandData.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/PresentationRowExpandData.vue
@@ -1,7 +1,7 @@
 <template>
   <RowExpandData
     :id="props.row.verifier_presentation_id"
-    :url="'/tenant/v1/verifier/presentations/'"
+    :url="API_PATH.VERIFIER_PRESENTATIONS"
     :params="{ acapy: true }"
   >
     <template #details="presentation">
@@ -50,6 +50,7 @@ import { PropType } from 'vue';
 import { formatDateLong } from '@/helpers';
 import RowExpandData from '../common/RowExpandData.vue';
 import VerifiedPresentationData from './VerifiedPresentationData.vue';
+import { API_PATH } from '@/helpers/constants';
 
 const props = defineProps({
   row: {

--- a/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
@@ -69,13 +69,13 @@ import { useVerifierStore } from '../../store';
 import { storeToRefs } from 'pinia';
 
 import PresentationRowExpandData from './PresentationRowExpandData.vue';
-import { TABLE_OPT } from '@/helpers/constants';
+import { API_PATH, TABLE_OPT } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 import StatusChip from '../common/StatusChip.vue';
 import SuperYou from '@/components/common/SuperYou.vue';
 const toast = useToast();
 
-const apiUrl = '/tenant/v1/verifier/presentations/adhoc-request';
+const apiUrl = API_PATH.VERIFIER_PRESENTATION_ADHOC_REQUEST;
 
 const templateJson = {
   contact_id: '67f68781-4dd9-49ad-9a5e-1e9a06e901f4',

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -2,3 +2,61 @@ export const TABLE_OPT = {
   ROWS_DEFAULT: 10,
   ROWS_OPTIONS: [10, 25, 50],
 };
+
+export const API_PATH = {
+  CONFIG: '/config',
+
+  INNKEEPER_TOKEN: '/innkeeper/token',
+  INNKEEPER_TENANTS: '/innkeeper/v1/tenants/',
+  INNKEEPER_TENANT: (id: string) => `/innkeeper/v1/tenants/${id}`,
+  INNKEEPER_TENANT_CHECK_IN: '/innkeeper/v1/tenants/check-in',
+
+  OIDC_INNKEEPER_LOGIN: '/api/innkeeperLogin',
+  OIDC_INNKEEPER_REDIRECT_URI: `${window.location.origin}/innkeeper`,
+
+  TENANT_TOKEN: '/tenant/token',
+
+  CONTACTS: '/tenant/v1/contacts/',
+  CONTACTS_CREATE_INVITATION: '/tenant/v1/contacts/create-invitation',
+  CONTACTS_RECEIVE_INVITATION: '/tenant/v1/contacts/receive-invitation',
+  CONTACT: (id: string) => `/tenant/v1/contacts/${id}`,
+
+  HOLDER_CREDENTIALS: '/tenant/v1/holder/credentials/',
+  HOLDER_CREDENTIALS_ACCEPT_OFFER: (id: string) =>
+    `/tenant/v1/holder/credentials/${id}/accept-offer`,
+  HOLDER_CREDENTIALS_REJECT_OFFER: (id: string) =>
+    `/tenant/v1/holder/credentials/${id}/reject-offer`,
+  HOLDER_CREDENTIAL: (id: string) => `/tenant/v1/holder/credentials/${id}`,
+  HOLDER_PRESENTATIONS: '/tenant/v1/holder/presentations/',
+  HOLDER_PRESENTATION: (id: string) => `/tenant/v1/holder/presentations/${id}`,
+
+  ISSUER_CREDENTIALS: '/tenant/v1/issuer/credentials/',
+  ISSUER_CREDENTIAL: (id: string) => `/tenant/v1/issuer/credentials/${id}`,
+  ISSUER_CREDENTIAL_REVOKE: (id: string) =>
+    `/tenant/v1/issuer/credentials/${id}/revoke-credential`,
+
+  VERIFIER_PRESENTATIONS: '/tenant/v1/verifier/presentations/',
+  VERIFIER_PRESENTATION: (id: string) =>
+    `/tenant/v1/verifier/presentations/${id}`,
+  VERIFIER_PRESENTATION_ADHOC_REQUEST:
+    '/tenant/v1/verifier/presentations/adhoc-request',
+  VERIFIER_PRESENTATION_TEMPLATES:
+    '/tenant/v1/verifier/presentation_templates/',
+
+  GOVERNANCE_SCHEMA_TEMPLATES: '/tenant/v1/governance/schema_templates/',
+  GOVERNANCE_SCHEMA_TEMPLATES_IMPORT:
+    '/tenant/v1/governance/schema_templates/import',
+  GOVERNANCE_SCHEMA_TEMPLATE: (id: string) =>
+    `/tenant/v1/governance/schema_templates/${id}`,
+  GOVERNANCE_CREDENTIAL_TEMPLATES:
+    '/tenant/v1/governance/credential_templates/',
+  GOVERNANCE_CREDENTIAL_TEMPLATE: (id: string) =>
+    `/tenant/v1/governance/credential_templates/${id}`,
+
+  BASICMESSAGES: '/basicmessages',
+  BASICMESSAGES_SEND: (connId: string) => `/connections/${connId}/send-message`,
+
+  TENANT_SELF: '/tenant/v1/admin/self',
+  TENANT_MAKE_ISSUER: '/tenant/v1/admin/make-issuer',
+  TENANT_CONFIGURATION: '/tenant/v1/admin/configuration',
+};

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -12,7 +12,6 @@ export const API_PATH = {
   INNKEEPER_TENANT_CHECK_IN: '/innkeeper/v1/tenants/check-in',
 
   OIDC_INNKEEPER_LOGIN: '/api/innkeeperLogin',
-  OIDC_INNKEEPER_REDIRECT_URI: `${window.location.origin}/innkeeper`,
 
   TENANT_TOKEN: '/tenant/token',
 

--- a/services/tenant-ui/frontend/src/store/configStore.ts
+++ b/services/tenant-ui/frontend/src/store/configStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import axios from 'axios';
+import { API_PATH } from '@/helpers/constants';
 
 export const useConfigStore = defineStore('config', () => {
   // state
@@ -33,7 +34,7 @@ export const useConfigStore = defineStore('config', () => {
     error.value = null;
     loading.value = true;
     await axios
-      .get('/config')
+      .get(API_PATH.CONFIG)
       .then((res) => {
         console.log(res);
         config.value = res.data;

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -1,3 +1,4 @@
+import { API_PATH } from '@/helpers/constants';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { useTenantApi } from './tenantApi';
@@ -33,7 +34,7 @@ export const useContactsStore = defineStore('contacts', () => {
 
   async function listContacts() {
     selectedContact.value = null;
-    return fetchList('/tenant/v1/contacts/', contacts, error, loading, {
+    return fetchList(API_PATH.CONTACTS, contacts, error, loading, {
       acapy: true,
     });
   }
@@ -46,7 +47,7 @@ export const useContactsStore = defineStore('contacts', () => {
     let invitationData = null;
     // need the await here since the returned invitationData is not one of our stored refs...
     await tenantApi
-      .postHttp('/tenant/v1/contacts/create-invitation', { alias })
+      .postHttp(API_PATH.CONTACTS_CREATE_INVITATION, { alias })
       .then((res) => {
         console.log(res);
         // don't grab the item, there are other parts of the response data we need (invitation, invitation url)
@@ -84,7 +85,7 @@ export const useContactsStore = defineStore('contacts', () => {
     let acceptedData = null;
     // need the await here since the returned invitation_data is not one of our stored refs...
     await tenantApi
-      .postHttp('/tenant/v1/contacts/receive-invitation', {
+      .postHttp(API_PATH.CONTACTS_RECEIVE_INVITATION, {
         alias,
         invitation_url: inviteUrl,
       })
@@ -128,7 +129,7 @@ export const useContactsStore = defineStore('contacts', () => {
     let result = null;
 
     await tenantApi
-      .deleteHttp(`/tenant/v1/contacts/${contactId}`, payload)
+      .deleteHttp(API_PATH.CONTACT(contactId), payload)
       .then((res) => {
         result = res.data.item;
       })
@@ -153,7 +154,7 @@ export const useContactsStore = defineStore('contacts', () => {
 
   async function getContact(id: string, params: any = {}) {
     const getloading: any = ref(false);
-    return fetchItem('/tenant/v1/contacts/', id, error, getloading, params);
+    return fetchItem(API_PATH.CONTACTS, id, error, getloading, params);
   }
 
   // Only going to do alias right now but expand to other params as needed later
@@ -164,7 +165,7 @@ export const useContactsStore = defineStore('contacts', () => {
 
     let contactData = null;
     await tenantApi
-      .putHttp(`/tenant/v1/contacts/${contactId}`, {
+      .putHttp(`${API_PATH.CONTACTS}${contactId}`, {
         contact_id: contactId,
         alias,
       })

--- a/services/tenant-ui/frontend/src/store/governanceStore.ts
+++ b/services/tenant-ui/frontend/src/store/governanceStore.ts
@@ -1,3 +1,4 @@
+import { API_PATH } from '@/helpers/constants';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { useTenantApi } from './tenantApi';
@@ -72,7 +73,7 @@ export const useGovernanceStore = defineStore('governance', () => {
     selectedSchemaTemplate.value = null;
     schemaTemplates.value = null;
     return fetchList(
-      '/tenant/v1/governance/schema_templates/',
+      API_PATH.GOVERNANCE_SCHEMA_TEMPLATES,
       schemaTemplates,
       error,
       loading,
@@ -84,7 +85,7 @@ export const useGovernanceStore = defineStore('governance', () => {
     selectedCredentialTemplate.value = null;
     credentialTemplates.value = null;
     return fetchList(
-      '/tenant/v1/governance/credential_templates/',
+      API_PATH.GOVERNANCE_CREDENTIAL_TEMPLATES,
       credentialTemplates,
       error,
       loading
@@ -99,7 +100,7 @@ export const useGovernanceStore = defineStore('governance', () => {
     let result = null;
 
     await tenantApi
-      .postHttp('/tenant/v1/governance/schema_templates/', payload)
+      .postHttp(API_PATH.GOVERNANCE_SCHEMA_TEMPLATES, payload)
       .then((res) => {
         console.log(res);
         result = res.data.item;
@@ -137,7 +138,7 @@ export const useGovernanceStore = defineStore('governance', () => {
     let result = null;
 
     await tenantApi
-      .postHttp('/tenant/v1/governance/credential_templates/', payload)
+      .postHttp(API_PATH.GOVERNANCE_CREDENTIAL_TEMPLATES, payload)
       .then((res) => {
         console.log(res);
         result = res.data.item;
@@ -180,7 +181,7 @@ export const useGovernanceStore = defineStore('governance', () => {
     let result = null;
 
     await tenantApi
-      .postHttp('/tenant/v1/governance/schema_templates/import', payload)
+      .postHttp(API_PATH.GOVERNANCE_SCHEMA_TEMPLATES_IMPORT, payload)
       .then((res) => {
         console.log(res);
         result = res.data.item;
@@ -216,7 +217,7 @@ export const useGovernanceStore = defineStore('governance', () => {
       params.credential_templates = true;
     }
     return fetchItem(
-      '/tenant/v1/governance/schema_templates/',
+      API_PATH.GOVERNANCE_SCHEMA_TEMPLATES,
       id,
       error,
       getloading,
@@ -227,7 +228,7 @@ export const useGovernanceStore = defineStore('governance', () => {
   async function getCredentialTemplate(id: string, params: any = {}) {
     const getloading: any = ref(false);
     return fetchItem(
-      '/tenant/v1/governance/credential_templates/',
+      API_PATH.GOVERNANCE_CREDENTIAL_TEMPLATES,
       id,
       error,
       getloading,
@@ -252,7 +253,7 @@ export const useGovernanceStore = defineStore('governance', () => {
     let result = null;
 
     await tenantApi
-      .deleteHttp(`/tenant/v1/governance/schema_templates/${schemaId}`, payload)
+      .deleteHttp(API_PATH.GOVERNANCE_SCHEMA_TEMPLATE(schemaId), payload)
       .then((res) => {
         result = res.data.item;
       })

--- a/services/tenant-ui/frontend/src/store/holderStore.ts
+++ b/services/tenant-ui/frontend/src/store/holderStore.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { fetchItem } from './utils/fetchItem';
 import { fetchList } from './utils/fetchList.js';
 import { useTenantApi } from './tenantApi';
+import { API_PATH } from '@/helpers/constants';
 
 export const useHolderStore = defineStore('holder', () => {
   // state
@@ -19,18 +20,13 @@ export const useHolderStore = defineStore('holder', () => {
 
   async function listCredentials() {
     selectedCredential.value = null;
-    return fetchList(
-      '/tenant/v1/holder/credentials/',
-      credentials,
-      error,
-      loading
-    );
+    return fetchList(API_PATH.HOLDER_CREDENTIALS, credentials, error, loading);
   }
 
   async function listPresentations() {
     selectedPresentation.value = null;
     return fetchList(
-      '/tenant/v1/holder/presentations/',
+      API_PATH.HOLDER_PRESENTATIONS,
       presentations,
       error,
       loading
@@ -40,7 +36,7 @@ export const useHolderStore = defineStore('holder', () => {
   async function getCredential(id: string, params: any = {}) {
     const getloading: any = ref(false);
     return fetchItem(
-      '/tenant/v1/holder/credentials/',
+      API_PATH.HOLDER_CREDENTIALS,
       id,
       error,
       getloading,
@@ -51,7 +47,7 @@ export const useHolderStore = defineStore('holder', () => {
   async function getPresentation(id: string, params: any = {}) {
     const getloading: any = ref(false);
     return fetchItem(
-      '/tenant/v1/holder/presentations/',
+      API_PATH.HOLDER_PRESENTATIONS,
       id,
       error,
       getloading,
@@ -70,7 +66,7 @@ export const useHolderStore = defineStore('holder', () => {
     let result = null;
 
     await tenantApi
-      .postHttp(`/tenant/v1/holder/credentials/${credId}/accept-offer`, {
+      .postHttp(API_PATH.HOLDER_CREDENTIALS_ACCEPT_OFFER(credId), {
         holder_credential_id: credId,
       })
       .then((res) => {
@@ -103,7 +99,7 @@ export const useHolderStore = defineStore('holder', () => {
     let result = null;
 
     await tenantApi
-      .postHttp(`/tenant/v1/holder/credentials/${credId}/reject-offer`, {
+      .postHttp(API_PATH.HOLDER_CREDENTIALS_REJECT_OFFER(credId), {
         holder_credential_id: credId,
       })
       .then((res) => {
@@ -136,7 +132,7 @@ export const useHolderStore = defineStore('holder', () => {
     let result = null;
 
     await tenantApi
-      .deleteHttp(`/tenant/v1/holder/credentials/${credId}`)
+      .deleteHttp(API_PATH.HOLDER_CREDENTIAL(credId))
       .then((res) => {
         result = res.data.item;
       })

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperApi.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperApi.ts
@@ -32,7 +32,7 @@ export const useInnkeeperApi = defineStore('innkeeperApi', () => {
       const result = {
         ...apiConfig,
         headers: {
-          contentType: 'application/json',
+          'Content-Type': 'application/json',
           accept: 'application/json',
           ...apiConfig.headers,
           Authorization: `Bearer ${innkeeperTokenStore.token}`,

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperOidcStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperOidcStore.ts
@@ -15,10 +15,10 @@ export const useInnkeeperOidcStore = defineStore('innkeeperOidcStore', () => {
   const _settings: any = {
     authority: config.value.frontend.oidc.authority,
     client_id: config.value.frontend.oidc.client,
-    redirect_uri: API_PATH.OIDC_INNKEEPER_REDIRECT_URI,
+    redirect_uri: `${window.location.origin}/innkeeper`,
     response_type: 'code',
     automaticSilentRenew: false, // don't need to renew for our needs at this point
-    post_logout_redirect_uri: API_PATH.OIDC_INNKEEPER_REDIRECT_URI,
+    post_logout_redirect_uri: `${window.location.origin}/innkeeper`,
     loadUserInfo: true,
   };
   const _userManager: UserManager = new UserManager(_settings);

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperOidcStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperOidcStore.ts
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue';
 import { useConfigStore } from '../configStore';
 import { useInnkeeperTokenStore } from './innkeeperTokenStore';
 import { UserManager } from 'oidc-client-ts';
+import { API_PATH } from '@/helpers/constants';
 
 export const useInnkeeperOidcStore = defineStore('innkeeperOidcStore', () => {
   // other stores
@@ -14,10 +15,10 @@ export const useInnkeeperOidcStore = defineStore('innkeeperOidcStore', () => {
   const _settings: any = {
     authority: config.value.frontend.oidc.authority,
     client_id: config.value.frontend.oidc.client,
-    redirect_uri: `${window.location.origin}/innkeeper`,
+    redirect_uri: API_PATH.OIDC_INNKEEPER_REDIRECT_URI,
     response_type: 'code',
     automaticSilentRenew: false, // don't need to renew for our needs at this point
-    post_logout_redirect_uri: `${window.location.origin}/innkeeper`,
+    post_logout_redirect_uri: API_PATH.OIDC_INNKEEPER_REDIRECT_URI,
     loadUserInfo: true,
   };
   const _userManager: UserManager = new UserManager(_settings);
@@ -43,7 +44,10 @@ export const useInnkeeperOidcStore = defineStore('innkeeperOidcStore', () => {
       const loginCfg = {
         headers: { Authorization: `Bearer ${usr?.access_token}` },
       };
-      const response: any = await axios.get('/api/innkeeperLogin', loginCfg);
+      const response: any = await axios.get(
+        API_PATH.OIDC_INNKEEPER_LOGIN,
+        loginCfg
+      );
       token.value = response.data.access_token;
 
       // strip the oidc return params

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -3,6 +3,7 @@ import { ref, Ref } from 'vue';
 import { useInnkeeperApi } from './innkeeperApi';
 import { fetchList } from '../utils';
 import { AxiosRequestConfig } from 'axios';
+import { API_PATH } from '@/helpers/constants';
 export interface TenantResponseData {
   tenant_id?: string;
   name?: string;
@@ -24,7 +25,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
   const innkeeperApi = useInnkeeperApi();
 
   async function listTenants(): Promise<object | null> {
-    return fetchList('/innkeeper/v1/tenants/', tenants, error, loading);
+    return fetchList(API_PATH.INNKEEPER_TENANTS, tenants, error, loading);
   }
 
   // TODO: Test out creating a tenant
@@ -42,7 +43,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
 
     let tenantData: TenantResponseData | undefined;
     await innkeeperApi
-      .postHttp('/innkeeper/v1/tenants/check-in', {
+      .postHttp(API_PATH.INNKEEPER_TENANT_CHECK_IN, {
         name: data.name,
         allow_issue_credentials: data.allowIssue,
       })

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTokenStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTokenStore.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { useConfigStore } from '../configStore';
 import { Ref } from 'vue';
+import { API_PATH } from '@/helpers/constants';
 
 export const useInnkeeperTokenStore = defineStore(
   'useInnkeeperTokenStore',
@@ -36,7 +37,7 @@ export const useInnkeeperTokenStore = defineStore(
 
       // TODO: isolate this to something reusable when we grab an axios connection.
       const configStore = useConfigStore();
-      const url = configStore.proxyPath('/innkeeper/token');
+      const url = configStore.proxyPath(API_PATH.INNKEEPER_TOKEN);
       await axios({
         method: 'post',
         url,

--- a/services/tenant-ui/frontend/src/store/issuerStore.ts
+++ b/services/tenant-ui/frontend/src/store/issuerStore.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { fetchList } from './utils/fetchList.js';
 import { useTenantApi } from './tenantApi';
 import { fetchItem } from './utils/fetchItem';
+import { API_PATH } from '@/helpers/constants';
 
 export const useIssuerStore = defineStore('issuer', () => {
   const tenantApi = useTenantApi();
@@ -19,12 +20,7 @@ export const useIssuerStore = defineStore('issuer', () => {
 
   async function listCredentials() {
     selectedCredential.value = null;
-    return fetchList(
-      '/tenant/v1/issuer/credentials/',
-      credentials,
-      error,
-      loading
-    );
+    return fetchList(API_PATH.ISSUER_CREDENTIALS, credentials, error, loading);
   }
 
   async function offerCredential(payload: any = {}) {
@@ -35,7 +31,7 @@ export const useIssuerStore = defineStore('issuer', () => {
     let result = null;
 
     await tenantApi
-      .postHttp('/tenant/v1/issuer/credentials/', payload)
+      .postHttp(API_PATH.ISSUER_CREDENTIALS, payload)
       .then((res) => {
         console.log(res);
         result = res.data.item;
@@ -63,7 +59,7 @@ export const useIssuerStore = defineStore('issuer', () => {
   async function getCredential(id: string, params: any = {}) {
     const getloading: any = ref(false);
     return fetchItem(
-      '/tenant/v1/issuer/credentials/',
+      API_PATH.ISSUER_CREDENTIALS,
       id,
       error,
       getloading,
@@ -80,7 +76,7 @@ export const useIssuerStore = defineStore('issuer', () => {
 
     await tenantApi
       .postHttp(
-        `/tenant/v1/issuer/credentials/${payload.issuer_credential_id}/revoke-credential`,
+        API_PATH.ISSUER_CREDENTIAL_REVOKE(payload.issuer_credential_id),
         payload
       )
       .then((res) => {
@@ -114,7 +110,7 @@ export const useIssuerStore = defineStore('issuer', () => {
     let result = null;
 
     await tenantApi
-      .deleteHttp(`/tenant/v1/issuer/credentials/${issuerCredentialId}`)
+      .deleteHttp(API_PATH.ISSUER_CREDENTIAL(issuerCredentialId))
       .then((res) => {
         result = res.data.item;
       })

--- a/services/tenant-ui/frontend/src/store/messageStore.ts
+++ b/services/tenant-ui/frontend/src/store/messageStore.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { defineStore } from 'pinia';
 import { useAcapyApi } from './acapyApi';
 import { fetchListFromAPI } from './utils';
+import { API_PATH } from '@/helpers/constants';
 
 export const useMessageStore = defineStore('messages', () => {
   const messages: any = ref(null);
@@ -15,7 +16,7 @@ export const useMessageStore = defineStore('messages', () => {
   async function listMessages() {
     return fetchListFromAPI(
       acapyApi,
-      '/basicmessages',
+      API_PATH.BASICMESSAGES,
       messages,
       error,
       loading,
@@ -36,7 +37,7 @@ export const useMessageStore = defineStore('messages', () => {
     let result = null;
 
     await acapyApi
-      .postHttp(`/connections/${connId}/send-message`, payload)
+      .postHttp(API_PATH.BASICMESSAGES_SEND(connId), payload)
       .then((res) => {
         console.log(res);
         result = res.data.item;

--- a/services/tenant-ui/frontend/src/store/tenantStore.ts
+++ b/services/tenant-ui/frontend/src/store/tenantStore.ts
@@ -1,3 +1,4 @@
+import { API_PATH } from '@/helpers/constants';
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useTenantApi } from './tenantApi';
@@ -35,7 +36,7 @@ export const useTenantStore = defineStore('tenant', () => {
     loading.value = true;
 
     tenantApi
-      .getHttp('/tenant/v1/admin/self')
+      .getHttp(API_PATH.TENANT_SELF)
       .then((res) => {
         console.log(res);
         tenant.value = res.data.item;
@@ -65,7 +66,7 @@ export const useTenantStore = defineStore('tenant', () => {
     loading.value = true;
 
     tenantApi
-      .postHttp('/tenant/v1/admin/make-issuer')
+      .postHttp(API_PATH.TENANT_MAKE_ISSUER)
       .then((res) => {
         console.log(res);
         tenant.value = res.data.item;
@@ -94,7 +95,7 @@ export const useTenantStore = defineStore('tenant', () => {
     loading.value = true;
 
     await tenantApi
-      .getHttp('/tenant/v1/admin/configuration')
+      .getHttp(API_PATH.TENANT_CONFIGURATION)
       .then((res) => {
         console.log(res);
         tenantConfig.value = res.data.item;
@@ -123,7 +124,7 @@ export const useTenantStore = defineStore('tenant', () => {
     loading.value = true;
     console.log(payload);
     await tenantApi
-      .putHttp('/tenant/v1/admin/configuration', payload)
+      .putHttp(API_PATH.TENANT_CONFIGURATION, payload)
       .then((res) => {
         console.log(res);
         tenantConfig.value = res.data.item;

--- a/services/tenant-ui/frontend/src/store/tokenStore.ts
+++ b/services/tenant-ui/frontend/src/store/tokenStore.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import axios from 'axios';
 import { useConfigStore } from './configStore';
 import jwtDecode from 'jwt-decode';
+import { API_PATH } from '@/helpers/constants';
 
 export const useTokenStore = defineStore('token', () => {
   // state
@@ -24,7 +25,7 @@ export const useTokenStore = defineStore('token', () => {
 
     // TODO: isolate this to something reusable when we grab an axios connection.
     const configStore = useConfigStore();
-    const url = configStore.proxyPath('/tenant/token');
+    const url = configStore.proxyPath(API_PATH.TENANT_TOKEN);
     await axios({
       method: 'post',
       url,

--- a/services/tenant-ui/frontend/src/store/verifierStore.ts
+++ b/services/tenant-ui/frontend/src/store/verifierStore.ts
@@ -1,3 +1,4 @@
+import { API_PATH } from '@/helpers/constants';
 import { defineStore } from 'pinia';
 import { Ref, ref } from 'vue';
 import { fetchItem } from './utils/fetchItem';
@@ -17,7 +18,7 @@ export const useVerifierStore = defineStore('verifier', () => {
   async function listPresentations() {
     selectedPresentation.value = null;
     return fetchList(
-      '/tenant/v1/verifier/presentations/',
+      API_PATH.VERIFIER_PRESENTATIONS,
       presentations,
       error,
       loading
@@ -27,7 +28,7 @@ export const useVerifierStore = defineStore('verifier', () => {
   async function getPresentation(id: string, params: any = {}) {
     const getloading: any = ref(false);
     return fetchItem(
-      '/tenant/v1/verifier/presentations/',
+      API_PATH.VERIFIER_PRESENTATIONS,
       id,
       error,
       getloading,

--- a/services/tenant-ui/frontend/src/views/verification/PresentationTemplates.vue
+++ b/services/tenant-ui/frontend/src/views/verification/PresentationTemplates.vue
@@ -9,6 +9,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import SuperYou from '@/components/common/SuperYou.vue';
+import { API_PATH } from '@/helpers/constants';
 
 /**
  * Convenient functionality for devs to test the API
@@ -39,5 +40,5 @@ const templateJson = ref({
     non_revoked: {},
   },
 });
-const apiUrl = ref('/tenant/v1/verifier/presentation_templates');
+const apiUrl = ref(API_PATH.VERIFIER_PRESENTATION_TEMPLATES);
 </script>


### PR DESCRIPTION
Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>

Moving all API paths into the constants file. This should help refactoring as we move forward. There are some constants that are currently not used but exist in the APIs. 

Note that the complete traction API is not in constants.

Also, note that some "constants" are functions. These are the ones where an ID is present in the path.