### PR TITLE
Update scripts to work with Docker Compose V2

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,6 +133,14 @@ cd ../../scripts
 docker compose up
 ```
 
+If there are still errors, try turning buildkit off. In the terminal where you are running your builds:
+
+```sh
+export DOCKER_BUILDKIT=0
+```
+
+Then try building again.
+
 ### stop
 This will leave the volume (data) intact and available on restart.
 

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -9,18 +9,23 @@ services:
     command: ngrok http traction-agent:${ACAPY_HTTP_PORT} --log stdout
 
   traction-acapy-image-builder:
+    pull_policy: build
     build:
       context: ../plugins
       dockerfile: ./docker/Dockerfile
-    image: traction-local:acapy
+    image: traction:plugins-acapy
     entrypoint: "/bin/bash"
     tty: true
 
   traction-agent:
+    pull_policy: build
     build:
       context: ../services/aca-py
       dockerfile: Dockerfile.acapy
+    image: traction:traction-agent
     depends_on:
+      traction-acapy-image-builder:
+        condition: service_started
       traction-db:
         condition: service_healthy
     environment:
@@ -84,10 +89,13 @@ services:
       retries: 5
     extra_hosts:
       - host.docker.internal:host-gateway
+  
   tenant-ui:
+    pull_policy: build
     build:
       context: ../services/tenant-ui
       dockerfile: Dockerfile
+    image: traction:tenant-ui
     depends_on:
       tenant-proxy:
         condition: service_started
@@ -110,10 +118,11 @@ services:
       - host.docker.internal:host-gateway
 
   tenant-proxy:
+    pull_policy: build
     build:
       context: ../plugins
       dockerfile: ./docker/Dockerfile.tenant-proxy
-    image: traction-local:tenant-proxy
+    image: traction:tenant-proxy
     depends_on:
       traction-agent:
         condition: service_started
@@ -127,9 +136,11 @@ services:
       - host.docker.internal:host-gateway
 
   endorser-api:
+    pull_policy: build
     build:
       context: ../services/endorser
       dockerfile: Dockerfile
+    image: traction:endorser-api
     depends_on:
       endorser-agent:
         condition: service_started

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -159,8 +159,6 @@ services:
       - ACAPY_WEBHOOK_URL_API_KEY=${ENDORSER_ACAPY_WEBHOOK_URL_API_KEY}
     ports:
       - ${ENDORSER_SERVICE_PORT}:5000
-    extra_hosts:
-      - host.docker.internal:host-gateway
     volumes:
       - ../services/endorser:/app:rw
     extra_hosts:

--- a/services/aca-py/Dockerfile.acapy
+++ b/services/aca-py/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM traction-local:acapy
+FROM traction:plugins-acapy
 
 USER root
 


### PR DESCRIPTION
Best attempt at having the scripts work in V1 and V2 of Docker Compose (which behave VERY differently).

1. Add more documentation on how to handle build errors and alternative paths for developers to build and stand up a local environment.
2. Standardize on local image names (`traction:<tag>`).

fixes #449 

Signed-off-by: Jason Sherman <tools@usingtechnolo.gy>

