### PR TITLE
Simple Tenant wallet settings form

### DIFF
--- a/services/tenant-ui/frontend/src/components/profile/ProfileButton.vue
+++ b/services/tenant-ui/frontend/src/components/profile/ProfileButton.vue
@@ -31,10 +31,10 @@ const items = [
     label: 'Profile',
     to: { name: 'Profile' },
   },
-  // {
-  //   label: 'Settings',
-  //   to: { name: 'Settings' },
-  // },
+  {
+    label: 'Settings',
+    to: { name: 'Settings' },
+  },
   {
     label: 'Developer',
     visible: config.value.frontend.showDeveloper,

--- a/services/tenant-ui/frontend/src/components/profile/issuance/PublicDid.vue
+++ b/services/tenant-ui/frontend/src/components/profile/issuance/PublicDid.vue
@@ -29,10 +29,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import InputSwitch from 'primevue/inputswitch';
-import InputText from 'primevue/inputtext';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
+import InputSwitch from 'primevue/inputswitch';
+import InputText from 'primevue/inputtext';
 import VueJsonPretty from 'vue-json-pretty';
 import { useToast } from 'vue-toastification';
 // State

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -67,6 +67,7 @@ export const API_PATH = {
   TENANT_ENDORSER_INFO: '/tenant/endorser-info',
   TENANT_REGISTER_PUBLIC_DID: '/tenant/register-public-did',
   TENANT_TOKEN: '/tenant/token',
+  TENANT_WALLET: '/tenant/wallet',
 
   WALLET_DID_PUBLIC: '/wallet/did/public',
   WALLET_DID_CREATE: '/wallet/did/create',

--- a/services/tenant-ui/frontend/src/store/tenantStore.ts
+++ b/services/tenant-ui/frontend/src/store/tenantStore.ts
@@ -258,7 +258,7 @@ export const useTenantStore = defineStore('tenant', () => {
     return tenantWallet.value;
   }
 
-  async function updateTenantSubWallet(payload: Object) {
+  async function updateTenantSubWallet(payload: object) {
     console.log('> tenantStore.updateTenantSubWallet');
     error.value = null;
     loading.value = true;

--- a/services/tenant-ui/frontend/src/store/tenantStore.ts
+++ b/services/tenant-ui/frontend/src/store/tenantStore.ts
@@ -14,7 +14,7 @@ export const useTenantStore = defineStore('tenant', () => {
   const endorserInfo: any = ref(null);
   const publicDid: any = ref(null);
   const publicDidRegistrationProgress: Ref<string> = ref('');
-  const tenantConfig: any = ref(null);
+  const tenantWallet: any = ref(null);
 
   const { token } = storeToRefs(useTokenStore());
   const acapyApi = useAcapyApi();
@@ -232,6 +232,32 @@ export const useTenantStore = defineStore('tenant', () => {
     }
   }
 
+  async function getTenantSubWallet() {
+    console.log('> tenantStore.getSubWallet');
+    error.value = null;
+    loading.value = true;
+
+    await acapyApi
+      .getHttp(API_PATH.TENANT_WALLET)
+      .then((res: any) => {
+        tenantWallet.value = res.data;
+      })
+      .catch((err) => {
+        error.value = err;
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< tenantStore.getSubWallet');
+
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return tenantWallet.value;
+  }
+
   return {
     loading,
     loadingIssuance,
@@ -242,8 +268,8 @@ export const useTenantStore = defineStore('tenant', () => {
     publicDid,
     tenantReady,
     isIssuer,
-    tenantConfig,
     publicDidRegistrationProgress,
+    tenantWallet,
     getSelf,
     clearTenant,
     getEndorserConnection,
@@ -251,6 +277,7 @@ export const useTenantStore = defineStore('tenant', () => {
     connectToEndorser,
     getPublicDid,
     registerPublicDid,
+    getTenantSubWallet,
   };
 });
 

--- a/services/tenant-ui/frontend/src/store/tenantStore.ts
+++ b/services/tenant-ui/frontend/src/store/tenantStore.ts
@@ -258,6 +258,30 @@ export const useTenantStore = defineStore('tenant', () => {
     return tenantWallet.value;
   }
 
+  async function updateTenantSubWallet(payload: Object) {
+    console.log('> tenantStore.updateTenantSubWallet');
+    error.value = null;
+    loading.value = true;
+
+    await acapyApi
+      .putHttp(API_PATH.TENANT_WALLET, payload)
+      .then((res) => {
+        console.log(res);
+      })
+      .catch((err) => {
+        error.value = err;
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< tenantStore.updateTenantSubWallet');
+
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+  }
+
   return {
     loading,
     loadingIssuance,
@@ -278,6 +302,7 @@ export const useTenantStore = defineStore('tenant', () => {
     getPublicDid,
     registerPublicDid,
     getTenantSubWallet,
+    updateTenantSubWallet,
   };
 });
 

--- a/services/tenant-ui/frontend/src/views/tenant/Settings.vue
+++ b/services/tenant-ui/frontend/src/views/tenant/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3 class="mt-0">Tenant Settings</h3>
+  <h3 class="mt-0">Tenant Wallet Settings</h3>
   <SettingsForm />
 </template>
 


### PR DESCRIPTION
Signed-off-by: Lucas ONeil <lucasoneil@gmail.com>

A tenant for the PR if you want to see it:
https://pr-463-tenant-ui-dev.apps.silver.devops.gov.bc.ca/
fbb04dab-59a0-4878-9175-a6071f3380b1
78d0be9f-2559-4ed1-9c8d-1f8bf2b412d6

Allow the tenant user to fetch and update the wallet settings using the plugin endpoint https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca/api/doc#/traction-tenant/put_tenant_wallet
(this opens the multitenancy wallet settings endpoint up to specific tenant access)

Add back in the simple settings page in the tenant UI under the profile button.
Couple UX caveats

-  Have a UX ticket (https://github.com/bcgov/traction/issues/451) to discuss with Guru around add/remove multiple webhooks if we want to handle that, so just doing a single webhook in this PR, everything is a 1 item array.
- Label updates, but the Tenant UI is still using the tenant NAME as the display name from /tenant, can discuss if that should fetch from the label instead...

![image](https://user-images.githubusercontent.com/17445138/218227412-2506e549-4c41-47fb-b499-13efd76d6371.png)
