### PR TITLE
Edit a connection alias using new plugin

### DIFF
--- a/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/Contacts.vue
@@ -51,7 +51,7 @@
           :disabled="deleteDisabled(data.alias)"
           @click="deleteContact($event, data.connection_id)"
         />
-        <!-- <EditContact :id="data.connection_id" /> -->
+        <EditContact :connection-id="data.connection_id" />
       </template>
     </Column>
     <Column :sortable="true" field="alias" header="Alias" />
@@ -90,7 +90,7 @@ import { storeToRefs } from 'pinia';
 import AcceptInvitation from './acceptInvitation/AcceptInvitation.vue';
 // import AcceptInvitation from './acceptInvitation/AcceptInvitation.vue';
 import DidExchange from './didExchange/DidExchange.vue';
-// import EditContact from './editContact/EditContact.vue';
+import EditContact from './editContact/EditContact.vue';
 import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';
 import { TABLE_OPT, API_PATH } from '@/helpers/constants';

--- a/services/tenant-ui/frontend/src/components/contacts/editContact/EditContact.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/editContact/EditContact.vue
@@ -1,17 +1,21 @@
 <template>
   <Button
-    title="Edit Contact"
+    title="Edit Connection"
     icon="pi pi-pencil"
     class="p-button-rounded p-button-icon-only p-button-text"
     @click="openModal"
   />
   <Dialog
     v-model:visible="displayModal"
-    header="Edit Contact"
+    :style="{ minWidth: '500px' }"
+    header="Edit Connection"
     :modal="true"
     @update:visible="handleClose"
   >
-    <EditContactForm :contact-id="props.contactId" @closed="handleClose" />
+    <EditContactForm
+      :connection-id="props.connectionId"
+      @closed="handleClose"
+    />
   </Dialog>
 </template>
 
@@ -26,7 +30,7 @@ import EditContactForm from './EditContactForm.vue';
 
 // Props
 const props = defineProps({
-  contactId: {
+  connectionId: {
     type: String as PropType<string>,
     required: true,
   },

--- a/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
@@ -6,10 +6,11 @@
     <!-- Alias -->
     <div class="field">
       <label for="alias" :class="{ 'p-error': v$.alias.$invalid && submitted }">
-        Contact Alias
+        Alias
       </label>
       <InputText
         v-model="v$.alias.$model"
+        class="w-full"
         :class="{ 'p-invalid': v$.alias.$invalid && submitted }"
         type="text"
         name="alias"
@@ -48,7 +49,7 @@ import { useToast } from 'vue-toastification';
 
 // Props
 const props = defineProps({
-  contactId: {
+  connectionId: {
     type: String as PropType<string>,
     required: true,
   },
@@ -76,11 +77,11 @@ const handleSubmit = async (isFormValid: boolean) => {
   }
 
   try {
-    // await contactsStore.updateContact(props.contactId, formFields.alias);
+    await contactsStore.updateConnection(props.connectionId, formFields.alias);
     emit('success');
     // close up on success
     emit('closed');
-    toast.info('Contact Updated');
+    toast.info('Connection Updated');
   } catch (error) {
     toast.error(`Failure: ${error}`);
   } finally {
@@ -92,7 +93,7 @@ const handleSubmit = async (isFormValid: boolean) => {
 const { loading, item, fetchItem } = useGetItem(API_PATH.CONNECTIONS);
 onMounted(async () => {
   try {
-    await fetchItem(props.contactId);
+    await fetchItem(props.connectionId);
     console.log(item.value.alias);
     formFields.alias = item.value.alias;
   } catch (error: any) {

--- a/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/editContact/EditContactForm.vue
@@ -25,7 +25,7 @@
 
     <div v-if="item" class="flex justify-content-end mb-0 mt-3">
       <small>
-        Contact Last Updated: {{ formatDateLong(item.updated_at) }}
+        Connection Last Updated: {{ formatDateLong(item.updated_at) }}
       </small>
     </div>
   </form>

--- a/services/tenant-ui/frontend/src/store/contactsStore.ts
+++ b/services/tenant-ui/frontend/src/store/contactsStore.ts
@@ -1,4 +1,8 @@
 import { API_PATH, CONNECTION_STATUSES } from '@/helpers/constants';
+import {
+  ConnRecord,
+  UpdateConnectionRequest,
+} from '@/types/acapyApi/acapyInterface';
 import { defineStore } from 'pinia';
 import { computed, ref, Ref } from 'vue';
 import { useAcapyApi } from './acapyApi';
@@ -174,39 +178,39 @@ export const useContactsStore = defineStore('contacts', () => {
     );
   }
 
-  // Only going to do alias right now but expand to other params as needed later
-  // async function updateContact(contactId: string, alias: string) {
-  //   console.log('> contactsStore.updateContact');
-  //   error.value = null;
-  //   loading.value = true;
+  // Only going to do alias right now but expand to other params if needed later
+  async function updateConnection(id: string, alias: string) {
+    console.log('> contactsStore.updateConnection');
+    error.value = null;
+    loading.value = true;
 
-  //   let contactData = null;
-  //   await acapyApi
-  //     .putHttp(`${API_PATH.CONTACTS}${contactId}`, {
-  //       contact_id: contactId,
-  //       alias,
-  //     })
-  //     .then((res) => {
-  //       contactData = res.data;
-  //     })
-  //     .then(() => {
-  //       listContacts();
-  //     })
-  //     .catch((err) => {
-  //       error.value = err;
-  //     })
-  //     .finally(() => {
-  //       loading.value = false;
-  //     });
-  //   console.log('< contactsStore.updateContact');
+    let updatedConnection: ConnRecord | null = null;
+    const payload: UpdateConnectionRequest = {
+      alias,
+    };
+    await acapyApi
+      .putHttp(API_PATH.CONNECTION(id), payload)
+      .then((res) => {
+        updatedConnection = res.data;
+      })
+      .then(() => {
+        listContacts();
+      })
+      .catch((err) => {
+        error.value = err;
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< contactsStore.updateConnection');
 
-  //   if (error.value != null) {
-  //     // throw error so $onAction.onError listeners can add their own handler
-  //     throw error.value;
-  //   }
-  //   // return data so $onAction.after listeners can add their own handler
-  //   return contactData;
-  // }
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return updatedConnection;
+  }
 
   async function didCreateRequest(did: string, alias: string, myLabel: string) {
     console.log('> contactsStore.didCreateRequest');
@@ -276,7 +280,7 @@ export const useContactsStore = defineStore('contacts', () => {
     deleteContact,
     getContact,
     getInvitation,
-    // updateContact,
+    updateConnection,
     didCreateRequest,
   };
 });

--- a/services/tenant-ui/frontend/src/types/acapyApi/acapyInterface.ts
+++ b/services/tenant-ui/frontend/src/types/acapyApi/acapyInterface.ts
@@ -605,6 +605,11 @@ export interface CredDefStorageList {
   results?: CredDefStorageRecord[];
 }
 
+export interface CredDefStorageOperationResponse {
+  /** True if operation successful, false if otherwise */
+  success: boolean;
+}
+
 export interface CredDefStorageRecord {
   /**
    * Time of record creation
@@ -2642,16 +2647,6 @@ export interface OobRecord {
   updated_at?: string;
 }
 
-export interface OperationResponse {
-  /** True if operation successful, false if otherwise */
-  success: boolean;
-}
-
-export interface OperationResponse1 {
-  /** True if operation successful, false if otherwise */
-  success: boolean;
-}
-
 export interface PerformRequest {
   /**
    * Menu option name
@@ -3203,6 +3198,11 @@ export interface SchemaStorageList {
   results?: SchemaStorageRecord[];
 }
 
+export interface SchemaStorageOperationResponse {
+  /** True if operation successful, false if otherwise */
+  success: boolean;
+}
+
 export interface SchemaStorageRecord {
   /**
    * Time of record creation
@@ -3503,6 +3503,14 @@ export interface TxnOrSchemaSendResult {
   sent?: SchemaSendResult;
   /** Schema transaction to endorse */
   txn?: TransactionRecord;
+}
+
+export interface UpdateConnectionRequest {
+  /**
+   * Optional alias to apply to connection for later use
+   * @example "Bob, providing quotes"
+   */
+  alias?: string;
 }
 
 export interface UpdateWalletRequest {


### PR DESCRIPTION
Using the PUT endpoint added by the new plugin from https://github.com/bcgov/traction/issues/490, edit a connection and set alias through the connections table.

Regenerate Types to use this new endpoint model and pick up the other couple plugin changes.

![image](https://user-images.githubusercontent.com/17445138/221326851-a950bda5-f7cb-4fbc-9c12-69712dccaa9e.png)
