### PR TITLE
Openshift network policies for Traction

### DIFF
--- a/charts/tenant-ui/templates/tenant_ui_nsp.yaml
+++ b/charts/tenant-ui/templates/tenant_ui_nsp.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.global.nsp.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tenant_ui.fullname" . }}-ingress-nsp
+  labels:
+    {{- include "tenant_ui.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tenant_ui.selectorLabels" . | nindent 6 }}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+{{- end }}

--- a/charts/tenant-ui/values-e79518-dev.yaml
+++ b/charts/tenant-ui/values-e79518-dev.yaml
@@ -1,0 +1,35 @@
+global:
+  fullnameOverride: 'tenant-ui-dts'
+  tractionNameOverride: "traction-dts"
+  ingressSuffix: -dev.apps.silver.devops.gov.bc.ca
+  nsp:
+    enabled: true
+tenant_ui:
+  image:
+    tag: 'ghcr.io/bcgov/traction-tenant-ui:sha-360c2f3'
+    version: 'sha-360c2f3'
+    buildtime: '2023-02-22T06:39:56.325Z'
+    pullPolicy: Always
+  traction_api:
+    endpoint: https://traction-dts-tenant-proxy-dev.apps.silver.devops.gov.bc.ca
+  tenant_proxy:
+    endpoint: https://traction-dts-tenant-proxy-dev.apps.silver.devops.gov.bc.ca
+  oidc:
+    active: true
+    showInnkeeperAdminLogin: true
+    authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
+    jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
+  ariesDetails:
+    ledgerDescription: 'bcovrin-test'
+  smtp:
+    server: apps.smtp.gov.bc.ca
+    port: 25
+    senderAddress: DoNotReplyTractionPR@gov.bc.ca
+    innkeeperInbox: lucas.oneil@gov.bc.ca
+  resources:
+    limits:
+      cpu: 200m
+      memory: 820Mi
+    requests:
+      cpu: 120m
+      memory: 400Mi

--- a/charts/tenant-ui/values.yaml
+++ b/charts/tenant-ui/values.yaml
@@ -21,6 +21,10 @@ global:
     # -- If true, the Postgres chart is deployed
     deployPostgres: true
 
+  # if true, run the Network Policy charts
+  nsp:
+    enabled: false
+
 tenant_ui:
   image:
     tag: "ghcr.io/bcgov/traction-tenant-ui:sha-5fdc664"

--- a/charts/traction/templates/acapy_ingress_nsp.yaml
+++ b/charts/traction/templates/acapy_ingress_nsp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.nsp.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -15,3 +16,4 @@ spec:
               network.openshift.io/policy-group: ingress
   policyTypes:
     - Ingress
+{{- end }}

--- a/charts/traction/templates/acapy_ingress_nsp.yaml
+++ b/charts/traction/templates/acapy_ingress_nsp.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "acapy.fullname" . }}-ingress-nsp
+  labels:
+    {{- include "acapy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "acapy.selectorLabels" . | nindent 6 }}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress

--- a/charts/traction/templates/tenant_proxy_ingress_nsp.yaml
+++ b/charts/traction/templates/tenant_proxy_ingress_nsp.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "global.fullname" . }}-ingress-nsp
+  labels:
+    {{- include "common.selectorLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tenant_proxy.selectorLabels" . | nindent 6 }}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress

--- a/charts/traction/templates/tenant_proxy_ingress_nsp.yaml
+++ b/charts/traction/templates/tenant_proxy_ingress_nsp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.nsp.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -15,3 +16,4 @@ spec:
               network.openshift.io/policy-group: ingress
   policyTypes:
     - Ingress
+{{- end }}

--- a/charts/traction/templates/traction_internal_nsp.yaml
+++ b/charts/traction/templates/traction_internal_nsp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.nsp.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -13,3 +14,4 @@ spec:
     - podSelector:
         matchLabels:
           'app.kubernetes.io/instance': {{ template "global.fullname" . }}
+{{- end }}

--- a/charts/traction/templates/traction_internal_nsp.yaml
+++ b/charts/traction/templates/traction_internal_nsp.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "global.fullname" . }}-nsp
+  labels:
+    {{- include "common.selectorLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      'app.kubernetes.io/instance': {{ template "global.fullname" . }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          'app.kubernetes.io/instance': {{ template "global.fullname" . }}

--- a/charts/traction/values-e79518-dev.yaml
+++ b/charts/traction/values-e79518-dev.yaml
@@ -1,6 +1,8 @@
 global:
   fullnameOverride: "traction-dts"
   ingressSuffix: -dev.apps.silver.devops.gov.bc.ca
+  nsp:
+    enabled: true
 acapy:
   image:
     tag: "ghcr.io/bcgov/traction-plugins-acapy:sha-4f98641"

--- a/charts/traction/values-e79518-dev.yaml
+++ b/charts/traction/values-e79518-dev.yaml
@@ -1,0 +1,42 @@
+global:
+  fullnameOverride: "traction-dts"
+  ingressSuffix: -dev.apps.silver.devops.gov.bc.ca
+acapy:
+  image:
+    tag: "ghcr.io/bcgov/traction-plugins-acapy:sha-4f98641"
+    version: 'sha-4f98641'
+    buildtime: '2023-02-16T21:45:48.653Z'
+    pullPolicy: Always
+  secret:
+    adminurl:
+      generated: false
+    pluginInnkeeper:
+      generated: false
+  pluginValues:
+    tractionInnkeeper:
+      printKey: true
+      printToken: true
+  resources:
+    limits:
+      cpu: 200m
+      memory: 820Mi
+    requests:
+      cpu: 120m
+      memory: 400Mi
+  tails:
+    enabled: true
+postgresql:
+  fullnameOverride: 'traction-dts'
+  resources:
+    limits:
+      cpu: 200m
+      memory: 820Mi
+    requests:
+      cpu: 120m
+      memory: 400Mi
+tenant_proxy:
+  image:
+    tag: "ghcr.io/bcgov/traction-tenant-proxy:sha-4f98641"
+    version: 'sha-4f98641'
+    buildtime: "2023-02-16T21:45:38.860Z"
+    pullPolicy: Always

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -22,6 +22,9 @@ global:
   # -- The used ledger. Will be used for default values.
   ledger: bcovrin-test
 
+  nsp:
+    enabled: false
+
 acapy:
   image:
     # building our own acapy with plugins


### PR DESCRIPTION
Deployed Traction to completely different Openshift namespaces and discovered that we need some network policies. Our namespaces had some pretty liberal ingress policies which may not be in place elsewhere.

Also, added a values for (manually) deploying an instance to a new namespace. The resource allocation is the same as a PR (as in... not much given).