### PR TITLE
Invitations

### DIFF
--- a/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
@@ -12,6 +12,8 @@
     :global-filter-fields="['alias']"
     selection-mode="single"
     data-key="connection_id"
+    sort-field="created_at"
+    :sort-order="-1"
   >
     <template #header>
       <div class="flex justify-content-between">

--- a/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
@@ -1,19 +1,17 @@
 <template>
   <h3 class="mt-0">{{ t('connect.connections') }}</h3>
 
-  (Table content filter TBD - need to divide invitations and contacts)
   <DataTable
-    v-model:selection="selectedContact"
     v-model:expandedRows="expandedRows"
     v-model:filters="filter"
     :loading="loading"
-    :value="contacts"
+    :value="filteredConnections"
     :paginator="true"
     :rows="TABLE_OPT.ROWS_DEFAULT"
     :rows-per-page-options="TABLE_OPT.ROWS_OPTIONS"
     :global-filter-fields="['alias']"
     selection-mode="single"
-    data-key="alias"
+    data-key="connection_id"
   >
     <template #header>
       <div class="flex justify-content-between">
@@ -25,7 +23,7 @@
             <i class="pi pi-search" />
             <InputText
               v-model="filter.alias.value"
-              placeholder="Search Contacts"
+              placeholder="Search Connections"
             />
           </span>
           <Button
@@ -52,7 +50,7 @@
       </template>
     </Column>
     <Column :sortable="true" field="alias" header="Alias" />
-    <Column :sortable="true" field="their_role" header="Role" />
+    <Column :sortable="true" field="their_label" header="Their Label" />
     <Column :sortable="true" field="status" header="Status">
       <template #body="{ data }">
         <StatusChip :status="data.state" />
@@ -98,7 +96,7 @@ const { t } = useI18n();
 
 const contactsStore = useContactsStore();
 
-const { loading, contacts, selectedContact } = storeToRefs(useContactsStore());
+const { loading, filteredConnections } = storeToRefs(useContactsStore());
 
 const loadTable = async () => {
   contactsStore.listContacts().catch((err) => {

--- a/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3 class="mt-0">{{ t('contact.contacts') }}</h3>
+  <h3 class="mt-0">{{ t('connect.connections') }}</h3>
 
   <DataTable
     v-model:selection="selectedContact"
@@ -17,8 +17,7 @@
     <template #header>
       <div class="flex justify-content-between">
         <div class="flex justify-content-start">
-          <CreateContact />
-          <AcceptInvitation class="ml-4" />
+          <!-- <AcceptInvitation class="ml-4" /> -->
         </div>
         <div class="flex justify-content-end">
           <span class="p-input-icon-left contact-search">
@@ -51,11 +50,11 @@
         <EditContact :contact-id="data.contact_id" />
       </template>
     </Column>
-    <Column :sortable="true" field="alias" header="Name" />
-    <Column :sortable="true" field="role" header="Role" />
+    <Column :sortable="true" field="alias" header="Alias" />
+    <Column :sortable="true" field="their_role" header="Role" />
     <Column :sortable="true" field="status" header="Status">
       <template #body="{ data }">
-        <StatusChip :status="data.status" />
+        <StatusChip :status="data.state" />
       </template>
     </Column>
     <Column :sortable="true" field="created_at" header="Created at">
@@ -65,9 +64,8 @@
     </Column>
     <template #expansion="{ data }">
       <RowExpandData
-        :id="data.contact_id"
-        :url="API_PATH.CONTACTS"
-        :params="{ acapy: true }"
+        :id="data.connection_id"
+        :url="API_PATH.CONNECTIONS"
       />
     </template>
   </DataTable>
@@ -88,13 +86,12 @@ import { FilterMatchMode } from 'primevue/api';
 import { useContactsStore } from '@/store';
 import { storeToRefs } from 'pinia';
 // Other components
-import AcceptInvitation from './acceptInvitation/AcceptInvitation.vue';
-import CreateContact from './createContact/CreateContact.vue';
-import { TABLE_OPT, API_PATH } from '@/helpers/constants';
-import { formatDateLong } from '@/helpers';
+// import AcceptInvitation from './acceptInvitation/AcceptInvitation.vue';
+import EditContact from './editContact/EditContact.vue';
 import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';
-import EditContact from './editContact/EditContact.vue';
+import { TABLE_OPT, API_PATH } from '@/helpers/constants';
+import { formatDateLong } from '@/helpers';
 import { useI18n } from 'vue-i18n';
 
 const confirm = useConfirm();
@@ -119,7 +116,7 @@ onMounted(async () => {
 const deleteContact = (event: any, schema: any) => {
   confirm.require({
     target: event.currentTarget,
-    message: 'Are you sure you want to delete this contact?',
+    message: 'Are you sure you want to delete this connection?',
     header: 'Confirmation',
     icon: 'pi pi-exclamation-triangle',
     accept: () => {
@@ -131,7 +128,7 @@ const doDelete = (schema: any) => {
   contactsStore
     .deleteContact(schema)
     .then(() => {
-      toast.success(`Contact successfully deleted`);
+      toast.success(`Connection successfully deleted`);
     })
     .catch((err) => {
       console.error(err);

--- a/services/tenant-ui/frontend/src/components/contacts/acceptInvitation/AcceptInviteForm.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/acceptInvitation/AcceptInviteForm.vue
@@ -96,10 +96,10 @@ const handleSubmit = async (isFormValid: boolean) => {
   }
 
   try {
-    await contactsStore.acceptInvitation(
-      formFields.inviteUrl,
-      formFields.alias
-    );
+    // await contactsStore.acceptInvitation(
+    //   formFields.inviteUrl,
+    //   formFields.alias
+    // );
     emit('success');
     // close up on success
     emit('closed');

--- a/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
@@ -1,33 +1,54 @@
 <template>
   <div>
-    <Button :label="t('contact.create')" icon="pi pi-plus" @click="openModal" />
+    <Button
+      :label="
+        props.multi
+          ? t('connect.invitations.multi')
+          : t('connect.invitations.single')
+      "
+      icon="pi pi-user-edit"
+      @click="openModal"
+    />
     <Dialog
       v-model:visible="displayModal"
-      :header="t('contact.create')"
+      :header="
+        props.multi
+          ? t('connect.invitations.multiCreate')
+          : t('connect.invitations.singleCreate')
+      "
       :modal="true"
       @update:visible="handleClose"
     >
-      <CreateContactForm @success="$emit('success')" @closed="handleClose" />
+      <CreateContactForm
+        :multi="props.multi"
+        @success="$emit('success')"
+        @closed="handleClose"
+      />
     </Dialog>
   </div>
 </template>
 
 <script setup lang="ts">
 // Vue
-import { ref } from 'vue';
-// PrimeVue
+import { ref, PropType } from 'vue';
+// PrimeVue etc
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
-// State
-
+import { useI18n } from 'vue-i18n';
 // Custom Components
 import CreateContactForm from './CreateContactForm.vue';
-// Other Imports
-import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 
 defineEmits(['success']);
+
+// Props
+const props = defineProps({
+  multi: {
+    type: Boolean as PropType<boolean>,
+    required: true,
+  },
+});
 
 // Display popup
 const displayModal = ref(false);

--- a/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContactForm.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContactForm.vue
@@ -2,8 +2,8 @@
   <form @submit.prevent="handleSubmit(!v$.$invalid)">
     <!-- Alias -->
     <div class="field">
-      <label for="alias" :class="{ 'p-error': v$.alias.$invalid && submitted }"
-        >Contact Alias
+      <label for="alias" :class="{ 'p-error': v$.alias.$invalid && submitted }">
+        Contact Alias
       </label>
       <InputText
         v-model="v$.alias.$model"
@@ -30,7 +30,7 @@
 
 <script setup lang="ts">
 // Vue
-import { reactive, ref } from 'vue';
+import { reactive, ref, PropType } from 'vue';
 // State
 import { useContactsStore } from '../../../store';
 // PrimeVue / Validation
@@ -44,16 +44,20 @@ import QRCode from '../../common/QRCode.vue';
 
 const contactsStore = useContactsStore();
 
-// For notifications
 const toast = useToast();
+
+const emit = defineEmits(['closed', 'success']);
+
+// Props
+const props = defineProps({
+  multi: {
+    type: Boolean as PropType<boolean>,
+    required: true,
+  },
+});
 
 // To store local data
 const invitation_url = ref('');
-
-// ----------------------------------------------------------------
-// Creating a new contact
-// ----------------------------------------------------------------
-const emit = defineEmits(['closed', 'success']);
 
 // Validation
 const formFields = reactive({
@@ -64,7 +68,7 @@ const rules = {
 };
 const v$ = useVuelidate(rules, formFields);
 
-// Form submission
+// Create a new connection
 const submitted = ref(false);
 const handleSubmit = async (isFormValid: boolean) => {
   submitted.value = true;
@@ -73,7 +77,10 @@ const handleSubmit = async (isFormValid: boolean) => {
   }
   try {
     // call store
-    const result = await contactsStore.createInvitation(formFields.alias);
+    const result = await contactsStore.createInvitation(
+      formFields.alias,
+      props.multi
+    );
     if (result != null && result['invitation_url']) {
       invitation_url.value = result['invitation_url'];
       console.log(`invitation_url: ${invitation_url.value}`);
@@ -87,6 +94,4 @@ const handleSubmit = async (isFormValid: boolean) => {
     submitted.value = false;
   }
 };
-
-// ---------------------------------------------------/create contact
 </script>

--- a/services/tenant-ui/frontend/src/components/contacts/editContact/DeleteContact.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/editContact/DeleteContact.vue
@@ -1,0 +1,56 @@
+<template>
+  <Button
+    title="Delete Contact"
+    icon="pi pi-trash"
+    class="p-button-rounded p-button-icon-only p-button-text"
+    @click="deleteContact($event)"
+  />
+</template>
+
+<script setup lang="ts">
+// Vue
+import { PropType } from 'vue';
+// PrimeVue
+import Button from 'primevue/button';
+import { useConfirm } from 'primevue/useconfirm';
+import { useToast } from 'vue-toastification';
+// State
+import { useContactsStore } from '@/store';
+
+const confirm = useConfirm();
+const toast = useToast();
+
+const contactsStore = useContactsStore();
+
+// Props
+const props = defineProps({
+  connectionId: {
+    type: String as PropType<string>,
+    required: true,
+  },
+});
+
+// Delete the connection record by connection id
+const deleteContact = (event: any) => {
+  confirm.require({
+    target: event.currentTarget,
+    message: 'Are you sure you want to delete this connection?',
+    header: 'Confirmation',
+    icon: 'pi pi-exclamation-triangle',
+    accept: () => {
+      doDelete();
+    },
+  });
+};
+const doDelete = () => {
+  contactsStore
+    .deleteContact(props.connectionId)
+    .then(() => {
+      toast.success(`Connection successfully deleted`);
+    })
+    .catch((err) => {
+      console.error(err);
+      toast.error(`Failure: ${err}`);
+    });
+};
+</script>

--- a/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
@@ -76,7 +76,7 @@ const handleSubmit = async (isFormValid: boolean) => {
   }
 
   try {
-    await contactsStore.updateContact(props.contactId, formFields.alias);
+    // await contactsStore.updateContact(props.contactId, formFields.alias);
     emit('success');
     // close up on success
     emit('closed');
@@ -89,7 +89,7 @@ const handleSubmit = async (isFormValid: boolean) => {
 };
 
 // Get the latest details about this contact when opening
-const { loading, item, fetchItem } = useGetItem(API_PATH.CONTACTS);
+const { loading, item, fetchItem } = useGetItem(API_PATH.CONNECTIONS);
 onMounted(async () => {
   try {
     await fetchItem(props.contactId);

--- a/services/tenant-ui/frontend/src/components/invitations/Invitations.vue
+++ b/services/tenant-ui/frontend/src/components/invitations/Invitations.vue
@@ -12,6 +12,8 @@
     :global-filter-fields="['alias']"
     selection-mode="single"
     data-key="connection_id"
+    sort-field="created_at"
+    :sort-order="-1"
   >
     <template #header>
       <div class="flex justify-content-between">

--- a/services/tenant-ui/frontend/src/components/invitations/Invitations.vue
+++ b/services/tenant-ui/frontend/src/components/invitations/Invitations.vue
@@ -1,7 +1,8 @@
 <template>
-  <h3 class="mt-0">{{ t('connect.connections') }}</h3>
+  <h3 class="mt-0">{{ t('connect.invitations.invitations') }}</h3>
 
   (Table content filter TBD - need to divide invitations and contacts)
+
   <DataTable
     v-model:selection="selectedContact"
     v-model:expandedRows="expandedRows"
@@ -13,19 +14,20 @@
     :rows-per-page-options="TABLE_OPT.ROWS_OPTIONS"
     :global-filter-fields="['alias']"
     selection-mode="single"
-    data-key="alias"
+    data-key="connection_id"
   >
     <template #header>
       <div class="flex justify-content-between">
         <div class="flex justify-content-start">
-          <!-- <AcceptInvitation class="ml-4" /> -->
+          <CreateContact :multi="false" class="mr-3" />
+          <CreateContact :multi="true" />
         </div>
         <div class="flex justify-content-end">
-          <span class="p-input-icon-left contact-search">
-            <i class="pi pi-search" />
+          <span class="p-input-icon-left mr-3">
+            <i class="pi pi-search ml-0" />
             <InputText
               v-model="filter.alias.value"
-              placeholder="Search Contacts"
+              placeholder="Search Invitations"
             />
           </span>
           <Button
@@ -42,17 +44,11 @@
     <Column :expander="true" header-style="width: 3rem" />
     <Column :sortable="false" header="Actions">
       <template #body="{ data }">
-        <Button
-          title="Delete Contact"
-          icon="pi pi-trash"
-          class="p-button-rounded p-button-icon-only p-button-text"
-          @click="deleteContact($event, data)"
-        />
-        <!-- <EditContact :contact-id="data.contact_id" /> -->
+        <DeleteContact :connection-id="data.connection_id" />
       </template>
     </Column>
     <Column :sortable="true" field="alias" header="Alias" />
-    <Column :sortable="true" field="their_role" header="Role" />
+    <Column :sortable="true" field="invitation_mode" header="Invitation Mode" />
     <Column :sortable="true" field="status" header="Status">
       <template #body="{ data }">
         <StatusChip :status="data.state" />
@@ -77,22 +73,20 @@ import Button from 'primevue/button';
 import Column from 'primevue/column';
 import InputText from 'primevue/inputtext';
 import DataTable from 'primevue/datatable';
-import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from 'vue-toastification';
 import { FilterMatchMode } from 'primevue/api';
 // State
 import { useContactsStore } from '@/store';
 import { storeToRefs } from 'pinia';
 // Other components
-// import AcceptInvitation from './acceptInvitation/AcceptInvitation.vue';
-// import EditContact from './editContact/EditContact.vue';
-import RowExpandData from '../common/RowExpandData.vue';
-import StatusChip from '../common/StatusChip.vue';
+import CreateContact from '@/components/contacts/createContact/CreateContact.vue';
+import DeleteContact from '@/components/contacts/editContact/DeleteContact.vue';
+import RowExpandData from '@/components/common/RowExpandData.vue';
+import StatusChip from '@/components/common/StatusChip.vue';
 import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 import { useI18n } from 'vue-i18n';
 
-const confirm = useConfirm();
 const toast = useToast();
 const { t } = useI18n();
 
@@ -111,29 +105,6 @@ onMounted(async () => {
   loadTable();
 });
 
-const deleteContact = (event: any, schema: any) => {
-  confirm.require({
-    target: event.currentTarget,
-    message: 'Are you sure you want to delete this connection?',
-    header: 'Confirmation',
-    icon: 'pi pi-exclamation-triangle',
-    accept: () => {
-      doDelete(schema);
-    },
-  });
-};
-const doDelete = (schema: any) => {
-  contactsStore
-    .deleteContact(schema)
-    .then(() => {
-      toast.success(`Connection successfully deleted`);
-    })
-    .catch((err) => {
-      console.error(err);
-      toast.error(`Failure: ${err}`);
-    });
-};
-
 // necessary for expanding rows, we don't do anything with this
 const expandedRows = ref([]);
 
@@ -141,23 +112,3 @@ const filter = ref({
   alias: { value: null, matchMode: FilterMatchMode.CONTAINS },
 });
 </script>
-
-<style scoped>
-fieldset {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.create-contact {
-  float: right;
-  margin: 3rem 1rem 0 0;
-}
-.p-datatable-header input {
-  padding-left: 3rem;
-  margin-right: 1rem;
-}
-.contact-search {
-  margin-left: 1.5rem;
-}
-</style>

--- a/services/tenant-ui/frontend/src/components/invitations/Invitations.vue
+++ b/services/tenant-ui/frontend/src/components/invitations/Invitations.vue
@@ -1,14 +1,11 @@
 <template>
   <h3 class="mt-0">{{ t('connect.invitations.invitations') }}</h3>
 
-  (Table content filter TBD - need to divide invitations and contacts)
-
   <DataTable
-    v-model:selection="selectedContact"
     v-model:expandedRows="expandedRows"
     v-model:filters="filter"
     :loading="loading"
-    :value="contacts"
+    :value="filteredInvitations"
     :paginator="true"
     :rows="TABLE_OPT.ROWS_DEFAULT"
     :rows-per-page-options="TABLE_OPT.ROWS_OPTIONS"
@@ -49,11 +46,6 @@
     </Column>
     <Column :sortable="true" field="alias" header="Alias" />
     <Column :sortable="true" field="invitation_mode" header="Invitation Mode" />
-    <Column :sortable="true" field="status" header="Status">
-      <template #body="{ data }">
-        <StatusChip :status="data.state" />
-      </template>
-    </Column>
     <Column :sortable="true" field="created_at" header="Created at">
       <template #body="{ data }">
         {{ formatDateLong(data.created_at) }}
@@ -82,7 +74,6 @@ import { storeToRefs } from 'pinia';
 import CreateContact from '@/components/contacts/createContact/CreateContact.vue';
 import DeleteContact from '@/components/contacts/editContact/DeleteContact.vue';
 import RowExpandData from '@/components/common/RowExpandData.vue';
-import StatusChip from '@/components/common/StatusChip.vue';
 import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 import { useI18n } from 'vue-i18n';
@@ -92,7 +83,7 @@ const { t } = useI18n();
 
 const contactsStore = useContactsStore();
 
-const { loading, contacts, selectedContact } = storeToRefs(useContactsStore());
+const { loading, filteredInvitations } = storeToRefs(useContactsStore());
 
 const loadTable = async () => {
   contactsStore.listContacts().catch((err) => {

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -24,11 +24,20 @@ const items = ref([
     icon: 'pi pi-fw pi-chart-bar',
     to: { name: 'Dashboard' },
   },
-  // {
-  //   label: () => t('contact.contacts'),
-  //   icon: 'pi pi-fw pi-users',
-  //   to: { name: 'MyContacts' },
-  // },
+  {
+    label: () => t('connect.connections'),
+    icon: 'pi pi-fw pi-users',
+    items: [
+      {
+        label: () => t('connect.connections'),
+        to: { name: 'MyContacts' },
+      },
+      {
+        label: () => t('connect.invitations.invitations'),
+        to: { name: 'MyInvitations' },
+      },
+    ],
+  },
 
   // {
   //   label: () => t('issue.issuance'),

--- a/services/tenant-ui/frontend/src/components/messages/Messages.vue
+++ b/services/tenant-ui/frontend/src/components/messages/Messages.vue
@@ -37,11 +37,11 @@
     </template>
     <template #empty> No records found. </template>
     <template #loading> Loading data. Please wait... </template>
-    <Column :sortable="true" field="connection_id" header="Contact">
+    <!-- <Column :sortable="true" field="connection_id" header="Contact">
       <template #body="{ data }">
         {{ findContactName(data.connection_id) }}
       </template>
-    </Column>
+    </Column> -->
     <Column :sortable="true" field="state" header="State" />
     <Column :sortable="true" field="content" header="Content" />
     <Column :sortable="true" field="sent_time" header="Sent">

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -23,10 +23,10 @@ export const API_PATH = {
 
   TENANT_TOKEN: '/tenant/token',
 
-  CONTACTS: '/tenant/v1/contacts/',
-  CONTACTS_CREATE_INVITATION: '/tenant/v1/contacts/create-invitation',
-  CONTACTS_RECEIVE_INVITATION: '/tenant/v1/contacts/receive-invitation',
-  CONTACT: (id: string) => `/tenant/v1/contacts/${id}`,
+  CONNECTIONS: '/connections',
+  // CONTACTS_CREATE_INVITATION: '/tenant/v1/contacts/create-invitation',
+  // CONTACTS_RECEIVE_INVITATION: '/tenant/v1/contacts/receive-invitation',
+  CONNECTION: (id: string) => `/connections/${id}`,
 
   HOLDER_CREDENTIALS: '/tenant/v1/holder/credentials/',
   HOLDER_CREDENTIALS_ACCEPT_OFFER: (id: string) =>

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -78,6 +78,12 @@ export const API_PATH = {
     `/multitenancy/wallet/${tenantId}/token`,
 };
 
+export const CONNECTION_STATUSES = {
+  INVITATION: 'invitation',
+  ACTIVE: 'active',
+  RESPONSE: 'response',
+};
+
 export const RESERVATION_STATUSES = {
   APPROVED: 'approved',
   CHECKED_IN: 'checked_in',

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -24,7 +24,7 @@ export const API_PATH = {
   TENANT_TOKEN: '/tenant/token',
 
   CONNECTIONS: '/connections',
-  // CONTACTS_CREATE_INVITATION: '/tenant/v1/contacts/create-invitation',
+  CONNECTIONS_CREATE_INVITATION: '/connections/create-invitation',
   // CONTACTS_RECEIVE_INVITATION: '/tenant/v1/contacts/receive-invitation',
   CONNECTION: (id: string) => `/connections/${id}`,
 

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -13,10 +13,18 @@
     "settings": "Settings",
     "logout": "Logout"
   },
-  "contact": {
-    "contacts": "Contacts",
-    "create": "Create Contact",
-    "accept": "Accept Invitation"
+  "connect": {
+    "connections": "Connections",
+    "edit": "Edit Connection",
+    "delete": "Delete Connection",
+    "invitations": {
+      "invitations": "Invitations",
+      "create": "Create Invitation",
+      "single": "Single Use",
+      "singleCreate": "Create Single Use Invitation",
+      "multi": "Multi Use",
+      "multiCreate": "Create Multi Use Invitation"
+    }
   },
   "issue": {
     "issuance": "Issuance",

--- a/services/tenant-ui/frontend/src/router/tenantRoutes.ts
+++ b/services/tenant-ui/frontend/src/router/tenantRoutes.ts
@@ -8,6 +8,7 @@ import Settings from '@/views/tenant/Settings.vue';
 import Developer from '@/views/tenant/Developer.vue';
 // Connections
 import MyContacts from '@/views/connections/MyContacts.vue';
+import MyInvitations from '@/views/connections/MyInvitations.vue';
 // Issuance
 import MyIssuedCredentials from '@/views/issuance/MyIssuedCredentials.vue';
 import Schemas from '@/views/issuance/Schemas.vue';
@@ -61,12 +62,17 @@ const tenantRoutes = [
 
       // Tenant - Connections
       {
-        path: '/contacts/',
+        path: '/connections/',
         children: [
           {
-            path: 'myContacts',
+            path: '',
             name: 'MyContacts',
             component: MyContacts,
+          },
+          {
+            path: 'invitations',
+            name: 'MyInvitations',
+            component: MyInvitations,
           },
         ],
       },

--- a/services/tenant-ui/frontend/src/store/acapyApi.ts
+++ b/services/tenant-ui/frontend/src/store/acapyApi.ts
@@ -12,7 +12,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { useConfigStore } from './configStore';
 import { useTenantStore, useTokenStore } from './index';
 
-export const useAcapyTenantApi = defineStore('acapyApi', () => {
+export const useAcapyApi = defineStore('acapyApi', () => {
   const tokenStore = useTokenStore();
   const tenantStore = useTenantStore();
   const { config } = storeToRefs(useConfigStore());
@@ -154,5 +154,5 @@ export const useAcapyTenantApi = defineStore('acapyApi', () => {
 });
 
 export default {
-  useAcapyTenantApi,
+  useAcapyApi,
 };

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -48,7 +48,7 @@ export const useContactsStore = defineStore('contacts', () => {
     return fetchList(API_PATH.CONNECTIONS, contacts, error, loading, {});
   }
 
-  async function createInvitation(alias: string, multiUse: boolean) {
+  async function createInvitation(alias: string, multi_use: boolean) {
     console.log('> contactsStore.createInvitation');
     error.value = null;
     loading.value = true;
@@ -60,7 +60,7 @@ export const useContactsStore = defineStore('contacts', () => {
         API_PATH.CONNECTIONS_CREATE_INVITATION,
         {},
         {
-          params: { alias: alias, multi_use: multiUse },
+          params: { alias, multi_use },
         }
       )
       .then((res) => {

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -1,7 +1,7 @@
 import { API_PATH } from '@/helpers/constants';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
-import { useTenantApi } from './tenantApi';
+import { useAcapyApi } from './acapyApi';
 import {
   fetchList,
   filterByStatusActive,
@@ -30,166 +30,164 @@ export const useContactsStore = defineStore('contacts', () => {
   // actions
 
   // grab the tenant api
-  const tenantApi = useTenantApi();
+  const acapyApi = useAcapyApi();
 
   async function listContacts() {
     selectedContact.value = null;
-    return fetchList(API_PATH.CONTACTS, contacts, error, loading, {
-      acapy: true,
-    });
+    return fetchList(API_PATH.CONNECTIONS, contacts, error, loading, {});
   }
 
-  async function createInvitation(alias: string) {
-    console.log('> contactsStore.createInvitation');
-    error.value = null;
-    loading.value = true;
+  // async function createInvitation(alias: string) {
+  //   console.log('> contactsStore.createInvitation');
+  //   error.value = null;
+  //   loading.value = true;
 
-    let invitationData = null;
-    // need the await here since the returned invitationData is not one of our stored refs...
-    await tenantApi
-      .postHttp(API_PATH.CONTACTS_CREATE_INVITATION, { alias })
-      .then((res) => {
-        console.log(res);
-        // don't grab the item, there are other parts of the response data we need (invitation, invitation url)
-        invitationData = res.data;
-      })
-      .then(() => {
-        // do we want to automatically reload? or have the caller of this to load?
-        console.log(
-          'invitation created. the store calls load automatically, but do we want this done "manually"?'
-        );
-        listContacts();
-      })
-      .catch((err) => {
-        error.value = err;
-        // console.log(error.value);
-      })
-      .finally(() => {
-        loading.value = false;
-      });
-    console.log('< contactsStore.createInvitation');
+  //   let invitationData = null;
+  //   // need the await here since the returned invitationData is not one of our stored refs...
+  //   await acapyApi
+  //     .postHttp(API_PATH.CONTACTS_CREATE_INVITATION, { alias })
+  //     .then((res) => {
+  //       console.log(res);
+  //       // don't grab the item, there are other parts of the response data we need (invitation, invitation url)
+  //       invitationData = res.data;
+  //     })
+  //     .then(() => {
+  //       // do we want to automatically reload? or have the caller of this to load?
+  //       console.log(
+  //         'invitation created. the store calls load automatically, but do we want this done "manually"?'
+  //       );
+  //       listContacts();
+  //     })
+  //     .catch((err) => {
+  //       error.value = err;
+  //       // console.log(error.value);
+  //     })
+  //     .finally(() => {
+  //       loading.value = false;
+  //     });
+  //   console.log('< contactsStore.createInvitation');
 
-    if (error.value != null) {
-      // throw error so $onAction.onError listeners can add their own handler
-      throw error.value;
-    }
-    // return data so $onAction.after listeners can add their own handler
-    return invitationData;
-  }
+  //   if (error.value != null) {
+  //     // throw error so $onAction.onError listeners can add their own handler
+  //     throw error.value;
+  //   }
+  //   // return data so $onAction.after listeners can add their own handler
+  //   return invitationData;
+  // }
 
-  async function acceptInvitation(inviteUrl: string, alias: string) {
-    console.log('> contactsStore.acceptInvitation');
-    error.value = null;
-    loading.value = true;
+  // async function acceptInvitation(inviteUrl: string, alias: string) {
+  //   console.log('> contactsStore.acceptInvitation');
+  //   error.value = null;
+  //   loading.value = true;
 
-    let acceptedData = null;
-    // need the await here since the returned invitation_data is not one of our stored refs...
-    await tenantApi
-      .postHttp(API_PATH.CONTACTS_RECEIVE_INVITATION, {
-        alias,
-        invitation_url: inviteUrl,
-      })
-      .then((res) => {
-        console.log(res);
-        // don't grab the item, there are other parts of the response data we need (invitation, invitation url)
-        acceptedData = res.data;
-      })
-      .then(() => {
-        // do we want to automatically reload? or have the caller of this to load?
-        console.log(
-          'invitation accepted. the store calls load automatically, but do we want this done "manually"?'
-        );
-        listContacts();
-      })
-      .catch((err) => {
-        error.value = err;
-        // console.log(error.value);
-      })
-      .finally(() => {
-        loading.value = false;
-      });
-    console.log('< contactsStore.acceptInvitation');
+  //   let acceptedData = null;
+  //   // need the await here since the returned invitation_data is not one of our stored refs...
+  //   await acapyApi
+  //     .postHttp(API_PATH.CONTACTS_RECEIVE_INVITATION, {
+  //       alias,
+  //       invitation_url: inviteUrl,
+  //     })
+  //     .then((res) => {
+  //       console.log(res);
+  //       // don't grab the item, there are other parts of the response data we need (invitation, invitation url)
+  //       acceptedData = res.data;
+  //     })
+  //     .then(() => {
+  //       // do we want to automatically reload? or have the caller of this to load?
+  //       console.log(
+  //         'invitation accepted. the store calls load automatically, but do we want this done "manually"?'
+  //       );
+  //       listContacts();
+  //     })
+  //     .catch((err) => {
+  //       error.value = err;
+  //       // console.log(error.value);
+  //     })
+  //     .finally(() => {
+  //       loading.value = false;
+  //     });
+  //   console.log('< contactsStore.acceptInvitation');
 
-    if (error.value != null) {
-      // throw error so $onAction.onError listeners can add their own handler
-      throw error.value;
-    }
-    // return data so $onAction.after listeners can add their own handler
-    return acceptedData;
-  }
+  //   if (error.value != null) {
+  //     // throw error so $onAction.onError listeners can add their own handler
+  //     throw error.value;
+  //   }
+  //   // return data so $onAction.after listeners can add their own handler
+  //   return acceptedData;
+  // }
 
-  async function deleteContact(payload: any = {}) {
-    console.log('> contactsStore.deleteContact');
+  // async function deleteContact(payload: any = {}) {
+  //   console.log('> contactsStore.deleteContact');
 
-    const contactId = payload.contact_id;
+  //   const contactId = payload.contact_id;
 
-    error.value = null;
-    loading.value = true;
+  //   error.value = null;
+  //   loading.value = true;
 
-    let result = null;
+  //   let result = null;
 
-    await tenantApi
-      .deleteHttp(API_PATH.CONTACT(contactId), payload)
-      .then((res) => {
-        result = res.data.item;
-      })
-      .then(() => {
-        listContacts(); // Refresh table
-      })
-      .catch((err) => {
-        error.value = err;
-      })
-      .finally(() => {
-        loading.value = false;
-      });
-    console.log('< contactsStore.deleteContact');
+  //   await acapyApi
+  //     .deleteHttp(API_PATH.CONTACT(contactId), payload)
+  //     .then((res) => {
+  //       result = res.data.item;
+  //     })
+  //     .then(() => {
+  //       listContacts(); // Refresh table
+  //     })
+  //     .catch((err) => {
+  //       error.value = err;
+  //     })
+  //     .finally(() => {
+  //       loading.value = false;
+  //     });
+  //   console.log('< contactsStore.deleteContact');
 
-    if (error.value != null) {
-      // throw error so $onAction.onError listeners can add their own handler
-      throw error.value;
-    }
-    // return data so $onAction.after listeners can add their own handler
-    return result;
-  }
+  //   if (error.value != null) {
+  //     // throw error so $onAction.onError listeners can add their own handler
+  //     throw error.value;
+  //   }
+  //   // return data so $onAction.after listeners can add their own handler
+  //   return result;
+  // }
 
   async function getContact(id: string, params: any = {}) {
     const getloading: any = ref(false);
-    return fetchItem(API_PATH.CONTACTS, id, error, getloading, params);
+    return fetchItem(API_PATH.CONNECTIONS, id, error, getloading, params);
   }
 
   // Only going to do alias right now but expand to other params as needed later
-  async function updateContact(contactId: string, alias: string) {
-    console.log('> contactsStore.updateContact');
-    error.value = null;
-    loading.value = true;
+  // async function updateContact(contactId: string, alias: string) {
+  //   console.log('> contactsStore.updateContact');
+  //   error.value = null;
+  //   loading.value = true;
 
-    let contactData = null;
-    await tenantApi
-      .putHttp(`${API_PATH.CONTACTS}${contactId}`, {
-        contact_id: contactId,
-        alias,
-      })
-      .then((res) => {
-        contactData = res.data;
-      })
-      .then(() => {
-        listContacts();
-      })
-      .catch((err) => {
-        error.value = err;
-      })
-      .finally(() => {
-        loading.value = false;
-      });
-    console.log('< contactsStore.updateContact');
+  //   let contactData = null;
+  //   await acapyApi
+  //     .putHttp(`${API_PATH.CONTACTS}${contactId}`, {
+  //       contact_id: contactId,
+  //       alias,
+  //     })
+  //     .then((res) => {
+  //       contactData = res.data;
+  //     })
+  //     .then(() => {
+  //       listContacts();
+  //     })
+  //     .catch((err) => {
+  //       error.value = err;
+  //     })
+  //     .finally(() => {
+  //       loading.value = false;
+  //     });
+  //   console.log('< contactsStore.updateContact');
 
-    if (error.value != null) {
-      // throw error so $onAction.onError listeners can add their own handler
-      throw error.value;
-    }
-    // return data so $onAction.after listeners can add their own handler
-    return contactData;
-  }
+  //   if (error.value != null) {
+  //     // throw error so $onAction.onError listeners can add their own handler
+  //     throw error.value;
+  //   }
+  //   // return data so $onAction.after listeners can add their own handler
+  //   return contactData;
+  // }
 
   // private functions
   const contactLabelValue = (item: any) => {
@@ -212,11 +210,11 @@ export const useContactsStore = defineStore('contacts', () => {
     loading,
     error,
     listContacts,
-    createInvitation,
-    acceptInvitation,
-    deleteContact,
+    // createInvitation,
+    // acceptInvitation,
+    // deleteContact,
     getContact,
-    updateContact,
+    // updateContact,
   };
 });
 

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -48,7 +48,7 @@ export const useContactsStore = defineStore('contacts', () => {
     return fetchList(API_PATH.CONNECTIONS, contacts, error, loading, {});
   }
 
-  async function createInvitation(alias: string, multi_use: boolean) {
+  async function createInvitation(alias: string, multiUse: boolean) {
     console.log('> contactsStore.createInvitation');
     error.value = null;
     loading.value = true;
@@ -60,7 +60,7 @@ export const useContactsStore = defineStore('contacts', () => {
         API_PATH.CONNECTIONS_CREATE_INVITATION,
         {},
         {
-          params: { alias, multi_use },
+          params: { alias, multi_use: multiUse },
         }
       )
       .then((res) => {

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -1,6 +1,10 @@
-import { API_PATH } from '@/helpers/constants';
+import {
+  API_PATH,
+  CONNECTION_STATUSES,
+  RESERVATION_STATUSES,
+} from '@/helpers/constants';
 import { defineStore } from 'pinia';
-import { computed, ref } from 'vue';
+import { computed, ref, Ref } from 'vue';
 import { useAcapyApi } from './acapyApi';
 import {
   fetchList,
@@ -12,10 +16,10 @@ import { fetchItem } from './utils/fetchItem';
 
 export const useContactsStore = defineStore('contacts', () => {
   // state
-  const contacts: any = ref(null);
+  const contacts: Ref<any[]> = ref([]);
   const selectedContact: any = ref(null);
-  const loading: any = ref(false);
-  const error: any = ref(null);
+  const loading: Ref<boolean> = ref(false);
+  const error: Ref<string | null> = ref(null);
 
   // getters
   const contactsDropdown = computed(() => {
@@ -26,6 +30,13 @@ export const useContactsStore = defineStore('contacts', () => {
       filterByStatusActive
     );
   });
+
+  const filteredConnections = computed(() =>
+    contacts.value.filter((c) => c.state !== CONNECTION_STATUSES.INVITATION)
+  );
+  const filteredInvitations = computed(() =>
+    contacts.value.filter((c) => c.state === CONNECTION_STATUSES.INVITATION)
+  );
 
   // actions
 
@@ -208,6 +219,8 @@ export const useContactsStore = defineStore('contacts', () => {
     selectedContact,
     loading,
     error,
+    filteredConnections,
+    filteredInvitations,
     listContacts,
     createInvitation,
     // acceptInvitation,

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -37,43 +37,44 @@ export const useContactsStore = defineStore('contacts', () => {
     return fetchList(API_PATH.CONNECTIONS, contacts, error, loading, {});
   }
 
-  // async function createInvitation(alias: string) {
-  //   console.log('> contactsStore.createInvitation');
-  //   error.value = null;
-  //   loading.value = true;
+  async function createInvitation(alias: string, multiUse: boolean) {
+    console.log('> contactsStore.createInvitation');
+    error.value = null;
+    loading.value = true;
 
-  //   let invitationData = null;
-  //   // need the await here since the returned invitationData is not one of our stored refs...
-  //   await acapyApi
-  //     .postHttp(API_PATH.CONTACTS_CREATE_INVITATION, { alias })
-  //     .then((res) => {
-  //       console.log(res);
-  //       // don't grab the item, there are other parts of the response data we need (invitation, invitation url)
-  //       invitationData = res.data;
-  //     })
-  //     .then(() => {
-  //       // do we want to automatically reload? or have the caller of this to load?
-  //       console.log(
-  //         'invitation created. the store calls load automatically, but do we want this done "manually"?'
-  //       );
-  //       listContacts();
-  //     })
-  //     .catch((err) => {
-  //       error.value = err;
-  //       // console.log(error.value);
-  //     })
-  //     .finally(() => {
-  //       loading.value = false;
-  //     });
-  //   console.log('< contactsStore.createInvitation');
+    let invitationData = null;
+    // need the await here since the returned invitationData is not one of our stored refs...
+    await acapyApi
+      .postHttp(
+        API_PATH.CONNECTIONS_CREATE_INVITATION,
+        {},
+        {
+          params: { alias: alias, multi_use: multiUse },
+        }
+      )
+      .then((res) => {
+        console.log(res);
+        invitationData = res.data;
+      })
+      .then(() => {
+        listContacts();
+      })
+      .catch((err) => {
+        error.value = err;
+        // console.log(error.value);
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< contactsStore.createInvitation');
 
-  //   if (error.value != null) {
-  //     // throw error so $onAction.onError listeners can add their own handler
-  //     throw error.value;
-  //   }
-  //   // return data so $onAction.after listeners can add their own handler
-  //   return invitationData;
-  // }
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return invitationData;
+  }
 
   // async function acceptInvitation(inviteUrl: string, alias: string) {
   //   console.log('> contactsStore.acceptInvitation');
@@ -116,39 +117,37 @@ export const useContactsStore = defineStore('contacts', () => {
   //   return acceptedData;
   // }
 
-  // async function deleteContact(payload: any = {}) {
-  //   console.log('> contactsStore.deleteContact');
+  async function deleteContact(connectionId: string) {
+    console.log('> contactsStore.deleteContact');
 
-  //   const contactId = payload.contact_id;
+    error.value = null;
+    loading.value = true;
 
-  //   error.value = null;
-  //   loading.value = true;
+    let result = null;
 
-  //   let result = null;
+    await acapyApi
+      .deleteHttp(API_PATH.CONNECTION(connectionId))
+      .then((res) => {
+        result = res.data;
+      })
+      .then(() => {
+        listContacts(); // Refresh table
+      })
+      .catch((err) => {
+        error.value = err;
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< contactsStore.deleteContact');
 
-  //   await acapyApi
-  //     .deleteHttp(API_PATH.CONTACT(contactId), payload)
-  //     .then((res) => {
-  //       result = res.data.item;
-  //     })
-  //     .then(() => {
-  //       listContacts(); // Refresh table
-  //     })
-  //     .catch((err) => {
-  //       error.value = err;
-  //     })
-  //     .finally(() => {
-  //       loading.value = false;
-  //     });
-  //   console.log('< contactsStore.deleteContact');
-
-  //   if (error.value != null) {
-  //     // throw error so $onAction.onError listeners can add their own handler
-  //     throw error.value;
-  //   }
-  //   // return data so $onAction.after listeners can add their own handler
-  //   return result;
-  // }
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return result;
+  }
 
   async function getContact(id: string, params: any = {}) {
     const getloading: any = ref(false);
@@ -210,9 +209,9 @@ export const useContactsStore = defineStore('contacts', () => {
     loading,
     error,
     listContacts,
-    // createInvitation,
+    createInvitation,
     // acceptInvitation,
-    // deleteContact,
+    deleteContact,
     getContact,
     // updateContact,
   };

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -1,7 +1,7 @@
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref, Ref } from 'vue';
 import axios from 'axios';
-import { useAcapyTenantApi } from '../acapyTenantApi';
+import { useAcapyApi } from '../acapyApi';
 import { fetchListFromAPI } from '../utils';
 import { API_PATH, RESERVATION_STATUSES } from '@/helpers/constants';
 import { useConfigStore } from '../configStore';
@@ -32,7 +32,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
   // actions
 
   // (using both things temporarily)
-  const acapyTenantApi = useAcapyTenantApi();
+  const acapyApi = useAcapyApi();
 
   // A different axios instance with a basepath just of the tenant UI backend
   const backendApi = axios.create({
@@ -52,7 +52,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
 
   async function listReservations() {
     return fetchListFromAPI(
-      acapyTenantApi,
+      acapyApi,
       API_PATH.INNKEEPER_RESERVATIONS,
       reservations,
       error,
@@ -76,7 +76,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
 
     // Don't keep this as state, make sure the password doesn't hang around in memory
     let approveResponse: ApproveResponse = {};
-    await acapyTenantApi
+    await acapyApi
       .putHttp(API_PATH.INNKEEPER_RESERVATIONS_APPROVE(id), payload)
       .then((res) => {
         approveResponse = res.data;
@@ -111,7 +111,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
     error.value = null;
     loading.value = true;
 
-    await acapyTenantApi
+    await acapyApi
       .putHttp(API_PATH.INNKEEPER_RESERVATIONS_DENY(id), payload)
       .then((res) => {
         console.log(res);

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -41,7 +41,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
 
   async function listTenants() {
     return fetchListFromAPI(
-      acapyTenantApi,
+      acapyApi,
       API_PATH.INNKEEPER_TENANTS,
       tenants,
       error,

--- a/services/tenant-ui/frontend/src/store/messageStore.ts
+++ b/services/tenant-ui/frontend/src/store/messageStore.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue';
 import { defineStore } from 'pinia';
-import { useAcapyTenantApi } from './acapyTenantApi';
+import { useAcapyApi } from './acapyApi';
 import { fetchListFromAPI } from './utils';
 import { API_PATH } from '@/helpers/constants';
 
@@ -11,11 +11,11 @@ export const useMessageStore = defineStore('messages', () => {
   const error: any = ref(null);
 
   // grab the tenant api
-  const acapyTenantApi = useAcapyTenantApi();
+  const acapyApi = useAcapyApi();
 
   async function listMessages() {
     return fetchListFromAPI(
-      acapyTenantApi,
+      acapyApi,
       API_PATH.BASICMESSAGES,
       messages,
       error,
@@ -35,7 +35,7 @@ export const useMessageStore = defineStore('messages', () => {
 
     let result = null;
 
-    await acapyTenantApi
+    await acapyApi
       .postHttp(API_PATH.BASICMESSAGES_SEND(connId), payload)
       .then((res) => {
         console.log(res);

--- a/services/tenant-ui/frontend/src/store/utils/fetchItem.ts
+++ b/services/tenant-ui/frontend/src/store/utils/fetchItem.ts
@@ -1,4 +1,4 @@
-import { useAcapyTenantApi } from '../acapyTenantApi';
+import { useAcapyApi } from '../acapyApi';
 import { AxiosRequestConfig } from 'axios';
 import { Ref } from 'vue';
 
@@ -9,8 +9,8 @@ export async function fetchItem(
   loading: Ref<boolean>,
   params: object = {}
 ): Promise<object | null | undefined> {
-  const acapyApi = useAcapyTenantApi();
-  const dataUrl = `${url}${id}`;
+  const acapyApi = useAcapyApi();
+  const dataUrl = `${url}/${id}`;
   console.log(` > fetchItem(${dataUrl})`);
   error.value = null;
   let result = null;

--- a/services/tenant-ui/frontend/src/store/utils/fetchList.ts
+++ b/services/tenant-ui/frontend/src/store/utils/fetchList.ts
@@ -1,4 +1,4 @@
-import { useAcapyTenantApi } from '../acapyTenantApi';
+import { useAcapyApi } from '../acapyApi';
 import { AxiosRequestConfig } from 'axios';
 import { Ref } from 'vue';
 
@@ -9,7 +9,7 @@ export async function fetchList(
   loading: Ref<boolean>,
   params: object = {}
 ) {
-  const acapyApi = useAcapyTenantApi();
+  const acapyApi = useAcapyApi();
   return fetchListFromAPI(acapyApi, url, list, error, loading, params);
 }
 
@@ -25,17 +25,16 @@ export async function fetchListFromAPI(
   list.value = [];
   error.value = null;
   loading.value = true;
-
   params = { ...params };
   await api
     .getHttp(url, params)
     .then((res: AxiosRequestConfig): void => {
       // console.log(res);
       list.value = res.data.results;
+      // console.log(list.value);
     })
     .catch((err: string): void => {
       error.value = err;
-      // console.log(error.value);
     })
     .finally((): void => {
       loading.value = false;

--- a/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
+++ b/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
@@ -1,0 +1,7 @@
+<template>
+  <Contacts />
+</template>
+
+<script setup lang="ts">
+import Contacts from '../../components/contacts/Contacts.vue';
+</script>

--- a/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
+++ b/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script setup lang="ts">
-import Invitations from '../../components/invitations/Invitations.vue';
+import Invitations from '@/components/invitations/Invitations.vue';
 </script>

--- a/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
+++ b/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
@@ -1,7 +1,7 @@
 <template>
-  <Contacts />
+  <Invitations />
 </template>
 
 <script setup lang="ts">
-import Contacts from '../../components/contacts/Contacts.vue';
+import Invitations from '../../components/invitations/Invitations.vue';
 </script>


### PR DESCRIPTION
Add in the connections and invitations tables. Both of these are just the results of the "connections" list from acapy, but we filter by whether they are in invitation state to determine which table has which records.

Single and multi-use buttons added and called from Invitations table.

Still things to do with this in that we want to invoke the new `connections/{conn_id}/invitation` endpoint to be able to go to a connection and re-fetch its invitation details. Mostly this will be to serve the ability to get the QR code/url for a multi-use invitation again after it's already been used.

Single-use invitations act like this:
- Invitation connection with mode "once" is created
- When actioned the status updates from invitation to active (or other statuses)
- Connection no longer has an invitation status so goes to connections table.

Multi-use invitations do the following (this is just acapy behaviour)
- Create a connection with mode "multi" (rather than "once") which is the invitation
- **Each** time that connection is actioned create a new connection to represent it
- This connection ends up with "once" as the mode, and a blank alias (need to think on what we want to do with this)
- The initial invitation stays around in the invitations list to be used again

Some of the file/folder names are pretty inconsistent with "contact" vs "connection" but I don't want to change that in case we switch up the concept naming again. Will do a pass over code naming once it's locked down.


![image](https://user-images.githubusercontent.com/17445138/212393724-fb5b2a11-67a4-4728-a6a9-ddfc704c4a53.png)

![image](https://user-images.githubusercontent.com/17445138/212393759-55f0c034-f271-40c7-b564-9238d439e9c3.png)
