### PR TITLE
Schema Storage usage in Tenant UI

### DIFF
--- a/services/tenant-ui/frontend/src/components/LoginForm.vue
+++ b/services/tenant-ui/frontend/src/components/LoginForm.vue
@@ -101,9 +101,20 @@ const handleSubmit = async (isFormValid: boolean) => {
     toast.error(`Failure getting token: ${err}`);
   }
   try {
-    // token is loaded, now go fetch the tenant data...
+    // token is loaded, now go fetch the global data about the tenant
     await tenantStore.getSelf();
     console.log(tenant.value);
+    // TODO: once we get response statuses working correctly again can re-configure this
+    // Don't throw errors since not-found and stuff is fine for non-issuers
+    try {
+      // Find out issuer status when logging in
+      await Promise.all([
+        tenantStore.getEndorserConnection(),
+        tenantStore.getPublicDid(),
+      ]);
+    } catch (err) {
+      console.error(err);
+    }
   } catch (err) {
     console.error(err);
     toast.error(`Failure getting tenant: ${err}`);

--- a/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchema.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchema.vue
@@ -5,8 +5,8 @@
       v-model:visible="displayModal"
       header="Copy Schema"
       :modal="true"
-      @update:visible="handleClose"
       :style="{ minWidth: '400px' }"
+      @update:visible="handleClose"
     >
       <CopySchemaForm @success="$emit('success')" @closed="handleClose" />
     </Dialog>
@@ -19,22 +19,12 @@ import { ref } from 'vue';
 // PrimeVue
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
-// State
-
 // Custom Components
 import CopySchemaForm from './CopySchemaForm.vue';
-// Other Imports
-import { useToast } from 'vue-toastification';
-
-// State setup
-
-const toast = useToast();
 
 defineEmits(['success']);
 
-// -----------------------------------------------------------------------
-// Display popup
-// ---------------------------------------------------------------------
+// Open close dialog
 const displayModal = ref(false);
 const openModal = async () => {
   // Kick of the loading asyncs (if needed)
@@ -44,5 +34,4 @@ const handleClose = async () => {
   // some logic... maybe we shouldn't close?
   displayModal.value = false;
 };
-// ---------------------------------------------------------------/display
 </script>

--- a/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchema.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchema.vue
@@ -6,6 +6,7 @@
       header="Copy Schema"
       :modal="true"
       @update:visible="handleClose"
+      :style="{ minWidth: '400px' }"
     >
       <CopySchemaForm @success="$emit('success')" @closed="handleClose" />
     </Dialog>

--- a/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchemaForm.vue
@@ -11,8 +11,8 @@
           >
           <InputText
             id="schemaId"
-            class="w-full"
             v-model="v$.schemaId.$model"
+            class="w-full"
             :class="{ 'p-invalid': v$.schemaId.$invalid && submitted }"
           />
           <span v-if="v$.schemaId.$error && submitted">
@@ -72,13 +72,11 @@ const handleSubmit = async (isFormValid: boolean) => {
   try {
     const payload = {
       schema_id: formFields.schemaId,
-      name: null,
-      tags: [],
     };
 
     // call store
     await governanceStore.copySchema(payload);
-    toast.info('Schema copied');
+    toast.success(`Schema copied.`);
     emit('success');
     // close up on success
     emit('closed');

--- a/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/copySchema/CopySchemaForm.vue
@@ -11,6 +11,7 @@
           >
           <InputText
             id="schemaId"
+            class="w-full"
             v-model="v$.schemaId.$model"
             :class="{ 'p-invalid': v$.schemaId.$invalid && submitted }"
           />

--- a/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchema.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchema.vue
@@ -10,8 +10,8 @@
       v-model:visible="displayModal"
       header="Create Schema"
       :modal="true"
-      @update:visible="handleClose"
       :style="{ minWidth: '500px' }"
+      @update:visible="handleClose"
     >
       <CreateSchemaForm @success="$emit('success')" @closed="handleClose" />
     </Dialog>
@@ -25,16 +25,10 @@ import { ref } from 'vue';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 // State
-import { useTenantStore } from '../../../store';
+import { useTenantStore } from '@/store';
 import { storeToRefs } from 'pinia';
 // Custom Components
 import CreateSchemaForm from './CreateSchemaForm.vue';
-// Other Imports
-import { useToast } from 'vue-toastification';
-
-// State setup
-
-const toast = useToast();
 
 const { isIssuer } = storeToRefs(useTenantStore());
 

--- a/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchema.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchema.vue
@@ -11,6 +11,7 @@
       header="Create Schema"
       :modal="true"
       @update:visible="handleClose"
+      :style="{ minWidth: '500px' }"
     >
       <CreateSchemaForm @success="$emit('success')" @closed="handleClose" />
     </Dialog>
@@ -39,9 +40,7 @@ const { isIssuer } = storeToRefs(useTenantStore());
 
 defineEmits(['success']);
 
-// -----------------------------------------------------------------------
 // Display popup
-// ---------------------------------------------------------------------
 const displayModal = ref(false);
 const openModal = async () => {
   // Kick of the loading asyncs (if needed)
@@ -51,5 +50,4 @@ const handleClose = async () => {
   // some logic... maybe we shouldn't close?
   displayModal.value = false;
 };
-// ---------------------------------------------------------------/display
 </script>

--- a/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchemaForm.vue
@@ -12,6 +12,7 @@
           >
           <InputText
             id="schemaName"
+            class="w-full"
             v-model="v$.schemaName.$model"
             :class="{ 'p-invalid': v$.schemaName.$invalid && submitted }"
           />
@@ -35,6 +36,7 @@
           >
           <InputText
             id="schemaVersion"
+            class="w-full"
             v-model="v$.schemaVersion.$model"
             :class="{ 'p-invalid': v$.schemaVersion.$invalid && submitted }"
           />
@@ -57,13 +59,13 @@
         <div
           v-for="(item, index) in attributes"
           :key="index"
-          style="display: flex; flex-direction: row"
+          class="flex w-full"
         >
           <InputText
             v-model="item.name"
             type="text"
             name="{{ `attribute_${index}` }}"
-            class="mb-5"
+            class="mb-5 w-full"
           />
           <div class="flex justify-content-between">
             <button

--- a/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/createSchema/CreateSchemaForm.vue
@@ -12,8 +12,8 @@
           >
           <InputText
             id="schemaName"
-            class="w-full"
             v-model="v$.schemaName.$model"
+            class="w-full"
             :class="{ 'p-invalid': v$.schemaName.$invalid && submitted }"
           />
           <span v-if="v$.schemaName.$error && submitted">
@@ -36,8 +36,8 @@
           >
           <InputText
             id="schemaVersion"
-            class="w-full"
             v-model="v$.schemaVersion.$model"
+            class="w-full"
             :class="{ 'p-invalid': v$.schemaVersion.$invalid && submitted }"
           />
           <span v-if="v$.schemaVersion.$error && submitted">
@@ -97,10 +97,11 @@ import { reactive, ref } from 'vue';
 // PrimeVue / Validation
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
-import { required } from '@vuelidate/validators';
+import { required, helpers } from '@vuelidate/validators';
 import { useVuelidate } from '@vuelidate/core';
 // State
 import { useGovernanceStore } from '@/store';
+import { storeToRefs } from 'pinia';
 // Other imports
 import { useToast } from 'vue-toastification';
 
@@ -108,6 +109,7 @@ const toast = useToast();
 
 // Store values
 const governanceStore = useGovernanceStore();
+const { loading } = storeToRefs(useGovernanceStore());
 
 const emit = defineEmits(['closed', 'success']);
 
@@ -133,9 +135,16 @@ const formFields = reactive({
   schemaName: '',
   schemaVersion: '',
 });
+const mustBeDecimal = (value: string) => /^\d+(\.\d+)(\.\d+)?$/.test(value);
 const rules = {
   schemaName: { required },
-  schemaVersion: { required },
+  schemaVersion: {
+    required,
+    mustBeDecimal: helpers.withMessage(
+      'Must be a 2 or 3-part decimal value like x.y or x.y.z',
+      mustBeDecimal
+    ),
+  },
 };
 const v$ = useVuelidate(rules, formFields);
 
@@ -152,19 +161,22 @@ const handleSubmit = async (isFormValid: boolean) => {
       .filter((x) => x.name !== '')
       .map((attribute) => attribute.name);
 
+    if (!justAttributeNames.length) {
+      toast.error('Please provide at least one attribute for the schema');
+      return;
+    }
+
     const payload = {
-      schema_definition: {
-        schema_name: formFields.schemaName,
-        schema_version: formFields.schemaVersion,
-        attributes: justAttributeNames,
-      },
-      name: formFields.schemaName,
-      tags: [],
+      attributes: justAttributeNames,
+      schema_name: formFields.schemaName,
+      schema_version: formFields.schemaVersion,
     };
 
     // call store
-    governanceStore.createSchemaTemplate(payload);
-    toast.info('Schema created');
+    await governanceStore.createSchema(payload);
+    toast.success(
+      'Schema created. If it does not appear yet, refresh the table.'
+    );
     emit('success');
     // close up on success
     emit('closed');

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredential.vue
@@ -55,7 +55,7 @@ const openModal = async () => {
   // Kick of the loading asyncs in the store to fetch contacts/creds
   Promise.all([
     contactsStore.listContacts(),
-    governanceStore.listSchemaTemplates(),
+    // governanceStore.listSchemaTemplates(),
     governanceStore.listCredentialTemplates(),
   ]).catch((err) => {
     console.error(err);

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -62,7 +62,8 @@ const items = ref([
     icon: 'pi pi-fw pi-file',
     items: [
       {
-        label: () => t('configuration.schemasCreds.schemas'),
+        // label: () => t('configuration.schemasCreds.schemas'),
+        label: 'Schema Storage',
         icon: 'pi pi-fw pi-book',
         to: { name: 'Schemas' },
       },

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -58,25 +58,26 @@ const items = ref([
   // },
 
   {
+    label: () => t('configuration.configuration'),
+    icon: 'pi pi-fw pi-file',
+    items: [
+      {
+        label: () => t('configuration.schemasCreds.schemas'),
+        icon: 'pi pi-fw pi-book',
+        to: { name: 'Schemas' },
+      },
+      // {
+      //   label: () => t('configuration.presentationTemplates.templates'),
+      //   to: { name: 'PresentationTemplates' },
+      // },
+    ],
+  },
+
+  {
     label: () => t('messages.messages'),
     icon: 'pi pi-fw pi-envelope',
     to: { name: 'MyMessages' },
   },
-
-  // {
-  //   label: () => t('configuration.configuration'),
-  //   icon: 'pi pi-fw pi-file',
-  //   items: [
-  //     {
-  //       label: () => t('configuration.schemasCreds.schemas'),
-  //       to: { name: 'Schemas' },
-  //     },
-  //     {
-  //       label: () => t('configuration.presentationTemplates.templates'),
-  //       to: { name: 'PresentationTemplates' },
-  //     },
-  //   ],
-  // },
 
   {
     label: () => t('about.about'),

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -9,7 +9,18 @@ export const API_PATH = {
   EMAIL_CONFIRMATION: '/email/reservationConfirmation',
   EMAIL_STATUS: '/email/reservationStatus',
 
-  // Acapy and plugins (and Traction for now)
+  OIDC_INNKEEPER_LOGIN: '/api/innkeeperLogin',
+
+  // Acapy and Plugins
+  BASICMESSAGES: '/basicmessages',
+  BASICMESSAGES_SEND: (connId: string) => `/connections/${connId}/send-message`,
+
+  CONNECTIONS: '/connections',
+  CONNECTION: (id: string) => `/connections/${id}`,
+  CONNECTIONS_CREATE_INVITATION: '/connections/create-invitation',
+  // CONTACTS_RECEIVE_INVITATION: '/tenant/v1/contacts/receive-invitation',
+  CONNECTIONS_INVITATION: (id: string) => `/connections/${id}/invitation`,
+
   INNKEEPER_TOKEN: '/innkeeper/token',
   INNKEEPER_TENANTS: '/innkeeper/tenants/',
   INNKEEPER_TENANT: (id: string) => `/innkeeper/tenants/${id}`,
@@ -19,15 +30,35 @@ export const API_PATH = {
   INNKEEPER_RESERVATIONS_DENY: (id: string) =>
     `/innkeeper/reservations/${id}/deny`,
 
-  OIDC_INNKEEPER_LOGIN: '/api/innkeeperLogin',
+  MULTITENANCY_RESERVATIONS: '/multitenancy/reservations',
+  MULTITENANCY_RESERVATION: (resId: string) =>
+    `/multitenancy/reservations/${resId}`,
+  MULTITENANCY_RESERVATION_CHECK_IN: (resId: string) =>
+    `/multitenancy/reservations/${resId}/check-in`,
+  MULTITENANCY_TENANT_TOKEN: (tenantId: string) =>
+    `/multitenancy/tenant/${tenantId}/token`,
+  MULTITENANCY_WALLET_TOKEN: (tenantId: string) =>
+    `/multitenancy/wallet/${tenantId}/token`,
 
+  SCHEMAS: '/schemas',
+  SCHEMA: (id: string) => `/schemas/${id}`,
+  SCHEMAS_CREATED: '/schemas/created',
+  SCHEMAS_WRITE_RECORD: (id: string) => `/schemas/${id}/write_record`,
+
+  SCHEMA_STORAGE: '/schema-storage',
+  SCHEMA_STORAGE_SYNC: '/schema-storage/sync-created',
+  SCHEMA_STORAGE_ITEM: (id: string) => `/schema-storage/${id}`,
+
+  TENANT_SELF: '/tenant',
+  TENANT_ENDORSER_CONNECTION: '/tenant/endorser-connection',
+  TENANT_ENDORSER_INFO: '/tenant/endorser-info',
+  TENANT_REGISTER_PUBLIC_DID: '/tenant/register-public-did',
   TENANT_TOKEN: '/tenant/token',
 
-  CONNECTIONS: '/connections',
-  CONNECTION: (id: string) => `/connections/${id}`,
-  CONNECTIONS_CREATE_INVITATION: '/connections/create-invitation',
-  // CONTACTS_RECEIVE_INVITATION: '/tenant/v1/contacts/receive-invitation',
-  CONNECTIONS_INVITATION: (id: string) => `/connections/${id}/invitation`,
+  WALLET_DID_PUBLIC: '/wallet/did/public',
+  WALLET_DID_CREATE: '/wallet/did/create',
+
+  // Legacy (to be removed)
 
   HOLDER_CREDENTIALS: '/tenant/v1/holder/credentials/',
   HOLDER_CREDENTIALS_ACCEPT_OFFER: (id: string) =>
@@ -51,36 +82,10 @@ export const API_PATH = {
   VERIFIER_PRESENTATION_TEMPLATES:
     '/tenant/v1/verifier/presentation_templates/',
 
-  GOVERNANCE_SCHEMA_TEMPLATES: '/tenant/v1/governance/schema_templates/',
-  GOVERNANCE_SCHEMA_TEMPLATES_IMPORT:
-    '/tenant/v1/governance/schema_templates/import',
-  GOVERNANCE_SCHEMA_TEMPLATE: (id: string) =>
-    `/tenant/v1/governance/schema_templates/${id}`,
   GOVERNANCE_CREDENTIAL_TEMPLATES:
     '/tenant/v1/governance/credential_templates/',
   GOVERNANCE_CREDENTIAL_TEMPLATE: (id: string) =>
     `/tenant/v1/governance/credential_templates/${id}`,
-
-  BASICMESSAGES: '/basicmessages',
-  BASICMESSAGES_SEND: (connId: string) => `/connections/${connId}/send-message`,
-
-  TENANT_SELF: '/tenant',
-  TENANT_ENDORSER_CONNECTION: '/tenant/endorser-connection',
-  TENANT_ENDORSER_INFO: '/tenant/endorser-info',
-  TENANT_REGISTER_PUBLIC_DID: '/tenant/register-public-did',
-
-  MULTITENANCY_RESERVATIONS: '/multitenancy/reservations',
-  MULTITENANCY_RESERVATION: (resId: string) =>
-    `/multitenancy/reservations/${resId}`,
-  MULTITENANCY_RESERVATION_CHECK_IN: (resId: string) =>
-    `/multitenancy/reservations/${resId}/check-in`,
-  MULTITENANCY_TENANT_TOKEN: (tenantId: string) =>
-    `/multitenancy/tenant/${tenantId}/token`,
-  MULTITENANCY_WALLET_TOKEN: (tenantId: string) =>
-    `/multitenancy/wallet/${tenantId}/token`,
-
-  WALLET_DID_PUBLIC: '/wallet/did/public',
-  WALLET_DID_CREATE: '/wallet/did/create',
 };
 
 export const CONNECTION_STATUSES = {

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -44,7 +44,7 @@
   "configuration": {
     "configuration": "Configuration",
     "schemasCreds": {
-      "schemas": "Schemas",
+      "schemas": "Stored Schemas",
       "create": "Create Schema",
       "copy": "Copy Schema"
     },

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -35,7 +35,7 @@
   "configuration": {
     "configuration": "Configuration <FR>",
     "schemasCreds": {
-      "schemas": "Schemas <FR>",
+      "schemas": "Stored Schemas <FR>",
       "create": "Create Schema <FR>",
       "copy": "Copy Schema <FR>"
     },

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
@@ -35,7 +35,7 @@
   "configuration": {
     "configuration": "Configuration <JP>",
     "schemasCreds": {
-      "schemas": "Schemas <JP>",
+      "schemas": "Stored Schemas <JP>",
       "create": "Create Schema <JP>",
       "copy": "Copy Schema <JP>"
     },


### PR DESCRIPTION
Adjust schema page with other additional improvements to call plugin schema storage for schema list/creation/import.
Only issuer tenants can create, others can copy/import.

Does not do any of the ledger listing, or schema-sync stuff from the storage plugin. Might want to discuss places to fit that stuff in but this can allow us to move forward with issuing flow at this point.

Some asynchronicity with storage appearing after creating so for now just warning the user they may need to refresh to see it appear in table.

If anyone wants to try on this PR without setting up tenants these ephemeral ones can be used

Issuer
806ba96b-6548-4972-a254-1995ac334ddb
021f52c9-5632-4f75-a214-3f33ceb4fce5

Non-Issuer
d586d345-0694-4fc5-8ca3-3632e6c8eb9e
e5798ce7-ad12-4b0d-ab72-dbee35a70649


![image](https://user-images.githubusercontent.com/17445138/216525005-a43f95da-02ec-490f-80ce-bec1677806a2.png)


Signed-off-by: Lucas ONeil <lucasoneil@gmail.com>