### PR TITLE
Upgrade Aca-PY to 1.0.0-rc1

### DIFF
--- a/plugins/basicmessage_storage/poetry.lock
+++ b/plugins/basicmessage_storage/poetry.lock
@@ -90,7 +90,7 @@ yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "aries-cloudagent"
-version = "0.7.5"
+version = "1.0.0rc1"
 description = ""
 category = "main"
 optional = false
@@ -115,10 +115,10 @@ msgpack = ">=1.0,<2.0"
 nest-asyncio = ">=1.5.5,<1.6.0"
 packaging = ">=20.4,<21.0"
 prompt-toolkit = ">=2.0.9,<2.1.0"
-pydid = ">=0.3.3,<0.4.0"
+pydid = ">=0.3.6,<0.4.0"
 pyjwt = ">=2.4.0,<2.5.0"
 pyld = ">=2.0.3,<2.1.0"
-pynacl = ">=1.4.0,<1.5.0"
+pynacl = ">=1.5.0,<1.6.0"
 python-dateutil = ">=2.8.1,<2.9.0"
 pytz = ">=2021.1,<2022.0"
 pyyaml = ">=5.4.0,<5.5.0"
@@ -654,15 +654,14 @@ requests = ["requests"]
 
 [[package]]
 name = "pynacl"
-version = "1.4.0"
+version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 cffi = ">=1.4.1"
-six = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
@@ -867,7 +866,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "236c878986d274995e29648854fc767787905e39d31de6d949f92e435a06b8d5"
+content-hash = "6891c70b87e6dd09a8132a83d8363dd67f7cea2d03db6870830ffd63e7e43221"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/basicmessage_storage/pyproject.toml
+++ b/plugins/basicmessage_storage/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Jason Sherman <tools@usingtechnolo.gy>"]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "0.7.5" }
+aries-cloudagent = { version = "1.0.0rc1" }
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/plugins/docker/Dockerfile
+++ b/plugins/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN poetry install --no-dev
 RUN ln -s $(poetry env info -p)/lib/python3.6/site-packages site-packages
 
 
-FROM bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
+FROM bcgovimages/aries-cloudagent:py36-1.16-1_1.0.0-rc1
 COPY --from=base --chown=indy:indy /home/indy/.venv /home/indy/.venv
 ENV PATH="/home/indy/.venv/bin:$PATH"
 

--- a/plugins/multitenant_provider/poetry.lock
+++ b/plugins/multitenant_provider/poetry.lock
@@ -101,7 +101,7 @@ cached-property = ">=1.5,<2.0"
 
 [[package]]
 name = "aries-cloudagent"
-version = "0.7.5"
+version = "1.0.0rc1"
 description = ""
 category = "main"
 optional = false
@@ -126,10 +126,10 @@ msgpack = ">=1.0,<2.0"
 nest-asyncio = ">=1.5.5,<1.6.0"
 packaging = ">=20.4,<21.0"
 prompt-toolkit = ">=2.0.9,<2.1.0"
-pydid = ">=0.3.3,<0.4.0"
+pydid = ">=0.3.6,<0.4.0"
 pyjwt = ">=2.4.0,<2.5.0"
 pyld = ">=2.0.3,<2.1.0"
-pynacl = ">=1.4.0,<1.5.0"
+pynacl = ">=1.5.0,<1.6.0"
 python-dateutil = ">=2.8.1,<2.9.0"
 pytz = ">=2021.1,<2022.0"
 pyyaml = ">=5.4.0,<5.5.0"
@@ -709,15 +709,14 @@ requests = ["requests"]
 
 [[package]]
 name = "pynacl"
-version = "1.4.0"
+version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 cffi = ">=1.4.1"
-six = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
@@ -936,7 +935,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "e2cabc26a05a775d3809b87d6714f78b9df10b13e622f75cbbff6ee84130c275"
+content-hash = "8720989d0e0391ea62c6d6a3dd0538d6ddbfecebb69f8ef94185adeed4c0fbca"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/multitenant_provider/pyproject.toml
+++ b/plugins/multitenant_provider/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "multitenant_provider"}]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "0.7.5" }
+aries-cloudagent = { version = "1.0.0rc1" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"

--- a/plugins/pyproject.toml
+++ b/plugins/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "0.7.5" }
+aries-cloudagent = { version = "1.0.0rc1" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"

--- a/plugins/traction_innkeeper/poetry.lock
+++ b/plugins/traction_innkeeper/poetry.lock
@@ -90,7 +90,7 @@ yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "aries-cloudagent"
-version = "0.7.5"
+version = "1.0.0rc1"
 description = ""
 category = "main"
 optional = false
@@ -115,10 +115,10 @@ msgpack = ">=1.0,<2.0"
 nest-asyncio = ">=1.5.5,<1.6.0"
 packaging = ">=20.4,<21.0"
 prompt-toolkit = ">=2.0.9,<2.1.0"
-pydid = ">=0.3.3,<0.4.0"
+pydid = ">=0.3.6,<0.4.0"
 pyjwt = ">=2.4.0,<2.5.0"
 pyld = ">=2.0.3,<2.1.0"
-pynacl = ">=1.4.0,<1.5.0"
+pynacl = ">=1.5.0,<1.6.0"
 python-dateutil = ">=2.8.1,<2.9.0"
 pytz = ">=2021.1,<2022.0"
 pyyaml = ">=5.4.0,<5.5.0"
@@ -674,15 +674,14 @@ requests = ["requests"]
 
 [[package]]
 name = "pynacl"
-version = "1.4.0"
+version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 cffi = ">=1.4.1"
-six = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
@@ -901,7 +900,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "254edefb0506bc025496aaccec088c8610c61793a88c8a4e132e0bfc0b3bb8d7"
+content-hash = "1a97b7bfaabeab701b8e90ad5c6f29b0b9a9395a928e6fbd2de5a9af04dd4319"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/traction_innkeeper/pyproject.toml
+++ b/plugins/traction_innkeeper/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "traction_innkeeper"}]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "0.7.5" }
+aries-cloudagent = { version = "1.0.0rc1" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"

--- a/plugins/traction_metadata/poetry.lock
+++ b/plugins/traction_metadata/poetry.lock
@@ -90,7 +90,7 @@ yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "aries-cloudagent"
-version = "0.7.5"
+version = "1.0.0rc1"
 description = ""
 category = "main"
 optional = false
@@ -115,10 +115,10 @@ msgpack = ">=1.0,<2.0"
 nest-asyncio = ">=1.5.5,<1.6.0"
 packaging = ">=20.4,<21.0"
 prompt-toolkit = ">=2.0.9,<2.1.0"
-pydid = ">=0.3.3,<0.4.0"
+pydid = ">=0.3.6,<0.4.0"
 pyjwt = ">=2.4.0,<2.5.0"
 pyld = ">=2.0.3,<2.1.0"
-pynacl = ">=1.4.0,<1.5.0"
+pynacl = ">=1.5.0,<1.6.0"
 python-dateutil = ">=2.8.1,<2.9.0"
 pytz = ">=2021.1,<2022.0"
 pyyaml = ">=5.4.0,<5.5.0"
@@ -654,15 +654,14 @@ requests = ["requests"]
 
 [[package]]
 name = "pynacl"
-version = "1.4.0"
+version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 cffi = ">=1.4.1"
-six = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
@@ -881,7 +880,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.13,<4.0"
-content-hash = "18acea5a623be8233e164b16da0490782644a9b94dc1ede90b34b21bb866ab00"
+content-hash = "c0174391a7de8f270f781734b2748aa94f04539cd4c9dca5f509a1dc435bd77e"
 
 [metadata.files]
 aiohttp = []

--- a/plugins/traction_metadata/pyproject.toml
+++ b/plugins/traction_metadata/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "traction_metadata"}]
 
 [tool.poetry.dependencies]
 python = ">=3.6.13,<4.0"
-aries-cloudagent = { version = "0.7.5" }
+aries-cloudagent = { version = "1.0.0rc1" }
 typing-extensions = "^3.7.4"
 python-dateutil = "^2.8.1"
 PyJWT = "^2.4.0"


### PR DESCRIPTION
Plugins and base docker image updated.

Also tightened up the `/multitenancy/tenant/<tenant_id>/token` endpoint in `traction_innkeeper` to behave like `multitenant_provider` and throw a 409 when `wallet_key` is incorrect.

Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>