### PR TITLE
Feature/issue 527 res pwd

### DIFF
--- a/charts/tenant-ui/values-int.yaml
+++ b/charts/tenant-ui/values-int.yaml
@@ -23,5 +23,5 @@ tenant_ui:
     server: apps.smtp.gov.bc.ca
     port: 25
     senderAddress: DoNotReplyTractionINT@gov.bc.ca
-    innkeeperInbox: jason.sherman@gmail.com
+    innkeeperInbox: lucasoneil@gmail.com
 

--- a/charts/tenant-ui/values-pr.yaml
+++ b/charts/tenant-ui/values-pr.yaml
@@ -23,7 +23,7 @@ tenant_ui:
     server: apps.smtp.gov.bc.ca
     port: 25
     senderAddress: DoNotReplyTractionPR@gov.bc.ca
-    innkeeperInbox: lucasoneil@gmail.com,jason.sherman@gmail.com
+    innkeeperInbox: lucasoneil@gmail.com
   resources:
     limits:
       cpu: 200m

--- a/charts/tenant-ui/values-pr.yaml
+++ b/charts/tenant-ui/values-pr.yaml
@@ -23,7 +23,7 @@ tenant_ui:
     server: apps.smtp.gov.bc.ca
     port: 25
     senderAddress: DoNotReplyTractionPR@gov.bc.ca
-    innkeeperInbox: jason.sherman@gmail.com
+    innkeeperInbox: lucasoneil@gmail.com,jason.sherman@gmail.com
   resources:
     limits:
       cpu: 200m

--- a/charts/tenant-ui/values-test.yaml
+++ b/charts/tenant-ui/values-test.yaml
@@ -22,4 +22,4 @@ tenant_ui:
     server: apps.smtp.gov.bc.ca
     port: 25
     senderAddress: DoNotReplyTractionTEST@gov.bc.ca
-    innkeeperInbox: jason.sherman@gmail.com
+    innkeeperInbox: lucasoneil@gmail.com

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,1 +1,8 @@
-TBD
+# Traction Aca-Py Plugins
+
+Traction is a set of plugins that facilitate multi-tenant management within [Aca-Py](https://github.com/hyperledger/aries-cloudagent-python). Some of the plugins ([basicmessage_storage](./basicmessage_storage/README.md), [connection_update](./connection_update/README.md) and [multitenant_provider](./multitenant_provider/README.md)) can be used independently from Traction.  
+
+
+### Developing Aca-Py Plugins
+
+Please refer to [Getting Started Aries Development: Plugins](https://github.com/hyperledger/aries-cloudagent-python/blob/45c832658245747a3366735f6179362d127bae02/docs/GettingStartedAriesDev/PlugIns.md) for an in depth look at how to build Aca-Py plugins and how they operate within Aca-Py.

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
@@ -257,7 +257,7 @@ async def tenant_reservation_get(request: web.BaseRequest):
     reservation_id = request.match_info["reservation_id"]
 
     async with profile.session() as session:
-        rec = await ReservationRecord.retrieve_by_id(session, reservation_id)
+        rec = await ReservationRecord.retrieve_by_reservation_id(session, reservation_id)
         LOGGER.info(rec)
 
     return web.json_response(rec.serialize())
@@ -282,7 +282,7 @@ async def tenant_checkin(request: web.BaseRequest):
     reservation_id = request.match_info["reservation_id"]
 
     async with profile.session() as session:
-        res_rec = await ReservationRecord.retrieve_by_id(session, reservation_id)
+        res_rec = await ReservationRecord.retrieve_by_reservation_id(session, reservation_id)
         reservation_pwd = body.get("reservation_pwd")
 
         if res_rec.expired:
@@ -411,7 +411,7 @@ async def innkeeper_reservations_approve(request: web.BaseRequest):
 
     async with profile.session() as session:
         # innkeeper can access all reservation records.
-        rec = await ReservationRecord.retrieve_by_id(
+        rec = await ReservationRecord.retrieve_by_reservation_id(
             session, reservation_id, for_update=True
         )
         if rec.state == ReservationRecord.STATE_REQUESTED:
@@ -453,7 +453,7 @@ async def innkeeper_reservations_deny(request: web.BaseRequest):
 
     async with profile.session() as session:
         # innkeeper can access all reservation records.
-        rec = await ReservationRecord.retrieve_by_id(
+        rec = await ReservationRecord.retrieve_by_reservation_id(
             session, reservation_id, for_update=True
         )
         if rec.state == ReservationRecord.STATE_REQUESTED:

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/tenant_manager.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/tenant_manager.py
@@ -162,7 +162,7 @@ class TenantManager:
             print(f"Bearer {token}\n")
 
     def generate_reservation_token_data(self):
-        _pwd = str(uuid.uuid4())
+        _pwd = str(uuid.uuid4().hex)
         self._logger.info(f"_pwd = {_pwd}")
 
         _salt = bcrypt.gensalt()

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     command: ngrok http traction-agent:${TRACTION_ACAPY_HTTP_PORT} --log stdout
 
   traction-acapy-image-builder:
-    pull_policy: build
+    pull_policy: missing
     build:
       context: ../plugins
       dockerfile: ./docker/Dockerfile
@@ -18,7 +18,7 @@ services:
     tty: true
 
   traction-agent:
-    pull_policy: build
+    pull_policy: missing
     build:
       context: ../services/aca-py
       dockerfile: Dockerfile.acapy
@@ -111,7 +111,7 @@ services:
       - host.docker.internal:host-gateway
   
   tenant-ui:
-    pull_policy: build
+    pull_policy: missing
     build:
       context: ../services/tenant-ui
       dockerfile: Dockerfile
@@ -138,7 +138,7 @@ services:
       - host.docker.internal:host-gateway
 
   tenant-proxy:
-    pull_policy: build
+    pull_policy: missing
     build:
       context: ../plugins
       dockerfile: ./docker/Dockerfile.tenant-proxy
@@ -176,7 +176,7 @@ services:
       - host.docker.internal:host-gateway
 
   endorser-api:
-    pull_policy: build
+    pull_policy: missing
     build:
       context: ../services/endorser
       dockerfile: Dockerfile

--- a/services/tenant-lob/app/set_public_did.py
+++ b/services/tenant-lob/app/set_public_did.py
@@ -43,7 +43,7 @@ async def set_public_did(tenant):
     # register did
     data = None
     res = requests.post(
-        f"{PROXY_URL}/tenant/register-public-did?did={wallet_create_did}&verkey={wallet_create_verkey}",
+        f"{PROXY_URL}/ledger/register-nym?did={wallet_create_did}&verkey={wallet_create_verkey}&alias={tenant_name}",
         headers=tenant_headers,
         json=data,
     )


### PR DESCRIPTION
Remove dashes from reservation password (and reservation id).
These ids end up in emails and having dashes makes it impossible to just double click to select the word. Make it as easy as possible for tenants to complete the reservation flow.

Note: the reservation id is stored as a UUID with dashes, it's only in the REST API that we accept and return without dashes.


Also, touched up the tenant-lob app to use the `/ledger/register-nym` call - should have been done in my last PR, but done now...

Closes #527 