### PR TITLE
Use /ledger/register-nym endpoint

### DIFF
--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -89,7 +89,7 @@ export const API_PATH = {
   TENANT_SELF: '/tenant',
   TENANT_ENDORSER_CONNECTION: '/tenant/endorser-connection',
   TENANT_ENDORSER_INFO: '/tenant/endorser-info',
-  TENANT_REGISTER_PUBLIC_DID: '/tenant/register-public-did',
+  TENANT_REGISTER_PUBLIC_DID: '/ledger/register-nym',
   TENANT_TOKEN: '/tenant/token',
   TENANT_WALLET: '/tenant/wallet',
 

--- a/services/tenant-ui/frontend/src/store/tenantStore.ts
+++ b/services/tenant-ui/frontend/src/store/tenantStore.ts
@@ -196,10 +196,11 @@ export const useTenantStore = defineStore('tenant', () => {
       // Use the did and verkey
       const did = cRes.data.result.did;
       const verkey = cRes.data.result.verkey;
+      const alias = tenant.value.tenant_name || tenant.value.wallet_id;
       // Register the DID
       publicDidRegistrationProgress.value = 'Registering the DID';
       const rRes = await acapyApi.postHttp(
-        `${API_PATH.TENANT_REGISTER_PUBLIC_DID}?did=${did}&verkey=${verkey}`,
+        `${API_PATH.TENANT_REGISTER_PUBLIC_DID}?did=${did}&verkey=${verkey}&alias=${alias}`,
         {}
       );
       console.log(rRes);


### PR DESCRIPTION
Remove the custom innkeeper/tenant plugin endpoint and use the one provided by Aca-Py.

It's preferable to stick with raw Aca-Py where possible.

Closes #513