### PR TITLE
Fix CORS errors with error response codes

### DIFF
--- a/plugins/docker/tenant-proxy.conf.template
+++ b/plugins/docker/tenant-proxy.conf.template
@@ -68,10 +68,10 @@ server {
         set $CORS_PREFLIGHT_CACHE_AGE 600;
 
         if ($request_method = 'OPTIONS') {
-            add_header Access-Control-Allow-Origin $CORS_ORIGIN;
+            add_header Access-Control-Allow-Origin $CORS_ORIGIN always ;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
             add_header Access-Control-Allow-Headers $http_access_control_request_headers;
-            add_header Access-Control-Allow-Credentials $CORS_CREDS;
+            add_header Access-Control-Allow-Credentials $CORS_CREDS always ;
 
             add_header Access-Control-Max-Age $CORS_PREFLIGHT_CACHE_AGE;
             add_header Content-Type 'text/plain; charset=utf-8';
@@ -79,10 +79,10 @@ server {
             return 204;
         }
         if ($request_method != 'OPTIONS') {
-            add_header Access-Control-Allow-Origin $CORS_ORIGIN;
+            add_header Access-Control-Allow-Origin $CORS_ORIGIN always ;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
             add_header Access-Control-Allow-Headers $http_access_control_request_headers;
-            add_header Access-Control-Allow-Credentials $CORS_CREDS;
+            add_header Access-Control-Allow-Credentials $CORS_CREDS always ;
         }
     }
 

--- a/services/tenant-ui/frontend/src/components/LoginForm.vue
+++ b/services/tenant-ui/frontend/src/components/LoginForm.vue
@@ -100,26 +100,28 @@ const handleSubmit = async (isFormValid: boolean) => {
     console.error(err);
     toast.error(`Failure getting token: ${err}`);
   }
-  try {
-    // token is loaded, now go fetch the global data about the tenant
-    await tenantStore.getSelf();
-    console.log(tenant.value);
-    // TODO: once we get response statuses working correctly again can re-configure this
-    // Don't throw errors since not-found and stuff is fine for non-issuers
+  if (token.value) {
     try {
-      // Find out issuer status when logging in
-      await Promise.all([
-        tenantStore.getEndorserConnection(),
-        tenantStore.getPublicDid(),
-      ]);
+      // token is loaded, now go fetch the global data about the tenant
+      await tenantStore.getSelf();
+      console.log(tenant.value);
+      // TODO: once we get response statuses working correctly again can re-configure this
+      // Don't throw errors since not-found and stuff is fine for non-issuers
+      try {
+        // Find out issuer status when logging in
+        await Promise.all([
+          tenantStore.getEndorserConnection(),
+          tenantStore.getPublicDid(),
+        ]);
+      } catch (err) {
+        console.error(err);
+      }
     } catch (err) {
       console.error(err);
+      toast.error(`Failure getting tenant: ${err}`);
+    } finally {
+      submitted.value = false;
     }
-  } catch (err) {
-    console.error(err);
-    toast.error(`Failure getting tenant: ${err}`);
-  } finally {
-    submitted.value = false;
   }
 };
 </script>

--- a/services/tenant-ui/frontend/src/components/reservation/Status.vue
+++ b/services/tenant-ui/frontend/src/components/reservation/Status.vue
@@ -18,6 +18,11 @@
         name="email"
         autofocus
         class="w-full"
+        :class="{
+          'p-invalid':
+            ($v.email.$invalid && submitted) ||
+            status === RESERVATION_STATUSES.NOT_FOUND,
+        }"
       />
       <span v-if="$v.email.$error && submitted">
         <span v-for="(error, index) of $v.email.$errors" :key="index">
@@ -41,6 +46,11 @@
         v-model="$v.reservationId.$model"
         name="reservationId"
         class="w-full"
+        :class="{
+          'p-invalid':
+            ($v.reservationId.$invalid && submitted) ||
+            status === RESERVATION_STATUSES.NOT_FOUND,
+        }"
       />
       <small v-if="$v.reservationId.$invalid && submitted" class="p-error">{{
         $v.reservationId.required.$message
@@ -59,6 +69,7 @@
     <CheckedIn v-else-if="status === RESERVATION_STATUSES.CHECKED_IN" />
     <Denied v-else-if="status === RESERVATION_STATUSES.DENIED" />
     <Pending v-else-if="status === RESERVATION_STATUSES.REQUESTED" />
+    <NotFound v-else-if="status === RESERVATION_STATUSES.NOT_FOUND" />
     <ShowWallet v-else-if="status === RESERVATION_STATUSES.SHOW_WALLET" />
   </div>
 </template>
@@ -80,6 +91,7 @@ import { storeToRefs } from 'pinia';
 import Approved from './status/Approved.vue';
 import CheckedIn from './status/CheckedIn.vue';
 import Denied from './status/Denied.vue';
+import NotFound from './status/NotFound.vue';
 import Pending from './status/Pending.vue';
 import ShowWallet from './status/ShowWallet.vue';
 import { RESERVATION_STATUSES } from '@/helpers/constants';
@@ -116,7 +128,8 @@ const handleSubmit = async (isFormValid: boolean) => {
       formFields.email
     );
   } catch (err) {
-    toast.error(`Failure checking status: ${err}`);
+    if (err === RESERVATION_STATUSES.NOT_FOUND)
+      toast.error(`Failure checking status: ${err}`);
   } finally {
     submitted.value = false;
   }

--- a/services/tenant-ui/frontend/src/components/reservation/Status.vue
+++ b/services/tenant-ui/frontend/src/components/reservation/Status.vue
@@ -128,8 +128,7 @@ const handleSubmit = async (isFormValid: boolean) => {
       formFields.email
     );
   } catch (err) {
-    if (err === RESERVATION_STATUSES.NOT_FOUND)
-      toast.error(`Failure checking status: ${err}`);
+    toast.error(`Failure checking status: ${err}`);
   } finally {
     submitted.value = false;
   }

--- a/services/tenant-ui/frontend/src/components/reservation/status/NotFound.vue
+++ b/services/tenant-ui/frontend/src/components/reservation/status/NotFound.vue
@@ -1,0 +1,8 @@
+<template>
+  <Message severity="error" :closable="false">
+    Incorrect Email or Reservation ID. Please try again.
+  </Message>
+</template>
+<script setup lang="ts">
+import Message from 'primevue/message';
+</script>

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -102,4 +102,6 @@ export const RESERVATION_STATUSES = {
   // Not an API status, but the state on the FE when just checked-in
   // so they can one-time see the wallet key
   SHOW_WALLET: 'show_wallet',
+  // Not API response but show on the FE when it 404s
+  NOT_FOUND: 'not_found',
 };

--- a/services/tenant-ui/frontend/src/store/reservationStore.ts
+++ b/services/tenant-ui/frontend/src/store/reservationStore.ts
@@ -93,8 +93,7 @@ export const useReservationStore = defineStore('reservation', () => {
         if (res.data) {
           // The API doesn't check email address against res ID but we can do it on the front end at least
           if (res.data.contact_email !== email) {
-            error.value =
-              'The email provided does not match with the email from the reservation ID.';
+            status.value = RESERVATION_STATUSES.NOT_FOUND;
           } else {
             reservation.value = res.data;
             status.value = res.data.state;
@@ -102,9 +101,13 @@ export const useReservationStore = defineStore('reservation', () => {
         }
       })
       .catch((err) => {
-        error.value = err;
-        console.log(error.value);
-        // TODO: detect 404 differently to display specifically that it can't be found?
+        if (err.response && err.response.status === 404) {
+          // Handle not founds for this as a status not an exception
+          status.value = RESERVATION_STATUSES.NOT_FOUND;
+        } else {
+          error.value = err;
+          console.log(error.value);
+        }
       })
       .finally(() => {
         loading.value = false;


### PR DESCRIPTION
NGINX wasn't returning response codes for error type responses because of CORS, so add the 'always' keyword which I think is the way to overcome that

http://nginx.org/en/docs/http/ngx_http_headers_module.html
```
Adds the specified field to a response header provided that the response code equals 200, 201 (1.3.10), 204, 206, 301, 302, 303, 304, 307 (1.1.16, 1.0.13), or 308 (1.13.0). Parameter value can contain variables.

There could be several add_header directives. These directives are inherited from the previous configuration level if and only if there are no add_header directives defined on the current level.

If the always parameter is specified (1.7.5), the header field will be added regardless of the response code.

```

Reference:
https://serverfault.com/questions/393532/allowing-cross-origin-requests-cors-on-nginx-for-404-responses