### PR TITLE
Simple OCA plugin, allow protected write and public read

### DIFF
--- a/charts/traction/templates/acapy_deployment.yaml
+++ b/charts/traction/templates/acapy_deployment.yaml
@@ -46,20 +46,20 @@ spec:
            --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5, \"wallet_scheme\":\"{{ .Values.acapy.service.walletScheme }}\"}' \
            --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \
            --plugin 'aries_cloudagent.messaging.jsonld' \ 
-           {{- if .Values.acapy.plugins.multitenantProvider }}
-           --plugin traction_plugins.multitenant_provider.v1_0 \
-           {{- end }}           
+           {{- if .Values.acapy.plugins.tractionInnkeeper }}
+           --plugin traction_plugins.traction_innkeeper.v1_0 \
+           --plugin-config-value traction_innkeeper.innkeeper_wallet.tenant_id=\"$(INNKEEPER_WALLET_TENANT_ID)\" \
+           --plugin-config-value traction_innkeeper.innkeeper_wallet.wallet_key=\"$(INNKEEPER_WALLET_WALLET_KEY)\" \
+           {{- end }}
            {{- if .Values.acapy.plugins.basicmessageStorage }}
            --plugin traction_plugins.basicmessage_storage.v1_0 \
            {{- end }}
            {{- if .Values.acapy.plugins.connectionUpdate }}
            --plugin traction_plugins.connection_update.v1_0 \
            {{- end }}
-           {{- if .Values.acapy.plugins.tractionInnkeeper }}
-           --plugin traction_plugins.traction_innkeeper.v1_0 \
-           --plugin-config-value traction_innkeeper.innkeeper_wallet.tenant_id=\"$(INNKEEPER_WALLET_TENANT_ID)\" \
-           --plugin-config-value traction_innkeeper.innkeeper_wallet.wallet_key=\"$(INNKEEPER_WALLET_WALLET_KEY)\" \
-           {{- end }}
+           {{- if .Values.acapy.plugins.multitenantProvider }}
+           --plugin traction_plugins.multitenant_provider.v1_0 \
+           {{- end }}           
            "
           ]
           ports:

--- a/plugins/demo/configs/default.yml
+++ b/plugins/demo/configs/default.yml
@@ -22,10 +22,10 @@ endpoint:
 # plugins
 plugin:
   - aries_cloudagent.messaging.jsonld
+  - traction_plugins.traction_innkeeper.v1_0
   - traction_plugins.basicmessage_storage.v1_0
   - traction_plugins.connection_update.v1_0
   - traction_plugins.multitenant_provider.v1_0
-  - traction_plugins.traction_innkeeper.v1_0
 
 # block-plugin:
 

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/__init__.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/__init__.py
@@ -8,9 +8,10 @@ from aries_cloudagent.core.event_bus import EventBus
 from aries_cloudagent.core.plugin_registry import PluginRegistry
 from aries_cloudagent.core.protocol_registry import ProtocolRegistry
 
-from . import schema_storage, creddef_storage, endorser, connections, tenant, innkeeper
+from . import schema_storage, creddef_storage, endorser, connections, tenant, innkeeper, oca
 
 MODULES = [
+    oca,
     innkeeper,
     tenant,
     connections,

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/__init__.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/__init__.py
@@ -1,0 +1,61 @@
+import logging
+
+from aries_cloudagent.admin.base_server import BaseAdminServer
+from aries_cloudagent.admin.server import AdminServer
+from aries_cloudagent.config.injection_context import InjectionContext
+from aries_cloudagent.core.event_bus import EventBus, Event
+from aries_cloudagent.core.plugin_registry import PluginRegistry
+from aries_cloudagent.core.profile import Profile
+from aries_cloudagent.core.protocol_registry import ProtocolRegistry
+from aries_cloudagent.core.util import STARTUP_EVENT_PATTERN
+
+from .oca_service import OcaService
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def setup(context: InjectionContext):
+    LOGGER.info("> plugin setup...")
+
+    protocol_registry = context.inject(ProtocolRegistry)
+    if not protocol_registry:
+        raise ValueError("ProtocolRegistry missing in context")
+
+    plugin_registry = context.inject(PluginRegistry)
+    if not plugin_registry:
+        raise ValueError("PluginRegistry missing in context")
+
+    bus = context.inject(EventBus)
+    if not bus:
+        raise ValueError("EventBus missing in context")
+
+    bus.subscribe(STARTUP_EVENT_PATTERN, on_startup)
+
+    LOGGER.info("< plugin setup.")
+
+
+async def on_startup(profile: Profile, event: Event):
+    LOGGER.info("> on_startup")
+    svc = OcaService(profile)
+    profile.context.injector.bind_instance(OcaService, svc)
+
+    OCA_PATH = "/oca"
+
+    srv: AdminServer = profile.context.inject(BaseAdminServer)
+
+    # see if any other base wallet routes were added...
+    base_wallet_routes = profile.context.settings.get("multitenant.base_wallet_routes")
+    LOGGER.info(f"base_wallet_routes = {base_wallet_routes}")
+    if base_wallet_routes is None:
+        base_wallet_routes = []
+    if OCA_PATH not in base_wallet_routes:
+        base_wallet_routes.append(OCA_PATH)
+    # now add set the "configuration"
+    profile.context.settings.set_value("multitenant.base_wallet_routes", base_wallet_routes)
+    # and we need to tell the server to load the additional routes
+    # first call to this property "builds" the underlying property...
+    srv.additional_routes_pattern
+    # our pattern should be known to the server now...
+    # second call to the property should return all the patterns it will use
+    LOGGER.info(f"srv.additional_routes_pattern = {srv.additional_routes_pattern}")
+    LOGGER.info("< on_startup")

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/models.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/models.py
@@ -1,0 +1,85 @@
+from typing import Optional
+
+from aries_cloudagent.messaging.models.base_record import BaseRecord, BaseRecordSchema
+from aries_cloudagent.messaging.valid import INDY_SCHEMA_ID, INDY_CRED_DEF_ID, UUIDFour
+from marshmallow import EXCLUDE, fields
+
+
+class OcaRecord(BaseRecord):
+    """Traction OCA Record."""
+
+    class Meta:
+        """OcaRecord Meta."""
+
+        schema_class = "OcaRecordSchema"
+
+    RECORD_TYPE = "oca"
+    RECORD_ID_NAME = "oca_id"
+    TAG_NAMES = {
+        "schema_id",
+        "cred_def_id",
+        "owner_did",
+    }
+
+    def __init__(
+        self,
+        *,
+        oca_id: str = None,
+        schema_id: str = None,
+        cred_def_id: str = None,
+        url: str = None,
+        bundle: dict = None,
+        owner_did: str = None,
+        **kwargs,
+    ):
+        """Construct record."""
+        super().__init__(oca_id, **kwargs)
+        self.schema_id = schema_id
+        self.cred_def_id = cred_def_id
+        self.url = url
+        self.bundle = bundle
+        self.owner_did = owner_did
+
+    @property
+    def oca_id(self) -> Optional[str]:
+        """Return record id."""
+        return self._id
+
+    @property
+    def record_value(self) -> dict:
+        """Return record value."""
+        return {
+            prop: getattr(self, prop)
+            for prop in ("schema_id", "cred_def_id", "url", "bundle", "owner_did")
+        }
+
+
+class OcaRecordSchema(BaseRecordSchema):
+    """Traction Oca Record Schema."""
+
+    class Meta:
+        """SchemaStorageRecord Meta."""
+
+        model_class = "OcaRecord"
+        unknown = EXCLUDE
+
+    oca_id = fields.Str(
+        required=True,
+        description="OCA Record identifier",
+        example=UUIDFour.EXAMPLE,
+    )
+    schema_id = fields.Str(
+        required=False, description="Schema identifier", **INDY_SCHEMA_ID
+    )
+    cred_def_id = fields.Str(
+        required=False, description="Cred Def identifier", **INDY_CRED_DEF_ID
+    )
+    url = fields.Str(required=False, description="(Public) Url for OCA Bundle")
+    bundle = fields.Dict(
+        required=False,
+        description="OCA Bundle",
+    )
+    owner_did = fields.Str(
+        required=False,
+        description="Public DID of OCA record owner"
+    )

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/oca_service.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/oca_service.py
@@ -1,0 +1,259 @@
+import logging
+from typing import Optional
+
+from aries_cloudagent.core.error import BaseError
+from aries_cloudagent.core.profile import Profile
+from aries_cloudagent.storage.error import StorageDuplicateError, StorageNotFoundError
+from aries_cloudagent.wallet.base import BaseWallet
+from aries_cloudagent.wallet.did_info import DIDInfo
+from aries_cloudagent.wallet.error import WalletError
+from marshmallow import ValidationError
+
+from .models import OcaRecord
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PublicDIDRequiredError(BaseError):
+    """Public DID Required exception."""
+
+
+class PublicDIDMismatchError(BaseError):
+    """Public DID Mismatch exception."""
+
+
+class OcaService:
+    def __init__(self, profile: Profile):
+        self._profile = profile
+        self._logger = logging.getLogger(__name__)
+
+    @property
+    def profile(self) -> Profile:
+        """
+        Accessor for the current profile.
+
+        Returns:
+            The profile for this service
+
+        """
+        return self._profile
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger
+
+    async def get_public_did_info(self, issuer_profile: Profile):
+        self.logger.info("> get_public_did_info()")
+        result = None
+        async with issuer_profile.session() as session:
+            wallet = session.inject_or(BaseWallet)
+            if not wallet:
+                raise WalletError("Wallet not found")
+            try:
+                result = await wallet.get_public_did()
+            except WalletError as err:
+                raise err
+        self.logger.info(f"< get_public_did_info() = {result}")
+        return result
+
+    async def get_public_did(self, issuer_profile: Profile, raise_err: bool = False):
+        self.logger.info("> get_public_did()")
+        result = None
+        public_info = await self.get_public_did_info(issuer_profile)
+        if public_info and public_info.did:
+            result = public_info.did
+        else:
+            if raise_err:
+                raise PublicDIDRequiredError()
+        self.logger.info(f"< get_public_did() = {result}")
+        return result
+
+    def is_cred_def_owner(self, issuer_did: str, cred_def_id: str):
+        self.logger.info(f"> is_cred_def_owner({issuer_did}, {cred_def_id})")
+        data_did = None
+        result = False
+        try:
+            if cred_def_id:
+                data_did = cred_def_id.split(":")[0]
+            result = issuer_did == data_did
+        except Exception as err:
+            raise err
+        self.logger.info(f"< is_cred_def_owner() = {result}")
+        return result
+
+    def validate_oca_data(self, issuer_did: str, oca_data: dict):
+        # must have schema id, cred def id, one of url or bundle
+        # must be the issuer
+        message = {}
+        schema_id = oca_data.get("schema_id")
+        cred_def_id = oca_data.get("cred_def_id")
+        if not schema_id:
+            message["schema_id"] = "Schema ID is required."
+        if not cred_def_id:
+            message["cred_def_id"] = "Credential Definition ID is required."
+        if cred_def_id and not self.is_cred_def_owner(issuer_did, cred_def_id):
+            message["cred_def_id"] = "Credential Definition not created by caller"
+        if not oca_data.get("url") and not oca_data.get("bundle"):
+            message["url"] = "URL or bundle is required"
+
+        if message != {}:
+            raise ValidationError(message=message, data=oca_data)
+
+        return True
+
+    def build_tag_filter(self, schema_id: Optional[str], cred_def_id: Optional[str]):
+        result = {}
+        if schema_id:
+            result["schema_id"] = schema_id
+        if cred_def_id:
+            result["cred_def_id"] = cred_def_id
+        return result
+
+    def build_post_filter(self, public_info: Optional[DIDInfo]):
+        result = {}
+        if public_info and public_info.did:
+            result = {"owner_did": public_info.did}
+        return result
+
+    async def list_oca_records(
+        self,
+        issuer_profile: Profile,
+        schema_id: Optional[str],
+        cred_def_id: Optional[str],
+    ):
+        self.logger.info(
+            f"> list_oca_records({issuer_profile}, {schema_id}, {cred_def_id})"
+        )
+        is_root_profile = issuer_profile == self.profile
+        public_info = await self.get_public_did_info(issuer_profile)
+        tag_filter = self.build_tag_filter(schema_id, cred_def_id)
+        post_filter = self.build_post_filter(public_info)
+        records = []
+        if is_root_profile or public_info:
+            self.logger.info(f"post_filter = {post_filter}")
+            async with self.profile.session() as session:
+                records = await OcaRecord.query(
+                    session=session,
+                    tag_filter=tag_filter,
+                    post_filter_positive=post_filter,
+                    alt=True,
+                )
+        else:
+            # error
+            self.logger.error("Profile does not have access to this function.")
+        self.logger.info(f"< list_oca_records({tag_filter}): {len(records)}")
+        return records
+
+    async def find_or_new_oca_record(
+        self, issuer_profile: Profile, oca_data: dict, update: bool = True
+    ):
+        self.logger.info(
+            f"> find_or_new_oca_record({issuer_profile}, {oca_data}, update={update})"
+        )
+        public_info = await self.get_public_did_info(issuer_profile)
+        tag_filter = self.build_tag_filter(
+            oca_data.get("schema_id"), oca_data.get("cred_def_id")
+        )
+        post_filter = self.build_post_filter(public_info)
+        async with self.profile.session() as session:
+            records = await OcaRecord.query(
+                session=session,
+                tag_filter=tag_filter,
+                post_filter_positive=post_filter,
+                alt=True,
+            )
+        if len(records) > 1:
+            raise StorageDuplicateError(
+                "More than one OCA record was found for the given criteria"
+            )
+        elif len(records) == 1:
+            self.logger.info("... found existing record ...")
+            record = records[0]
+            if update:
+                record.bundle = oca_data.get("bundle")
+                record.url = oca_data.get("url")
+            self.logger.info(f"< find_or_new_oca_record() = {record}")
+            return record
+        else:
+            self.logger.info("... creating new record ...")
+            record = OcaRecord(
+                schema_id=oca_data.get("schema_id"),
+                cred_def_id=oca_data.get("cred_def_id"),
+                url=oca_data.get("url"),
+                bundle=oca_data.get("bundle"),
+                owner_did=public_info.did,
+            )
+            self.logger.info(f"< find_or_new_oca_record() = {record}")
+            return record
+
+    async def create_or_update_oca_record(
+        self, issuer_profile: Profile, oca_data: dict
+    ):
+        self.logger.info(f"> create_or_update_oca_record({issuer_profile}, {oca_data})")
+        public_did = await self.get_public_did(issuer_profile, True)
+        if self.validate_oca_data(public_did, oca_data):
+            # validate that schema id and cred def id are present and match
+            rec = await self.find_or_new_oca_record(issuer_profile, oca_data, True)
+            try:
+                self.logger.debug(f"oca_record = {rec}")
+                async with self.profile.session() as session:
+                    await rec.save(session, reason="Create/Update OCA record")
+                self.logger.info(f"< create_or_update_oca_record() = {rec}")
+                return rec
+            except Exception as err:
+                self.logger.error("Error creating or updating OCA record.", err)
+                raise err
+
+    async def read_oca_record(self, issuer_profile: Profile, oca_id: str):
+        self.logger.info(f"> read_oca_record({issuer_profile}, {oca_id})")
+        public_did = await self.get_public_did(issuer_profile, True)
+        async with self.profile.session() as session:
+            rec = await OcaRecord.retrieve_by_id(session, oca_id)
+            # must exist, caller must be the owner...
+            if rec.owner_did != public_did:
+                raise PublicDIDMismatchError()
+
+            await rec.save(session)
+        self.logger.info(f"< read_oca_record({oca_id}) = {rec}")
+        return rec
+
+    async def update_oca_record(
+        self, issuer_profile: Profile, oca_id: str, oca_data: dict
+    ):
+        self.logger.info(f"> update_oca_record({issuer_profile}, {oca_id}, {oca_data})")
+        public_did = await self.get_public_did(issuer_profile, True)
+        async with self.profile.session() as session:
+            rec = await OcaRecord.retrieve_by_id(session, oca_id, for_update=True)
+            # must exist, caller must be the owner...
+            if rec.owner_did != public_did:
+                raise PublicDIDMismatchError()
+
+            if not oca_data.get("url") and not oca_data.get("bundle"):
+                raise ValidationError("URL or bundle is required")
+
+            rec.url = oca_data.get("url")
+            rec.bundle = oca_data.get("bundle")
+
+            await rec.save(session)
+        self.logger.info(f"< update_oca_record({oca_id}) = {rec}")
+        return rec
+
+    async def delete_oca_record(self, issuer_profile: Profile, oca_id: str):
+        self.logger.info(f"> delete_oca_record({issuer_profile}, {oca_id})")
+        public_did = await self.get_public_did(issuer_profile, True)
+        result = False
+        async with self.profile.session() as session:
+            rec = await OcaRecord.retrieve_by_id(session, oca_id, for_update=True)
+            # must exist, caller must be the owner...
+            if rec.owner_did != public_did:
+                raise PublicDIDMismatchError()
+
+            await rec.delete_record(session)
+
+            try:
+                await OcaRecord.retrieve_by_id(session, oca_id)
+            except StorageNotFoundError:
+                # this is to be expected... do nothing, do not log
+                result = True
+        self.logger.info(f"< delete_oca_record({oca_id}) = {result}")
+        return result

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
@@ -32,7 +32,7 @@ def error_handler(func):
             ret = await func(request)
             return ret
         except ValidationError as err:
-            raise web.HTTPUnprocessableEntity(reason=err.roll_up) from err
+            raise web.HTTPUnprocessableEntity(reason=err.messages) from err
         except PublicDIDRequiredError as err:
             raise web.HTTPBadRequest(reason=err.roll_up) from err
         except PublicDIDMismatchError as err:

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
@@ -14,7 +14,7 @@ from aries_cloudagent.messaging.models.base import BaseModelError
 from aries_cloudagent.messaging.models.openapi import OpenAPISchema
 from aries_cloudagent.messaging.valid import INDY_SCHEMA_ID, INDY_CRED_DEF_ID, UUIDFour
 from aries_cloudagent.storage.error import StorageNotFoundError, StorageError
-from marshmallow import fields
+from marshmallow import fields, ValidationError
 
 from . import OcaService
 from .models import OcaRecordSchema
@@ -31,6 +31,8 @@ def error_handler(func):
         try:
             ret = await func(request)
             return ret
+        except ValidationError as err:
+            raise web.HTTPUnprocessableEntity(reason=err.roll_up) from err
         except PublicDIDRequiredError as err:
             raise web.HTTPBadRequest(reason=err.roll_up) from err
         except PublicDIDMismatchError as err:

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
@@ -1,0 +1,191 @@
+import functools
+import logging
+
+from aiohttp import web
+from aiohttp_apispec import (
+    docs,
+    response_schema,
+    request_schema,
+    querystring_schema,
+    match_info_schema,
+)
+from aries_cloudagent.admin.request_context import AdminRequestContext
+from aries_cloudagent.messaging.models.base import BaseModelError
+from aries_cloudagent.messaging.models.openapi import OpenAPISchema
+from aries_cloudagent.messaging.valid import INDY_SCHEMA_ID, INDY_CRED_DEF_ID, UUIDFour
+from aries_cloudagent.storage.error import StorageNotFoundError, StorageError
+from marshmallow import fields
+
+from . import OcaService
+from .models import OcaRecordSchema
+from .oca_service import PublicDIDRequiredError, PublicDIDMismatchError
+
+LOGGER = logging.getLogger(__name__)
+
+SWAGGER_CATEGORY = "oca"
+
+
+def error_handler(func):
+    @functools.wraps(func)
+    async def wrapper(request):
+        try:
+            ret = await func(request)
+            return ret
+        except PublicDIDRequiredError as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+        except PublicDIDMismatchError as err:
+            raise web.HTTPUnauthorized(reason=err.roll_up) from err
+        except StorageNotFoundError as err:
+            raise web.HTTPNotFound(reason=err.roll_up) from err
+        except (StorageError, BaseModelError) as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+        except Exception as err:
+            LOGGER.error(err)
+            raise err
+
+    return wrapper
+
+
+class OcaRecordListQueryStringSchema(OpenAPISchema):
+    cred_def_id = fields.Str(
+        required=False, description="Cred Def identifier", **INDY_CRED_DEF_ID
+    )
+
+
+class OcaRecordListSchema(OpenAPISchema):
+    """Response schema for oca list."""
+
+    results = fields.List(
+        fields.Nested(OcaRecordSchema()),
+        description="List of OCA records",
+    )
+
+
+class AddOcaRecordRequestSchema(OpenAPISchema):
+    """Request schema for adding oca record link."""
+
+    schema_id = fields.Str(
+        required=False, description="Schema identifier", **INDY_SCHEMA_ID
+    )
+    cred_def_id = fields.Str(
+        required=False, description="Cred Def identifier", **INDY_CRED_DEF_ID
+    )
+    url = fields.Str(required=False, description="(Public) Url for OCA Bundle")
+    bundle = fields.Dict(
+        required=False,
+        description="OCA Bundle",
+    )
+
+
+class OcaIdMatchInfoSchema(OpenAPISchema):
+    oca_id = fields.Str(
+        description="OCA Record identifier", required=True, example=UUIDFour.EXAMPLE
+    )
+
+
+class OcaRecordOperationResponseSchema(OpenAPISchema):
+    """Response schema for simple operations."""
+
+    success = fields.Bool(
+        required=True,
+        description="True if operation successful, false if otherwise",
+    )
+
+@docs(tags=[SWAGGER_CATEGORY], summary="Add OCA Record")
+@request_schema(AddOcaRecordRequestSchema())
+@response_schema(OcaRecordSchema(), 200, description="")
+@error_handler
+async def oca_record_create(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    service = context.inject(OcaService)
+
+    body = await request.json()
+    rec = await service.create_or_update_oca_record(context.profile, body)
+
+    return web.json_response(rec.serialize())
+
+
+@docs(tags=[SWAGGER_CATEGORY], summary="Read OCA Record")
+@match_info_schema(OcaIdMatchInfoSchema())
+@response_schema(OcaRecordSchema(), 200, description="")
+@error_handler
+async def oca_record_read(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    service = context.inject(OcaService)
+
+    oca_id = request.match_info["oca_id"]
+    rec = await service.read_oca_record(context.profile, oca_id)
+    LOGGER.info(f"rec = {rec}")
+    return web.json_response(rec.serialize())
+
+
+@docs(tags=[SWAGGER_CATEGORY], summary="Update OCA Record")
+@match_info_schema(OcaIdMatchInfoSchema())
+@request_schema(OcaRecordSchema())
+@response_schema(OcaRecordSchema(), 200, description="")
+@error_handler
+async def oca_record_update(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    service = context.inject(OcaService)
+
+    oca_id = request.match_info["oca_id"]
+    body = await request.json()
+    rec = await service.update_oca_record(context.profile, oca_id, body)
+    return web.json_response(rec.serialize())
+
+
+@docs(tags=[SWAGGER_CATEGORY], summary="Delete OCA Record")
+@match_info_schema(OcaIdMatchInfoSchema())
+@response_schema(OcaRecordOperationResponseSchema, 200, description="")
+@error_handler
+async def oca_record_delete(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    service = context.inject(OcaService)
+    oca_id = request.match_info["oca_id"]
+    success = await service.delete_oca_record(context.profile, oca_id)
+    return web.json_response({"success": success})
+
+
+@docs(
+    tags=[SWAGGER_CATEGORY],
+)
+@querystring_schema(OcaRecordListQueryStringSchema())
+@response_schema(OcaRecordListSchema(), 200, description="")
+@error_handler
+async def oca_record_list(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    service = context.inject(OcaService)
+    cred_def_id = request.query.get("cred_def_id")
+    records = await service.list_oca_records(context.profile, None, cred_def_id)
+    results = [record.serialize() for record in records]
+
+    return web.json_response({"results": results})
+
+
+async def register(app: web.Application):
+    """Register routes."""
+    LOGGER.info("> registering routes")
+    app.add_routes(
+        [
+            web.get("/oca", oca_record_list, allow_head=False),
+            web.post("/oca", oca_record_create),
+            web.get("/oca/{oca_id}", oca_record_read, allow_head=False),
+            web.put("/oca/{oca_id}", oca_record_update),
+            web.delete("/oca/{oca_id}", oca_record_delete),
+        ]
+    )
+    LOGGER.info("< registering routes")
+
+
+def post_process_routes(app: web.Application):
+    """Amend swagger API."""
+
+    # Add top-level tags description
+    if "tags" not in app._state["swagger_dict"]:
+        app._state["swagger_dict"]["tags"] = []
+    app._state["swagger_dict"]["tags"].append(
+        {
+            "name": SWAGGER_CATEGORY,
+            "description": "OCA Bundles - manage OCA Bundles (traction_innkeeper v1_0 plugin)",
+        }
+    )

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       - ACAPY_AUTO_PROMOTE_AUTHOR_DID=${ACAPY_AUTO_PROMOTE_AUTHOR_DID}
       - ACAPY_CREATE_REVOCATION_TRANSACTIONS=${ACAPY_CREATE_REVOCATION_TRANSACTIONS}
       - ACAPY_PLUGIN_CONFIG=${ACAPY_PLUGIN_CONFIG}
+      - RUST_LOG=error
     ports:
       - ${TRACTION_ACAPY_ADMIN_PORT}:${TRACTION_ACAPY_ADMIN_PORT}
       - ${TRACTION_ACAPY_HTTP_PORT}:${TRACTION_ACAPY_HTTP_PORT}
@@ -238,6 +239,8 @@ services:
         --auto-endorse-transactions \
         ",
       ]
+    environment:
+      - RUST_LOG=error
     volumes:
       - "./endorser-acapy-args.yml:/home/indy/endorser-acapy-args.yml"
     extra_hosts:

--- a/services/aca-py/ngrok-wait.sh
+++ b/services/aca-py/ngrok-wait.sh
@@ -37,7 +37,7 @@ exec aca-py start \
     --wallet-storage-config "{\"url\":\"${POSTGRESQL_HOST}:5432\",\"max_connections\":5, \"wallet_scheme\":\"${TRACTION_ACAPY_WALLET_SCHEME}\"}" \
     --wallet-storage-creds "{\"account\":\"${POSTGRESQL_USER}\",\"password\":\"${POSTGRESQL_PASSWORD}\",\"admin_account\":\"${POSTGRESQL_USER}\",\"admin_password\":\"${POSTGRESQL_PASSWORD}\"}" \
     --admin "0.0.0.0" ${TRACTION_ACAPY_ADMIN_PORT} \
-    --plugin traction_plugins.multitenant_provider.v1_0 \
+    --plugin traction_plugins.traction_innkeeper.v1_0 \
     --plugin traction_plugins.basicmessage_storage.v1_0 \
     --plugin traction_plugins.connection_update.v1_0 \
-    --plugin traction_plugins.traction_innkeeper.v1_0 \
+    --plugin traction_plugins.multitenant_provider.v1_0 \


### PR DESCRIPTION
This is VERY simple.
A tenant (that has a public DID) can use the `/oca` API to store a URL or a JSON bundle associated with their cred def id.  Public can query (by cred def id) to see if there is an available OCA bundle and where to get it.

Public (expected) use:

`GET /oca?cred_def_id=GwP16L98qUb4f6UrDcYpby:3:CL:731436:unhurled` will return a list (0 or 1).

```
{
  "results": [
    {
      "owner_did": "GwP16L98qUb4f6UrDcYpby",
      "created_at": "2023-03-21T16:48:41.716101Z",
      "cred_def_id": "GwP16L98qUb4f6UrDcYpby:3:CL:731436:unhurled",
      "oca_id": "8208c1d2-3fa4-4ea0-9c58-8f8837a7405c",
      "url": "http://this.is.where/the/oca.bundle.is?cred_def_id=GwP16L98qUb4f6UrDcYpby:3:CL:731436:unhurled",
      "updated_at": "2023-03-21T16:48:41.716101Z",
      "schema_id": "GwP16L98qUb4f6UrDcYpby:2:megrims:0.0.1"
    }
  ]
}
```

Tenant use:

`GET /oca` will return all the OCA records they have added.
