### PR TITLE
Regenerate invitation

### DIFF
--- a/services/tenant-ui/frontend/src/assets/primevueOverrides/dialog.scss
+++ b/services/tenant-ui/frontend/src/assets/primevueOverrides/dialog.scss
@@ -1,6 +1,0 @@
-// Dialogs
-.p-dialog-content {
-  input {
-    min-width: 400px;
-  }
-}

--- a/services/tenant-ui/frontend/src/assets/primevueOverrides/primevueOverrides.scss
+++ b/services/tenant-ui/frontend/src/assets/primevueOverrides/primevueOverrides.scss
@@ -1,5 +1,4 @@
 @import 'buttons.scss';
 @import 'datatable.scss';
-@import 'dialog.scss';
 @import 'formFields.scss';
 @import 'inputSwitch.scss';

--- a/services/tenant-ui/frontend/src/components/common/QRCode.vue
+++ b/services/tenant-ui/frontend/src/components/common/QRCode.vue
@@ -1,22 +1,6 @@
-<script setup lang="ts">
-import Button from 'primevue/button';
-import QrcodeVue from 'qrcode.vue';
-import Accordion from 'primevue/accordion';
-import AccordionTab from 'primevue/accordiontab';
-
-// For notifications
-import { useToast } from 'vue-toastification';
-const toast = useToast();
-
-const copy_to_clipboard = (content: string) => {
-  navigator.clipboard.writeText(content);
-  toast.info('URL copied to clipboard');
-  return;
-};
-</script>
-
 <template>
   <div v-if="qrContent" class="qr-container">
+    <!-- QR Code encoded link -->
     <qrcode-vue
       v-if="qrContent"
       class="qr-image"
@@ -24,48 +8,56 @@ const copy_to_clipboard = (content: string) => {
       :size="400"
       level="H"
     />
-    <Button
-      class="clipboard-button"
-      label="Copy to Clipboard"
-      icon="pi pi-paperclip"
-      @click="copy_to_clipboard(qrContent!)"
-    ></Button>
-    <Accordion class="qr-accordion">
-      <AccordionTab header="View Raw Content">
-        <p style="word-wrap: break-word">{{ qrContent }}</p>
-      </AccordionTab>
-    </Accordion>
+
+    <!-- Plain text of link -->
+    <div class="field mt-5 w-full">
+      <label for="inviteUrl">Invitation URL</label>
+      <div class="p-inputgroup">
+        <InputText
+          id="inviteUrl"
+          readonly
+          :value="qrContent"
+          name="invite-url"
+          class="w-full"
+        />
+        <Button
+          icon="pi pi-copy"
+          title="Copy to clipboard"
+          class="p-button-secondary"
+          @click="copy_to_clipboard"
+        />
+      </div>
+    </div>
   </div>
   <span v-else>No Content Found</span>
 </template>
 
-<script lang="ts">
-export default {
-  name: 'QRCode',
-  props: {
-    qrContent: {
-      type: String,
-      default: null,
-    },
+<script setup lang="ts">
+import { PropType } from 'vue';
+import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
+import QrcodeVue from 'qrcode.vue';
+import { useToast } from 'vue-toastification';
+const toast = useToast();
+
+// Props
+const props = defineProps({
+  qrContent: {
+    type: String as PropType<string>,
+    required: true,
   },
+});
+
+const copy_to_clipboard = () => {
+  navigator.clipboard.writeText(props.qrContent);
+  toast.info('URL copied to clipboard');
+  return;
 };
 </script>
 
 <style>
-.qr-accordion {
-  margin-top: 10px;
-}
-
 .qr-image {
   display: flex;
   margin-bottom: 25px;
-}
-
-.qr-container {
-  max-width: 400px;
-}
-
-i {
-  margin: 10px;
 }
 </style>

--- a/services/tenant-ui/frontend/src/components/contacts/Invitations.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Invitations.vue
@@ -44,6 +44,7 @@
     <Column :sortable="false" header="Actions">
       <template #body="{ data }">
         <DeleteContact :connection-id="data.connection_id" />
+        <RegenerateInvitation :connection-id="data.connection_id" />
       </template>
     </Column>
     <Column :sortable="true" field="alias" header="Alias" />
@@ -75,6 +76,7 @@ import { storeToRefs } from 'pinia';
 // Other components
 import CreateContact from '@/components/contacts/createContact/CreateContact.vue';
 import DeleteContact from '@/components/contacts/editContact/DeleteContact.vue';
+import RegenerateInvitation from '@/components/contacts/createContact/RegenerateInvitation.vue';
 import RowExpandData from '@/components/common/RowExpandData.vue';
 import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';

--- a/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContact.vue
@@ -17,6 +17,7 @@
           : t('connect.invitations.singleCreate')
       "
       :modal="true"
+      :style="{ minWidth: '400px' }"
       @update:visible="handleClose"
     >
       <CreateContactForm

--- a/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContactForm.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/createContact/CreateContactForm.vue
@@ -1,13 +1,14 @@
 <template>
   <form @submit.prevent="handleSubmit(!v$.$invalid)">
     <!-- Alias -->
-    <div class="field">
+    <div class="field w-full">
       <label for="alias" :class="{ 'p-error': v$.alias.$invalid && submitted }">
         Contact Alias
       </label>
       <InputText
         v-model="v$.alias.$model"
         :class="{ 'p-invalid': v$.alias.$invalid && submitted }"
+        class="w-full"
         type="text"
         name="alias"
         autofocus

--- a/services/tenant-ui/frontend/src/components/contacts/createContact/RegenerateInvitation.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/createContact/RegenerateInvitation.vue
@@ -1,0 +1,80 @@
+<template>
+  <Button
+    :title="t('connect.invitations.regenerate')"
+    icon="pi pi-link"
+    class="p-button-rounded p-button-icon-only p-button-text"
+    @click="openModal"
+  />
+  <Dialog
+    v-model:visible="displayModal"
+    :header="t('connect.invitations.regenerate')"
+    :modal="true"
+    :style="{ minWidth: '400px' }"
+    @update:visible="handleClose"
+  >
+    <div v-if="loadingItem" class="flex justify-content-center">
+      <ProgressSpinner />
+    </div>
+    <div v-else-if="invitation">
+      <!-- Alias -->
+      <div class="field w-full">
+        <label for="alias">Alias</label>
+        <InputText
+          :value="invitation.alias"
+          class="w-full"
+          name="alias"
+          readonly
+        />
+      </div>
+
+      <QRCode :qr-content="invitation.invitation_url" />
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { ref, PropType } from 'vue';
+// PrimeVue etc
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
+import InputText from 'primevue/inputtext';
+import ProgressSpinner from 'primevue/progressspinner';
+import { useI18n } from 'vue-i18n';
+import { useToast } from 'vue-toastification';
+// State
+import { storeToRefs } from 'pinia';
+import { useContactsStore } from '@/store';
+// Other Components
+import QRCode from '../../common/QRCode.vue';
+
+const { t } = useI18n();
+const toast = useToast();
+
+const contactsStore = useContactsStore();
+const { loadingItem } = storeToRefs(useContactsStore());
+
+// Props
+const props = defineProps({
+  connectionId: {
+    type: String as PropType<string>,
+    required: true,
+  },
+});
+
+// Display popup, fetch and display invitation
+const displayModal = ref(false);
+const invitation: any = ref(null);
+const openModal = async () => {
+  displayModal.value = true;
+  try {
+    invitation.value = await contactsStore.getInvitation(props.connectionId);
+  } catch (err) {
+    console.error(err);
+    toast.error(`Failure getting invitation: ${err}`);
+  }
+};
+const handleClose = async () => {
+  displayModal.value = false;
+};
+</script>

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -24,9 +24,10 @@ export const API_PATH = {
   TENANT_TOKEN: '/tenant/token',
 
   CONNECTIONS: '/connections',
+  CONNECTION: (id: string) => `/connections/${id}`,
   CONNECTIONS_CREATE_INVITATION: '/connections/create-invitation',
   // CONTACTS_RECEIVE_INVITATION: '/tenant/v1/contacts/receive-invitation',
-  CONNECTION: (id: string) => `/connections/${id}`,
+  CONNECTIONS_INVITATION: (id: string) => `/connections/${id}/invitation`,
 
   HOLDER_CREDENTIALS: '/tenant/v1/holder/credentials/',
   HOLDER_CREDENTIALS_ACCEPT_OFFER: (id: string) =>

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -23,7 +23,8 @@
       "single": "Single Use",
       "singleCreate": "Create Single Use Invitation",
       "multi": "Multi Use",
-      "multiCreate": "Create Multi Use Invitation"
+      "multiCreate": "Create Multi Use Invitation",
+      "regenerate": "Regenerate Invitation"
     }
   },
   "issue": {

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -19,6 +19,7 @@ export const useContactsStore = defineStore('contacts', () => {
   const contacts: Ref<any[]> = ref([]);
   const selectedContact: any = ref(null);
   const loading: Ref<boolean> = ref(false);
+  const loadingItem: Ref<boolean> = ref(false);
   const error: Ref<string | null> = ref(null);
 
   // getters
@@ -161,8 +162,23 @@ export const useContactsStore = defineStore('contacts', () => {
   }
 
   async function getContact(id: string, params: any = {}) {
-    const getloading: any = ref(false);
-    return fetchItem(API_PATH.CONNECTIONS, id, error, getloading, params);
+    loadingItem.value = true;
+    await new Promise((r) => setTimeout(r, 2000));
+
+    return fetchItem(API_PATH.CONNECTIONS, id, error, loadingItem, params);
+  }
+
+  async function getInvitation(id: string, params: any = {}) {
+    loadingItem.value = true;
+    await new Promise((r) => setTimeout(r, 2000));
+
+    return fetchItem(
+      API_PATH.CONNECTIONS_INVITATION(id),
+      '',
+      error,
+      loadingItem,
+      params
+    );
   }
 
   // Only going to do alias right now but expand to other params as needed later
@@ -218,6 +234,7 @@ export const useContactsStore = defineStore('contacts', () => {
     contactsDropdown,
     selectedContact,
     loading,
+    loadingItem,
     error,
     filteredConnections,
     filteredInvitations,
@@ -226,6 +243,7 @@ export const useContactsStore = defineStore('contacts', () => {
     // acceptInvitation,
     deleteContact,
     getContact,
+    getInvitation,
     // updateContact,
   };
 });

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -163,15 +163,11 @@ export const useContactsStore = defineStore('contacts', () => {
 
   async function getContact(id: string, params: any = {}) {
     loadingItem.value = true;
-    await new Promise((r) => setTimeout(r, 2000));
-
     return fetchItem(API_PATH.CONNECTIONS, id, error, loadingItem, params);
   }
 
   async function getInvitation(id: string, params: any = {}) {
     loadingItem.value = true;
-    await new Promise((r) => setTimeout(r, 2000));
-
     return fetchItem(
       API_PATH.CONNECTIONS_INVITATION(id),
       '',

--- a/services/tenant-ui/frontend/src/store/utils/fetchItem.ts
+++ b/services/tenant-ui/frontend/src/store/utils/fetchItem.ts
@@ -10,7 +10,7 @@ export async function fetchItem(
   params: object = {}
 ): Promise<object | null | undefined> {
   const acapyApi = useAcapyApi();
-  const dataUrl = `${url}/${id}`;
+  const dataUrl = id ? `${url}/${id}` : url;
   console.log(` > fetchItem(${dataUrl})`);
   error.value = null;
   let result = null;

--- a/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
+++ b/services/tenant-ui/frontend/src/views/connections/MyInvitations.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script setup lang="ts">
-import Invitations from '@/components/invitations/Invitations.vue';
+import Invitations from '@/components/contacts/Invitations.vue';
 </script>


### PR DESCRIPTION
Signed-off-by: Lucas ONeil <lucasoneil@gmail.com>

Add an action to the invitations table to re-get the invite
![image](https://user-images.githubusercontent.com/17445138/212440560-17c3c6de-e488-4317-b53f-082901703b80.png)

Brings up the QR code and the link (just like the create screen)
![image](https://user-images.githubusercontent.com/17445138/212440661-07fbbc79-c63f-4989-8e32-e9c569f5b992.png)


Uses the fetch invitation endpoint with the connection ID, since the invitations are themselves just connections in invitation state
https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca/api/doc#/connection/get_connections__conn_id__invitation
