### PR TITLE
Credential revocation (and exchange delete)

### DIFF
--- a/services/tenant-ui/frontend/src/assets/tenantuiComponents.scss
+++ b/services/tenant-ui/frontend/src/assets/tenantuiComponents.scss
@@ -34,6 +34,7 @@
   }
 
   /* red */
+  &.credential-revoked,
   &.error,
   &.denied,
   &.rejected,

--- a/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/IssuedCredentials.vue
@@ -12,6 +12,8 @@
     :rows-per-page-options="TABLE_OPT.ROWS_OPTIONS"
     selection-mode="single"
     data-key="credential_exchange_id"
+    sort-field="created_at"
+    :sort-order="-1"
   >
     <template #header>
       <div class="flex justify-content-between">
@@ -38,27 +40,18 @@
     <template #empty> No records found. </template>
     <template #loading> Loading data. Please wait... </template>
     <Column :expander="true" header-style="width: 3rem" />
-    <!-- <Column header="Actions">
+    <Column header="Actions">
       <template #body="{ data }">
-        <Button
-          title="Delete Credential"
-          icon="pi pi-trash"
-          class="p-button-rounded p-button-icon-only p-button-text mr-2"
-          @click="deleteCredential($event, data)"
+        <DeleteCredentialExchangeButton
+          :cred-exch-id="data.credential_exchange_id"
         />
-        <Button
-          v-if="
-            data.credential_template &&
-            data.credential_template.revocation_enabled &&
-            !data.revoked
-          "
-          title="Revoke Credential"
-          icon="pi pi-times-circle"
-          class="p-button-rounded p-button-icon-only p-button-text"
-          @click="revokeCredential($event, data)"
+
+        <RevokeCredentialButton
+          :cred-exch-record="data"
+          :connection-display="findConnectionName(data.connection_id)"
         />
       </template>
-    </Column> -->
+    </Column>
     <Column
       :sortable="true"
       field="credential_definition_id"
@@ -104,14 +97,15 @@ import { useToast } from 'vue-toastification';
 import { useConfirm } from 'primevue/useconfirm';
 import { useI18n } from 'vue-i18n';
 // Other Components
-import OfferCredential from './offerCredential/OfferCredential.vue';
-import RowExpandData from '../common/RowExpandData.vue';
 import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
+import DeleteCredentialExchangeButton from './deleteCredential/DeleteCredentialExchangeButton.vue';
+import OfferCredential from './offerCredential/OfferCredential.vue';
+import RevokeCredentialButton from './deleteCredential/RevokeCredentialButton.vue';
+import RowExpandData from '../common/RowExpandData.vue';
 import StatusChip from '../common/StatusChip.vue';
 
 const toast = useToast();
-const confirm = useConfirm();
 const { t } = useI18n();
 
 const contactsStore = useContactsStore();
@@ -121,50 +115,6 @@ const issuerStore = useIssuerStore();
 const { loading, credentials, selectedCredential } = storeToRefs(
   useIssuerStore()
 );
-
-// Delete a specific cred
-// const deleteCredential = (event: any, data: any) => {
-//   confirm.require({
-//     target: event.currentTarget,
-//     message: 'Are you sure you want to DELETE this credential?',
-//     header: 'Confirmation',
-//     icon: 'pi pi-exclamation-triangle',
-//     accept: () => {
-//       issuerStore
-//         .deleteCredential(data.issuer_credential_id)
-//         .then(() => {
-//           toast.success(`Credential deleted`);
-//         })
-//         .catch((err) => {
-//           console.error(err);
-//           toast.error(`Failure: ${err}`);
-//         });
-//     },
-//   });
-// };
-
-// Revoke a specific cred
-const revokeCredential = (event: any, data: any) => {
-  confirm.require({
-    target: event.currentTarget,
-    message: 'Are you sure you want to REVOKE this credential?',
-    header: 'Confirmation',
-    icon: 'pi pi-exclamation-triangle',
-    accept: () => {
-      issuerStore
-        .revokeCredential({
-          issuer_credential_id: data.issuer_credential_id,
-        })
-        .then(() => {
-          toast.success(`Credential revoked`);
-        })
-        .catch((err) => {
-          console.error(err);
-          toast.error(`Failure: ${err}`);
-        });
-    },
-  });
-};
 
 // Get the credentials
 const loadTable = async () => {

--- a/services/tenant-ui/frontend/src/components/issuance/deleteCredential/DeleteCredentialExchangeButton.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/deleteCredential/DeleteCredentialExchangeButton.vue
@@ -1,0 +1,52 @@
+<template>
+  <Button
+    :title="t('issue.delete.removeExchange')"
+    icon="pi pi-trash"
+    class="p-button-rounded p-button-icon-only p-button-text mr-2"
+    @click="deleteCredExchange($event)"
+  />
+</template>
+
+<script setup lang="ts">
+// State
+import { useIssuerStore } from '@/store';
+// PrimeVue/etc
+import Button from 'primevue/button';
+import { useToast } from 'vue-toastification';
+import { useConfirm } from 'primevue/useconfirm';
+import { useI18n } from 'vue-i18n';
+
+const toast = useToast();
+const confirm = useConfirm();
+const { t } = useI18n();
+
+const issuerStore = useIssuerStore();
+
+// Props
+const props = defineProps<{
+  credExchId: string;
+}>();
+
+// Delete a specific cred excch record
+const deleteCredExchange = (event: any) => {
+  confirm.require({
+    target: event.currentTarget,
+    message: t('issue.delete.confirm'),
+    header: 'Confirmation',
+    icon: 'pi pi-exclamation-triangle',
+    accept: () => {
+      issuerStore
+        .deleteCredentialExchange(props.credExchId)
+        .then(() => {
+          toast.success(t('issue.delete.success'));
+        })
+        .catch((err) => {
+          console.error(err);
+          toast.error(`Failure: ${err}`);
+        });
+    },
+  });
+};
+</script>
+
+<style scoped></style>

--- a/services/tenant-ui/frontend/src/components/issuance/deleteCredential/RevokeCredentialButton.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/deleteCredential/RevokeCredentialButton.vue
@@ -1,0 +1,65 @@
+<template>
+  <Button
+    v-if="canRevoke"
+    :title="t('issue.revoke.revokeCred')"
+    icon="pi pi-times-circle"
+    class="p-button-rounded p-button-icon-only p-button-text"
+    @click="openModal"
+  />
+  <Dialog
+    v-model:visible="displayModal"
+    :style="{ width: '500px' }"
+    :header="t('issue.revoke.revokeCred')"
+    :modal="true"
+    @update:visible="handleClose"
+  >
+    <RevokeCredentialForm
+      :connection-display="props.connectionDisplay"
+      :cred-exch-record="props.credExchRecord"
+      @success="$emit('success')"
+      @closed="handleClose"
+    />
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+// Types
+import { V10CredentialExchange } from '@/types/acapyApi/acapyInterface';
+
+// Vue/State
+import { computed, ref } from 'vue';
+// PrimeVue/etc
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
+import { useI18n } from 'vue-i18n';
+// Components
+import RevokeCredentialForm from './RevokeCredentialForm.vue';
+
+const { t } = useI18n();
+
+defineEmits(['success']);
+
+// Props
+const props = defineProps<{
+  credExchRecord: V10CredentialExchange;
+  connectionDisplay: string;
+}>();
+
+// Check revocation allowed
+const canRevoke = computed(() => {
+  return (
+    props.credExchRecord.state === 'credential_acked' &&
+    props.credExchRecord.revocation_id &&
+    props.credExchRecord.revoc_reg_id
+  );
+});
+
+// Display form
+const displayModal = ref(false);
+const openModal = async () => {
+  displayModal.value = true;
+};
+const handleClose = async () => {
+  displayModal.value = false;
+};
+</script>

--- a/services/tenant-ui/frontend/src/components/issuance/deleteCredential/RevokeCredentialForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/deleteCredential/RevokeCredentialForm.vue
@@ -1,0 +1,133 @@
+<template>
+  <form @submit.prevent="handleSubmit(!v$.$invalid)">
+    <!-- Comment -->
+    <div class="field">
+      <label
+        for="comment"
+        :class="{ 'p-error': v$.comment.$invalid && submitted }"
+      >
+        {{ t('issue.revoke.comment') }}
+      </label>
+      <Textarea
+        id="comment"
+        v-model="v$.comment.$model"
+        class="w-full"
+        :class="{ 'p-invalid': v$.comment.$invalid && submitted }"
+        :auto-resize="true"
+        rows="2"
+      />
+      <span v-if="v$.comment.$error && submitted">
+        <span v-for="(error, index) of v$.comment.$errors" :key="index">
+          <small class="p-error block">{{ error.$message }}</small>
+        </span>
+      </span>
+      <small v-else-if="v$.comment.$invalid && submitted" class="p-error">{{
+        v$.comment.required.$message
+      }}</small>
+    </div>
+
+    <div class="rev-details">
+      <p>
+        <small>Connection: {{ props.connectionDisplay }}</small>
+      </p>
+      <p>
+        <small>Revocation ID: {{ props.credExchRecord.revocation_id }}</small>
+      </p>
+      <p>
+        <small>
+          Revocation Registry: {{ props.credExchRecord.revoc_reg_id }}
+        </small>
+      </p>
+    </div>
+    <Button
+      type="submit"
+      :label="t('issue.revoke.action')"
+      class="mt-5 w-full"
+      :disabled="loading"
+      :loading="loading"
+    />
+  </form>
+</template>
+
+<script setup lang="ts">
+// Types
+import {
+  RevokeRequest,
+  V10CredentialExchange,
+} from '@/types/acapyApi/acapyInterface';
+
+// Vue/State
+import { reactive, ref } from 'vue';
+import { useIssuerStore } from '@/store';
+import { storeToRefs } from 'pinia';
+// PrimeVue / Validation
+import Button from 'primevue/button';
+import Textarea from 'primevue/textarea';
+import { useVuelidate } from '@vuelidate/core';
+import { useToast } from 'vue-toastification';
+import { useI18n } from 'vue-i18n';
+
+const issuerStore = useIssuerStore();
+const { loading } = storeToRefs(useIssuerStore());
+
+const toast = useToast();
+const { t } = useI18n();
+
+const emit = defineEmits(['closed', 'success']);
+
+// Props
+const props = defineProps<{
+  credExchRecord: V10CredentialExchange;
+  connectionDisplay: string;
+}>();
+
+// Validation
+const formFields = reactive({
+  comment: '',
+});
+const rules = {
+  comment: {},
+};
+const v$ = useVuelidate(rules, formFields);
+
+// Form submission
+const submitted = ref(false);
+const handleSubmit = async (isFormValid: boolean) => {
+  submitted.value = true;
+  if (!isFormValid) {
+    return;
+  }
+
+  try {
+    const payload: RevokeRequest = {
+      comment: formFields.comment,
+      connection_id: props.credExchRecord.connection_id,
+      rev_reg_id: props.credExchRecord.revoc_reg_id,
+      cred_rev_id: props.credExchRecord.revocation_id,
+      publish: true,
+      notify: true,
+    };
+    await issuerStore.revokeCredential(payload);
+    emit('success');
+    // close up on success
+    emit('closed');
+    toast.success(t('issue.revoke.success'));
+  } catch (error) {
+    console.error(error);
+    toast.error(`Failure: ${error}`);
+  } finally {
+    submitted.value = false;
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.rev-details {
+  p {
+    margin: 0;
+    small {
+      word-break: break-all;
+    }
+  }
+}
+</style>

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -53,6 +53,7 @@ export const API_PATH = {
     `/innkeeper/reservations/${id}/deny`,
 
   ISSUE_CREDENTIAL_RECORDS: 'issue-credential/records',
+  ISSUE_CREDENTIAL_RECORD: (id: string) => `issue-credential/records/${id}`,
   ISSUE_CREDENTIAL_RECORDS_SEND_OFFER: (id: string) =>
     `issue-credential/records/${id}/send-offer`,
   ISSUE_CREDENTIALS_SEND_OFFER: 'issue-credential/send-offer',

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -34,7 +34,19 @@
   "issue": {
     "issuance": "Issuance",
     "credentials": "Issued/Offered Credentials",
-    "offer": "Offer Credential"
+    "offer": "Offer Credential",
+    "delete": {
+      "removeExchange": "Remove Credential Exchange Record",
+      "confirm": "Are you sure you want to DELETE this credential exchange record?",
+      "success": "Credential exchange record deleted"
+    },
+    "revoke": {
+      "revokeCred": "Revoke Credential",
+      "comment": "Optional Comment",
+      "action": "Revoke",
+      "confirm": "Are you sure you want to REVOKE this credential?",
+      "success": "Credential revoked"
+    }
   },
   "verify": {
     "verification": "Verification",

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -21,7 +21,19 @@
   "issue": {
     "issuance": "Issuance <FR>",
     "credentials": "Issued/Offered Credentials <FR>",
-    "offer": "Offer Credential <FR>"
+    "offer": "Offer Credential <FR>",
+    "delete": {
+      "removeExchange": "Remove Credential Exchange Record <FR>",
+      "confirm": "Are you sure you want to DELETE this credential exchange record? <FR>",
+      "success": "Credential exchange record deleted <FR>"
+    },
+    "revoke": {
+      "revokeCred": "Revoke Credential <FR>",
+      "comment": "Optional Comment <FR>",
+      "action": "Revoke <FR>",
+      "confirm": "Are you sure you want to REVOKE this credential? <FR>",
+      "success": "Credential revoked <FR>"
+    }
   },
   "verify": {
     "verification": "Verification <FR>",

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
@@ -21,7 +21,19 @@
   "issue": {
     "issuance": "Issuance <JP>",
     "credentials": "Issued/Offered Credentials <JP>",
-    "offer": "Offer Credential <JP>"
+    "offer": "Offer Credential <JP>",
+    "delete": {
+      "removeExchange": "Remove Credential Exchange Record <JP>",
+      "confirm": "Are you sure you want to DELETE this credential exchange record? <JP>",
+      "success": "Credential exchange record deleted <JP>"
+    },
+    "revoke": {
+      "revokeCred": "Revoke Credential <JP>",
+      "comment": "Optional Comment <JP>",
+      "action": "Revoke <JP>",
+      "confirm": "Are you sure you want to REVOKE this credential? <JP>",
+      "success": "Credential revoked <JP>"
+    }
   },
   "verify": {
     "verification": "Verification <JP>",

--- a/services/tenant-ui/frontend/src/store/issuerStore.ts
+++ b/services/tenant-ui/frontend/src/store/issuerStore.ts
@@ -1,3 +1,8 @@
+import {
+  RevocationModuleResponse,
+  RevokeRequest,
+} from '@/types/acapyApi/acapyInterface';
+
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { fetchList } from './utils/fetchList.js';
@@ -71,18 +76,15 @@ export const useIssuerStore = defineStore('issuer', () => {
     );
   }
 
-  async function revokeCredential(payload: any = {}) {
+  async function revokeCredential(payload: RevokeRequest) {
     console.log('> issuerStore.revokeCredential');
     error.value = null;
     loading.value = true;
 
-    let result = null;
+    let result: RevocationModuleResponse | null = null;
 
     await acapyApi
-      .postHttp(
-        API_PATH.ISSUER_CREDENTIAL_REVOKE(payload.issuer_credential_id),
-        payload
-      )
+      .postHttp(API_PATH.REVOCATION_REVOKE, payload)
       .then((res) => {
         result = res.data.item;
       })
@@ -105,37 +107,37 @@ export const useIssuerStore = defineStore('issuer', () => {
     return result;
   }
 
-  // async function deleteCredential(issuerCredentialId: string) {
-  //   console.log('> contactsStore.deleteCredential');
+  async function deleteCredentialExchange(credExchangeId: string) {
+    console.log('> contactsStore.deleteCredential');
 
-  //   error.value = null;
-  //   loading.value = true;
+    error.value = null;
+    loading.value = true;
 
-  //   let result = null;
+    let result = null;
 
-  //   await acapyApi
-  //     .deleteHttp(API_PATH.ISSUER_CREDENTIAL(issuerCredentialId))
-  //     .then((res) => {
-  //       result = res.data.item;
-  //     })
-  //     .then(() => {
-  //       listCredentials(); // Refresh table
-  //     })
-  //     .catch((err) => {
-  //       error.value = err;
-  //     })
-  //     .finally(() => {
-  //       loading.value = false;
-  //     });
-  //   console.log('< contactsStore.deleteCredential');
+    await acapyApi
+      .deleteHttp(API_PATH.ISSUE_CREDENTIAL_RECORD(credExchangeId))
+      .then((res) => {
+        result = res.data.item;
+      })
+      .then(() => {
+        listCredentials(); // Refresh table
+      })
+      .catch((err) => {
+        error.value = err;
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+    console.log('< contactsStore.deleteCredential');
 
-  //   if (error.value != null) {
-  //     // throw error so $onAction.onError listeners can add their own handler
-  //     throw error.value;
-  //   }
-  //   // return data so $onAction.after listeners can add their own handler
-  //   return result;
-  // }
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+    // return data so $onAction.after listeners can add their own handler
+    return result;
+  }
 
   return {
     credentials,
@@ -146,7 +148,7 @@ export const useIssuerStore = defineStore('issuer', () => {
     offerCredential,
     getCredential,
     revokeCredential,
-    // deleteCredential,
+    deleteCredentialExchange,
   };
 });
 


### PR DESCRIPTION
**Revocation**
If an accepted cred is revocable, allow a credential revocation (the X icon, not sure if someone has a better idea, can run it by Guru)
![image](https://user-images.githubusercontent.com/17445138/222868653-3ddb44aa-6bfb-42d2-9d8e-de6309cbeec2.png)

When revoking, allow the comment to be filled out if you want
also through some details about the cred revocation (might remove these eventually if they are not useful)
![image](https://user-images.githubusercontent.com/17445138/222868701-08dff913-abbc-4ecb-806b-597118011fd0.png)

Calls /revocation/revoke and then refreshes the table with the updated state.

Tried with BC Wallet and this works (as an aside I'm not sure this revocation/dismiss thing on the card matches the OCA it's trying to go for?)
![Screenshot_20230303-173836](https://user-images.githubusercontent.com/17445138/222868808-ea642819-aec9-4944-a4f2-a7527a0df68d.png)

When revoking to a cred issued to another Traction tenant this successfully updates the state of the cred exchange record
![image](https://user-images.githubusercontent.com/17445138/222868946-02abe314-761b-43aa-8845-1eb18f6e0578.png)
but through the UI right now I'm only showing the HOLDER /credentials list, which doesn't tell you anything about if it's revoked or not?


**Exchange record delete**
Also allow any cred exchange record to be DELETEd as the issuer
![image](https://user-images.githubusercontent.com/17445138/222869127-b72a14b5-2ff7-4a39-ae03-6bec65d7e802.png)
