### PR TITLE
Show /plugins list

### DIFF
--- a/services/tenant-ui/frontend/src/components/about/Acapy.vue
+++ b/services/tenant-ui/frontend/src/components/about/Acapy.vue
@@ -37,15 +37,36 @@
       {{ config.frontend.ariesDetails.tailsServer }}
     </div>
   </div>
+
+  <div class="grid mt-4">
+    <div class="col-12 md:col-6 lg:col-4">
+      <Accordion>
+        <AccordionTab header="List of Installed Plugins">
+          <div v-if="loading" class="flex justify-content-center">
+            <ProgressSpinner />
+          </div>
+          <vue-json-pretty v-else :data="acapyPlugins" />
+        </AccordionTab>
+      </Accordion>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { useConfigStore } from '@/store/configStore';
 import { useI18n } from 'vue-i18n';
+// PrimeVue
+import Accordion from 'primevue/accordion';
+import AccordionTab from 'primevue/accordiontab';
+import ProgressSpinner from 'primevue/progressspinner';
+import VueJsonPretty from 'vue-json-pretty';
 
 const { t } = useI18n();
-const { config } = storeToRefs(useConfigStore());
+const { acapyPlugins, config, loading } = storeToRefs(useConfigStore());
+const configStore = useConfigStore();
+
+configStore.getPluginList();
 </script>
 
 <style scoped>

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -79,6 +79,8 @@ export const API_PATH = {
   WALLET_DID_PUBLIC: '/wallet/did/public',
   WALLET_DID_CREATE: '/wallet/did/create',
 
+  SERVER_PLUGINS: '/plugins',
+
   // Legacy (to be removed)
 
   HOLDER_CREDENTIALS: '/tenant/v1/holder/credentials/',

--- a/services/tenant-ui/frontend/src/store/configStore.ts
+++ b/services/tenant-ui/frontend/src/store/configStore.ts
@@ -1,10 +1,14 @@
+import { AdminModules } from '@/types/acapyApi/acapyInterface';
+
+import { Ref, ref } from 'vue';
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
 import axios from 'axios';
 import { API_PATH } from '@/helpers/constants';
+import { fetchList } from './utils';
 
 export const useConfigStore = defineStore('config', () => {
   // state
+  const acapyPlugins: Ref<AdminModules[]> = ref([]);
   const config: any = ref(null);
   const loading: any = ref(false);
   const error: any = ref(null);
@@ -54,7 +58,19 @@ export const useConfigStore = defineStore('config', () => {
     return config.value;
   }
 
-  return { config, loading, error, load, proxyPath };
+  async function getPluginList() {
+    return fetchList(API_PATH.SERVER_PLUGINS, acapyPlugins, error, loading);
+  }
+
+  return {
+    acapyPlugins,
+    config,
+    loading,
+    error,
+    load,
+    proxyPath,
+    getPluginList,
+  };
 });
 
 export default {

--- a/services/tenant-ui/frontend/src/store/utils/fetchList.ts
+++ b/services/tenant-ui/frontend/src/store/utils/fetchList.ts
@@ -29,9 +29,12 @@ export async function fetchListFromAPI(
   await api
     .getHttp(url, params)
     .then((res: AxiosRequestConfig): void => {
-      // console.log(res);
-      list.value = res.data.results;
-      // console.log(list.value);
+      if (res.data.results) {
+        list.value = res.data.results;
+      } else if (res.data.result) {
+        // Some lists have it singular
+        list.value = res.data.result;
+      }
     })
     .catch((err: string): void => {
       error.value = err;


### PR DESCRIPTION
On the About page (Tenant or Innkeeper) in the ACA-Py section fetch the plugins by calling ACA-Py `/plugins`

![image](https://user-images.githubusercontent.com/17445138/220806283-311c255b-309b-455d-bfb0-d4741fa9527f.png)

![image](https://user-images.githubusercontent.com/17445138/220806300-e7a18eab-8612-4d8c-a593-58b977ddc37a.png)
