### PR TITLE
AcaPy Liveness Probe

### DIFF
--- a/charts/traction/templates/acapy_deployment.yaml
+++ b/charts/traction/templates/acapy_deployment.yaml
@@ -151,7 +151,7 @@ spec:
               path: /status/live
               port: 8031
             initialDelaySeconds: 90
-            periodSeconds: 3
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /status/ready


### PR DESCRIPTION
Having issues with pods timing out over long calls (ie create cred def), lengthen time between liveness probes.

Try 10 seconds to match DTS team settings.