### PR TITLE
Tenant managed webhooks.

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/__init__.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/__init__.py
@@ -10,7 +10,7 @@ from aries_cloudagent.core.profile import Profile
 from aries_cloudagent.core.protocol_registry import ProtocolRegistry
 from aries_cloudagent.core.util import STARTUP_EVENT_PATTERN
 
-from . import schema_storage, creddef_storage, endorser, connections
+from . import schema_storage, creddef_storage, endorser, connections, tenant
 from .config import get_config
 from .tenant_manager import TenantManager
 
@@ -19,6 +19,7 @@ MODULES = [
     endorser,
     creddef_storage,
     schema_storage,
+    tenant,
 ]
 
 LOGGER = logging.getLogger(__name__)

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/endorser/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/endorser/routes.py
@@ -17,11 +17,9 @@ from aries_cloudagent.wallet.error import WalletError
 from marshmallow import fields
 
 from .endorser_connection_service import EndorserConnectionService
-from ..routes import SWAGGER_TENANT
+from ..tenant.routes import SWAGGER_CATEGORY
 
 LOGGER = logging.getLogger(__name__)
-
-SWAGGER_CATEGORY = SWAGGER_TENANT
 
 
 def error_handler(func):

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant/__init__.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant/__init__.py
@@ -1,0 +1,26 @@
+import logging
+
+from aries_cloudagent.config.injection_context import InjectionContext
+from aries_cloudagent.core.event_bus import EventBus
+from aries_cloudagent.core.plugin_registry import PluginRegistry
+from aries_cloudagent.core.protocol_registry import ProtocolRegistry
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def setup(context: InjectionContext):
+    LOGGER.info("> plugin setup...")
+
+    protocol_registry = context.inject(ProtocolRegistry)
+    if not protocol_registry:
+        raise ValueError("ProtocolRegistry missing in context")
+
+    plugin_registry = context.inject(PluginRegistry)
+    if not plugin_registry:
+        raise ValueError("PluginRegistry missing in context")
+
+    bus = context.inject(EventBus)
+    if not bus:
+        raise ValueError("EventBus missing in context")
+
+    LOGGER.info("< plugin setup.")

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant/routes.py
@@ -1,0 +1,223 @@
+import logging
+
+import requests
+from aiohttp import web
+from aiohttp_apispec import (
+    docs,
+    response_schema,
+    querystring_schema,
+    request_schema,
+)
+from aries_cloudagent.admin.request_context import AdminRequestContext
+from aries_cloudagent.messaging.models.openapi import OpenAPISchema
+from aries_cloudagent.messaging.valid import (
+    INDY_DID,
+    INDY_RAW_PUBLIC_KEY,
+)
+from aries_cloudagent.multitenant.admin.routes import (
+    format_wallet_record,
+    UpdateWalletRequestSchema,
+)
+from aries_cloudagent.multitenant.base import BaseMultitenantManager
+from aries_cloudagent.wallet.base import BaseWallet
+from aries_cloudagent.wallet.error import WalletError
+from aries_cloudagent.wallet.models.wallet_record import (
+    WalletRecordSchema,
+    WalletRecord,
+)
+
+from marshmallow import fields
+
+from ..routes import error_handler
+from ..tenant_manager import TenantManager
+from ..models import (
+    TenantRecord,
+    TenantRecordSchema,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+SWAGGER_CATEGORY = "traction-tenant"
+
+
+class RegisterPublicDidSchema(OpenAPISchema):
+    """Query string parameters and validators for register ledger nym request."""
+
+    did = fields.Str(
+        description="DID to register",
+        required=True,
+        **INDY_DID,
+    )
+    verkey = fields.Str(
+        description="Verification key", required=True, **INDY_RAW_PUBLIC_KEY
+    )
+    alias = fields.Str(
+        description="Alias",
+        required=False,
+        example="Barry",
+    )
+
+
+@docs(
+    tags=[SWAGGER_CATEGORY],
+)
+@response_schema(TenantRecordSchema(), 200, description="")
+@error_handler
+async def tenant_self(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    # we need the caller's wallet id
+    wallet_id = context.profile.settings.get("wallet.id")
+
+    # records are under base/root profile, use Tenant Manager profile
+    mgr = context.inject(TenantManager)
+    profile = mgr.profile
+
+    async with profile.session() as session:
+        # tenant's must always fetch by their wallet id.
+        rec = await TenantRecord.query_by_wallet_id(session, wallet_id)
+        LOGGER.info(rec)
+
+    return web.json_response(rec.serialize())
+
+
+@docs(tags=[SWAGGER_CATEGORY], summary="Register a Public DID")
+@querystring_schema(RegisterPublicDidSchema())
+@response_schema(schema=RegisterPublicDidSchema, code=200, description="")
+@error_handler
+async def register_public_did(request: web.BaseRequest):
+    LOGGER.info("> tenant_register_public_did()")
+    context: AdminRequestContext = request["context"]
+
+    # check if there is a public did
+    info = None
+    async with context.session() as session:
+        wallet = session.inject_or(BaseWallet)
+        if not wallet:
+            raise web.HTTPForbidden(reason="No wallet available")
+        try:
+            info = await wallet.get_public_did()
+        except WalletError as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+    if info:
+        raise web.HTTPConflict(reason=f"Wallet already has a public DID: `{info.did}`")
+
+    did = request.query.get("did")
+    verkey = request.query.get("verkey")
+    if not did or not verkey:
+        raise web.HTTPBadRequest(
+            reason="Request query must include both did and verkey"
+        )
+
+    alias = request.query.get("alias")
+    if not alias:
+        alias = context.profile.settings.get("wallet.id")
+
+    genesis_url = context.profile.settings.get("ledger.genesis_url")
+    did_registration_url = genesis_url.replace("genesis", "register")
+    data = {
+        "did": did,
+        "verkey": verkey,
+        "alias": alias,
+    }
+    requests.post(did_registration_url, json=data)
+    LOGGER.info(f"did_registration_url = {did_registration_url}, data = {data}")
+
+    LOGGER.info("< tenant_register_public_did()")
+    return web.json_response(data)
+
+
+@docs(tags=[SWAGGER_CATEGORY], summary="Get a tenant subwallet")
+@response_schema(WalletRecordSchema(), 200, description="")
+@error_handler
+async def tenant_wallet_get(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    # we need the caller's wallet id
+    wallet_id = context.profile.settings.get("wallet.id")
+
+    # records are under base/root profile, use Tenant Manager profile
+    mgr = context.inject(TenantManager)
+    profile = mgr.profile
+
+    # this is from multitenant / admin / routes.py -> wallet_get
+    # duplicate code.
+    async with profile.session() as session:
+        wallet_record = await WalletRecord.retrieve_by_id(session, wallet_id)
+    result = format_wallet_record(wallet_record)
+
+    return web.json_response(result)
+
+
+@docs(tags=[SWAGGER_CATEGORY], summary="Update tenant wallet")
+@request_schema(UpdateWalletRequestSchema)
+@response_schema(WalletRecordSchema(), 200, description="")
+@error_handler
+async def tenant_wallet_update(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    # we need the caller's wallet id
+    wallet_id = context.profile.settings.get("wallet.id")
+
+    # this is from multitenant / admin / routes.py -> wallet_update
+    # (mostly) duplicate code.
+    body = await request.json()
+    wallet_webhook_urls = body.get("wallet_webhook_urls")
+    wallet_dispatch_type = body.get("wallet_dispatch_type")
+    label = body.get("label")
+    image_url = body.get("image_url")
+
+    if all(
+        v is None for v in (wallet_webhook_urls, wallet_dispatch_type, label, image_url)
+    ):
+        raise web.HTTPBadRequest(reason="At least one parameter is required.")
+
+    # adjust wallet_dispatch_type according to wallet_webhook_urls
+    if wallet_webhook_urls and wallet_dispatch_type is None:
+        wallet_dispatch_type = "both"  # change from copied code (default)
+    if wallet_webhook_urls == []:
+        wallet_dispatch_type = "base"
+
+    # only parameters that are not none are updated
+    settings = {}
+    if wallet_webhook_urls is not None:
+        settings["wallet.webhook_urls"] = wallet_webhook_urls
+    if wallet_dispatch_type is not None:
+        settings["wallet.dispatch_type"] = wallet_dispatch_type
+    if label is not None:
+        settings["default_label"] = label
+    if image_url is not None:
+        settings["image_url"] = image_url
+
+    multitenant_mgr = context.profile.inject(BaseMultitenantManager)
+    wallet_record = await multitenant_mgr.update_wallet(wallet_id, settings)
+    result = format_wallet_record(wallet_record)
+
+    return web.json_response(result)
+
+
+async def register(app: web.Application):
+    """Register routes."""
+    LOGGER.info("> registering routes")
+    # routes that require a tenant token.
+    app.add_routes(
+        [
+            web.get("/tenant", tenant_self, allow_head=False),
+            web.post("/tenant/register-public-did", register_public_did),
+            web.get("/tenant/wallet", tenant_wallet_get, allow_head=False),
+            web.put("/tenant/wallet", tenant_wallet_update),
+        ]
+    )
+    LOGGER.info("< registering routes")
+
+
+def post_process_routes(app: web.Application):
+    """Amend swagger API."""
+
+    # Add top-level tags description
+    if "tags" not in app._state["swagger_dict"]:
+        app._state["swagger_dict"]["tags"] = []
+
+    app._state["swagger_dict"]["tags"].append(
+        {
+            "name": SWAGGER_CATEGORY,
+            "description": "Traction Tenant - tenant self administration (traction_innkeeper v1_0 plugin)",
+        }
+    )

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant_manager.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant_manager.py
@@ -46,17 +46,20 @@ class TenantManager:
         extra_settings: dict = {},
         tenant_id: str = None,
     ):
+        # this is from multitenant / admin / routes.py -> wallet_create
+        # (mostly) duplicate code.
+
         try:
             # we must stick with managed until AcaPy has full support for unmanaged.
             # transport/inbound/session.py only deals with managed.
             key_management_mode = WalletRecord.MODE_MANAGED
             wallet_webhook_urls = []
-            wallet_dispatch_type = "both"
+            wallet_dispatch_type = "base"  # use base notification until they add urls
 
             label = wallet_name  # use the name they provided as the label
 
-            unique_wallet_name = await self.get_unique_tenant_name(wallet_name, False)
-            if unique_wallet_name == wallet_name:
+            unique_wallet_name = await self.get_unique_wallet_name(wallet_name)
+            if unique_wallet_name != wallet_name:
                 # but... we have to change the actual wallet name
                 wallet_name = unique_wallet_name
 
@@ -202,48 +205,29 @@ class TenantManager:
             # else return None
             return None
 
-    async def get_unique_tenant_name(
-        self, tenant_name: str, check_reservations: bool = False
-    ):
-        self._logger.info(f"> get_unique_tenant_name('{tenant_name}')")
-        unique_tenant_name = tenant_name
+    async def get_unique_wallet_name(self, wallet_name: str):
+        self._logger.info(f"> get_unique_wallet_name('{wallet_name}')")
+        unique_wallet_name = wallet_name
         async with self._profile.session() as session:
-            r, t, w = await self.check_tables_for_tenant_name(
-                session, unique_tenant_name, check_reservations
-            )
+            w = await self.check_tables_for_wallet_name(session, unique_wallet_name)
             idx = 1
-            while r or t or w:
-                self._logger.info(
-                    f"'{unique_tenant_name}': reservation_exists = {r}, tenant_exists = {t}, wallet_exists = {w}"
-                )
-                unique_tenant_name = f"{unique_tenant_name}-{idx}"
-                r, t, w = await self.check_tables_for_tenant_name(
-                    session, unique_tenant_name
-                )
+            while w:
+                self._logger.info(f"'{unique_wallet_name}': wallet_exists = {w}")
+                unique_wallet_name = f"{unique_wallet_name}-{idx}"
+                w = await self.check_tables_for_wallet_name(session, unique_wallet_name)
                 idx += 1
         # return a unique wallet/tenant name, either the input or calculated...
         self._logger.info(
-            f"< get_unique_tenant_name('{tenant_name}') = '{unique_tenant_name}'"
+            f"< get_unique_wallet_name('{wallet_name}') = '{unique_wallet_name}'"
         )
-        return unique_tenant_name
+        return unique_wallet_name
 
-    async def check_tables_for_tenant_name(
-        self, session, tenant_name: str, check_reservations: bool = False
-    ):
-        if check_reservations:
-            reservation_records = await ReservationRecord.query(
-                session, {"tenant_name": tenant_name}
-            )
-            reservation_exists = len(reservation_records) > 0
-        else:
-            reservation_exists = False
-
-        wallet_records = await WalletRecord.query(session, {"wallet_name": tenant_name})
+    async def check_tables_for_wallet_name(self, session, wallet_name: str):
+        # we can add more tables here if need (ie reservations, tenants...)
+        wallet_records = await WalletRecord.query(session, {"wallet_name": wallet_name})
         wallet_exists = len(wallet_records) > 0
 
-        tenant_records = await TenantRecord.query(session, {"tenant_name": tenant_name})
-        tenant_exists = len(tenant_records) > 0
-        return reservation_exists, tenant_exists, wallet_exists
+        return wallet_exists
 
     async def get_wallet_and_tenant(self, wallet_id: str):
         self._logger.info(f"> get_wallet_and_tenant('{wallet_id}')")

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant_manager.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant_manager.py
@@ -104,9 +104,14 @@ class TenantManager:
         try:
             async with self._profile.session() as session:
                 wallet_record = await WalletRecord.retrieve_by_id(session, wallet_id)
+                tenant_name = (
+                    wallet_record.settings.get("default_label")
+                    if wallet_record.settings.get("default_label")
+                    else wallet_record.wallet_name
+                )
                 tenant: TenantRecord = TenantRecord(
                     tenant_id=tenant_id,
-                    tenant_name=wallet_record.wallet_name,
+                    tenant_name=tenant_name,
                     wallet_id=wallet_record.wallet_id,
                     new_with_id=tenant_id is not None,
                 )


### PR DESCRIPTION
API matches `GET` and `PUT` `/multitenancy/wallet/{wallet_id}` but under `/tenant/wallet` - so once logged in tenants can manage their own webhooks and label.  The multitenancy API was for admin use only and required the `x-api-key` only - no bearer tokens.

Also included is eliminating the requirement for a unique tenant name. The provided tenant name will become the default agent/wallet label and will be used for the wallet name.

Only the wallet name needs to be unique, so if the provided name is NOT, we just add `-N` until it is unique. ie `fred-5`.


Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>