### PR TITLE
Handle self-message loop bug by not listening for the event.

### DIFF
--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -138,7 +138,7 @@ acapy:
   staticArgs:
     autoAcceptInvites: true
     autoAcceptRequests: true
-    autoRespondMessages: false
+    autoRespondMessages: true
     autoRespondCredentialProposal: false
     autoRespondCredentialOffer: false
     autoRespondCredentialRequest: true

--- a/scripts/acapy-static-args.yml
+++ b/scripts/acapy-static-args.yml
@@ -1,6 +1,6 @@
 auto-accept-invites: true
 auto-accept-requests: true
-auto-respond-messages: false
+auto-respond-messages: true
 auto-respond-credential-proposal: false
 auto-respond-credential-offer: false
 auto-respond-credential-request: true

--- a/services/traction/api/endpoints/routes/v1/tenant/deprecate.py
+++ b/services/traction/api/endpoints/routes/v1/tenant/deprecate.py
@@ -1,0 +1,14 @@
+# HTTP Header Date format: Thu, 01 Dec 1994 16:00:00 GMT
+# Let's deprecate this set of endpoints.
+# messaging is handled in acapy plugins.
+from fastapi.responses import JSONResponse
+from starlette import status
+
+sunset_str = "Thu, 08 Dec 2022 00:00:00 GMT"
+
+# The HTTP_410_GONE will override whatever is in the route documentation
+sunset_response = JSONResponse(
+    status_code=status.HTTP_410_GONE,
+    content={"message": "API method is deprecated"},
+    headers={"sunset": sunset_str, "deprecated": "true"},
+)

--- a/services/traction/api/endpoints/routes/v1/tenant/messages/message.py
+++ b/services/traction/api/endpoints/routes/v1/tenant/messages/message.py
@@ -2,17 +2,17 @@ import logging
 from uuid import UUID
 
 from fastapi import APIRouter
+from fastapi.openapi.models import Response
 from starlette import status
 from starlette.requests import Request
 
-from api.endpoints.dependencies.tenant_security import get_from_context
+
 from api.endpoints.models.v1.messages import (
-    MessageGetResponse,
-    UpdateMessageResponse,
     UpdateMessagePayload,
 )
-from api.endpoints.routes.v1.link_utils import build_item_links
-from api.services.v1 import messages_service
+
+from api.endpoints.routes.v1.tenant.deprecate import sunset_response
+
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -21,73 +21,40 @@ logger = logging.getLogger(__name__)
 @router.get(
     "/{message_id}",
     status_code=status.HTTP_200_OK,
-    response_model=MessageGetResponse,
+    response_model=Response,
+    deprecated=True,
 )
 async def get_message(
     request: Request,
     message_id: UUID,
     acapy: bool | None = False,
     deleted: bool | None = False,
-) -> MessageGetResponse:
-    wallet_id = get_from_context("TENANT_WALLET_ID")
-    tenant_id = get_from_context("TENANT_ID")
-
-    item = await messages_service.get_message(
-        tenant_id,
-        wallet_id,
-        message_id=message_id,
-        acapy=acapy,
-        deleted=deleted,
-    )
-
-    links = build_item_links(str(request.url), item)
-
-    return MessageGetResponse(item=item, links=links)
+) -> Response:
+    return sunset_response
 
 
 @router.put(
     "/{message_id}",
     status_code=status.HTTP_200_OK,
-    response_model=UpdateMessageResponse,
+    response_model=Response,
+    deprecated=True,
 )
 async def update_message(
     request: Request,
     message_id: UUID,
     payload: UpdateMessagePayload,
-) -> UpdateMessageResponse:
-    wallet_id = get_from_context("TENANT_WALLET_ID")
-    tenant_id = get_from_context("TENANT_ID")
-
-    item = await messages_service.update_message(
-        tenant_id,
-        wallet_id,
-        message_id=message_id,
-        payload=payload,
-    )
-
-    links = build_item_links(str(request.url), item)
-
-    return UpdateMessageResponse(item=item, link=links)
+) -> Response:
+    return sunset_response
 
 
 @router.delete(
     "/{message_id}",
     status_code=status.HTTP_200_OK,
-    response_model=MessageGetResponse,
+    response_model=Response,
+    deprecated=True,
 )
 async def delete_message(
     request: Request,
     message_id: UUID,
-) -> MessageGetResponse:
-    wallet_id = get_from_context("TENANT_WALLET_ID")
-    tenant_id = get_from_context("TENANT_ID")
-
-    item = await messages_service.delete_message(
-        tenant_id,
-        wallet_id,
-        message_id=message_id,
-    )
-
-    links = build_item_links(str(request.url), item)
-
-    return MessageGetResponse(item=item, link=links)
+) -> Response:
+    return sunset_response

--- a/services/traction/api/endpoints/routes/v1/tenant/messages/messages.py
+++ b/services/traction/api/endpoints/routes/v1/tenant/messages/messages.py
@@ -2,26 +2,23 @@ import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Request
+from fastapi.openapi.models import Response
 from starlette import status
 
 from api.core.config import settings
-from api.endpoints.dependencies.tenant_security import get_from_context
 from api.endpoints.models.v1.messages import (
-    MessageListResponse,
-    MessageListParameters,
-    SendMessageResponse,
     SendMessagePayload,
     MessageRole,
 )
-
-from api.endpoints.routes.v1.link_utils import build_list_links
-from api.services.v1 import messages_service
+from api.endpoints.routes.v1.tenant.deprecate import sunset_response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.get("/", status_code=status.HTTP_200_OK, response_model=MessageListResponse)
+@router.get(
+    "/", status_code=status.HTTP_410_GONE, response_model=Response, deprecated=True
+)
 async def list_messages(
     request: Request,
     page_num: int | None = 1,
@@ -30,40 +27,17 @@ async def list_messages(
     role: MessageRole | None = None,
     tags: str | None = None,
     deleted: bool | None = False,
-) -> MessageListResponse:
-    wallet_id = get_from_context("TENANT_WALLET_ID")
-    tenant_id = get_from_context("TENANT_ID")
-
-    parameters = MessageListParameters(
-        url=str(request.url),
-        page_num=page_num,
-        page_size=page_size,
-        contact_id=contact_id,
-        role=role,
-        deleted=deleted,
-        tags=tags,
-    )
-    items, total_count = await messages_service.list_messages(
-        tenant_id, wallet_id, parameters
-    )
-
-    links = build_list_links(total_count, parameters)
-
-    return MessageListResponse(
-        items=items, count=len(items), total=total_count, links=links
-    )
+) -> Response:
+    return sunset_response
 
 
 @router.post(
     "/send-message",
-    status_code=status.HTTP_200_OK,
-    response_model=SendMessageResponse,
+    status_code=status.HTTP_410_GONE,
+    response_model=Response,
+    deprecated=True,
 )
 async def send_message(
     payload: SendMessagePayload,
-) -> SendMessageResponse:
-    wallet_id = get_from_context("TENANT_WALLET_ID")
-    tenant_id = get_from_context("TENANT_ID")
-    item = await messages_service.send_message(tenant_id, wallet_id, payload=payload)
-    links = []  # TODO
-    return SendMessageResponse(item=item, links=links)
+) -> Response:
+    return sunset_response

--- a/services/traction/api/protocols/v1/__init__.py
+++ b/services/traction/api/protocols/v1/__init__.py
@@ -1,4 +1,4 @@
-from .basic_messages import subscribe_basic_messages_protocol_listeners
+# from .basic_messages import subscribe_basic_messages_protocol_listeners
 from .connection import subscribe_connection_protocol_listeners
 from .endorser import subscribe_endorser_protocol_listeners
 from .holder import subscribe_holder_protocol_listeners
@@ -11,7 +11,9 @@ def subscribe_protocol_listeners():
     subscribe_connection_protocol_listeners()
     subscribe_endorser_protocol_listeners()
     subscribe_issuer_protocol_listeners()
-    subscribe_basic_messages_protocol_listeners()
+    # basic messages are handled via acapy plugin now, so let's not do any work
+    # on messages here.
+    # subscribe_basic_messages_protocol_listeners()
     subscribe_present_proof_protocol_listeners()
     subscribe_revocation_notification_protocol_listeners()
     subscribe_holder_protocol_listeners()

--- a/services/traction/bdd-tests/features/steps/messages.py
+++ b/services/traction/bdd-tests/features/steps/messages.py
@@ -1,7 +1,14 @@
-import json
+import pprint
+
 from behave import *
-from starlette import status
 from v1_api import *
+
+
+def assert_deprecated(response):
+    assert response.status_code == status.HTTP_410_GONE, response.__dict__
+    assert response.headers.get("sunset"), response.headers
+    assert response.headers.get("deprecated"), response.headers
+    pprint.pp(response.__dict__)
 
 
 @step('"{tenant}" sends "{contact_alias}" a message with content "{content}"')
@@ -10,16 +17,7 @@ def step_impl(context, tenant: str, contact_alias: str, content: str):
     contact = context.config.userdata[tenant]["connections"][contact_alias]
 
     response = send_message(context, tenant, contact["contact_id"], content)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert resp_json["item"]
-    assert resp_json["item"]["content"] == content
-    assert resp_json["item"]["contact"]["alias"] == contact_alias
-    assert resp_json["item"]["role"] == "Sender"
-    context.config.userdata[tenant].setdefault("messages", {})
-    context.config.userdata[tenant]["messages"].setdefault(
-        contact_alias, resp_json["item"]
-    )
+    assert_deprecated(response)
 
 
 @then(
@@ -32,13 +30,7 @@ def step_impl(
 
     params = {"role": role, "contact_id": contact["contact_id"], "tags": tags}
     response = list_messages(context, tenant, params)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert len(resp_json["items"]) == 1, resp_json
-    assert resp_json["items"][0]["contact"]["alias"] == contact_alias
-    _tags = [x.strip() for x in tags.split(",")]
-    for t in _tags:
-        assert t in resp_json["items"][0]["tags"]
+    assert_deprecated(response)
 
 
 @then('"{tenant}" can find {count:d} message(s) as "{role}" with "{contact_alias}"')
@@ -46,21 +38,14 @@ def step_impl(context, tenant: str, count: int, role: str, contact_alias: str):
     contact = context.config.userdata[tenant]["connections"][contact_alias]
     params = {"role": role, "contact_id": contact["contact_id"]}
     response = list_messages(context, tenant, params)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert len(resp_json["items"]) == count, resp_json
-    if count == 1:
-        assert resp_json["items"][0]["contact"]["alias"] == contact_alias
+    assert_deprecated(response)
 
 
 @then('"{tenant}" can get message with "{contact_alias}" by message_id')
 def step_impl(context, tenant: str, contact_alias: str):
     message = context.config.userdata[tenant]["messages"][contact_alias]
     response = get_message(context, tenant, message["message_id"])
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert resp_json["item"]
-    assert resp_json["item"]["contact"]["alias"] == contact_alias
+    assert_deprecated(response)
 
 
 @then('"{tenant}" can update message with "{contact_alias}"')
@@ -77,29 +62,14 @@ def step_impl(context, tenant: str, contact_alias: str):
         payload[attribute] = value
 
     response = update_message(context, tenant, message["message_id"], payload)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    item = resp_json["item"]
-    assert item["message_id"] == message["message_id"]
-    for row in context.table:
-        attribute = row["attribute"]
-        value = row["value"]
-        if attribute == "tags":
-            value = row["value"].split(",")
-
-        assert item[attribute] == value
+    assert_deprecated(response)
 
 
 @then('"{tenant}" can delete message with "{contact_alias}"')
 def step_impl(context, tenant: str, contact_alias: str):
     message = context.config.userdata[tenant]["messages"][contact_alias]
     response = delete_message(context, tenant, message["message_id"])
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    item = resp_json["item"]
-    assert item["message_id"] == message["message_id"]
-    assert item["deleted"]
-    assert item["status"] == "Deleted"
+    assert_deprecated(response)
 
 
 @then('"{tenant}" cannot find message with "{contact_alias}" by role')
@@ -108,9 +78,7 @@ def step_impl(context, tenant: str, contact_alias: str):
     message = context.config.userdata[tenant]["messages"][contact_alias]
     params = {"contact_id": contact["contact_id"], "role": message["role"]}
     response = list_messages(context, tenant, params)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert len(resp_json["items"]) == 0, resp_json
+    assert_deprecated(response)
 
 
 @then('"{tenant}" can find message with "{contact_alias}" by role with deleted flag')
@@ -123,20 +91,14 @@ def step_impl(context, tenant: str, contact_alias: str):
         "deleted": True,
     }
     response = list_messages(context, tenant, params)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert len(resp_json["items"]) == 1, resp_json
-    assert resp_json["items"][0]["contact"]["alias"] == contact_alias
-    assert resp_json["items"][0]["role"] == message["role"]
-    assert resp_json["items"][0]["deleted"]
-    assert resp_json["items"][0]["status"] == "Deleted"
+    assert_deprecated(response)
 
 
 @then('"{tenant}" cannot get message with "{contact_alias}"')
 def step_impl(context, tenant: str, contact_alias: str):
     message = context.config.userdata[tenant]["messages"][contact_alias]
     response = get_message(context, tenant, message["message_id"])
-    assert response.status_code == status.HTTP_404_NOT_FOUND, response.__dict__
+    assert_deprecated(response)
 
 
 @then('"{tenant}" can get message with "{contact_alias}" with deleted flag')
@@ -144,11 +106,7 @@ def step_impl(context, tenant: str, contact_alias: str):
     message = context.config.userdata[tenant]["messages"][contact_alias]
     params = {"deleted": True}
     response = get_message(context, tenant, message["message_id"], params)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert resp_json["item"]["contact"]["alias"] == contact_alias
-    assert resp_json["item"]["deleted"]
-    assert resp_json["item"]["status"] == "Deleted"
+    assert_deprecated(response)
 
 
 @step('"{tenant}" sets configuration "{configuration_name}" to "{flag:bool}"')
@@ -163,19 +121,11 @@ def step_impl(context, tenant: str, configuration_name: str, flag: bool):
 def step_impl(context, tenant: str, role: str):
     params = {"role": role}
     response = list_messages(context, tenant, params)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert resp_json["items"], resp_json
-    for item in resp_json["items"]:
-        assert item["content"] is None, item["content"]
+    assert_deprecated(response)
 
 
 @step('"{tenant}" messages as "{role}" will have content')
 def step_impl(context, tenant: str, role: str):
     params = {"role": role}
     response = list_messages(context, tenant, params)
-    assert response.status_code == status.HTTP_200_OK, response.__dict__
-    resp_json = json.loads(response.content)
-    assert resp_json["items"], resp_json
-    for item in resp_json["items"]:
-        assert item["content"] is not None, item["content"]
+    assert_deprecated(response)

--- a/services/traction/bdd-tests/features/v1-messages.feature
+++ b/services/traction/bdd-tests/features/v1-messages.feature
@@ -57,13 +57,15 @@ Feature: messaging contacts
         Then "alice" can find 1 message(s) as "Sender" with "faber"
         And we sadly wait for 5 seconds because we have not figured out how to listen for events
         Then "faber" can find 1 message(s) as "Recipient" with "alice"
-        And "alice" can get message with "faber" by message_id
-        And "alice" can update message with "faber"
+        # messages no longer work here, so we cannot store them for re-use in tests
+        # comment these steps out, perhaps bring them back in if we do BDD for plugins
+        # And "alice" can get message with "faber" by message_id
+        # And "alice" can update message with "faber"
         | attribute  | value    |
         | tags | my,message |
         Then "alice" can find 1 message(s) as "Sender" with "faber" and tags "my,message"
-        And "alice" can delete message with "faber"
-        Then "alice" cannot find message with "faber" by role
-        And "alice" cannot get message with "faber"
-        But "alice" can find message with "faber" by role with deleted flag
-        And "alice" can get message with "faber" with deleted flag
+        # And "alice" can delete message with "faber"
+        # Then "alice" cannot find message with "faber" by role
+        # And "alice" cannot get message with "faber"
+        # But "alice" can find message with "faber" by role with deleted flag
+        # And "alice" can get message with "faber" with deleted flag


### PR DESCRIPTION
Deprecate the traction basic message api.
Leave endpoints there, return "Sunset" and "Deprecated" headers (as suggested [here](https://blog.stoplight.io/deprecating-api-endpoints).
Have discussed this with the team, and we will return `410 Gone` status.

Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>

I have left the code behind for reference purposes (and if we had to turn it back on) but could be talked into removing the code completely.

Setting to return a default ack message using acapy flag `--auto-response-messages`