### PR TITLE
Bugfix attempt for innkeeper wallet key for oidc login

### DIFF
--- a/charts/tenant-ui/templates/_helpers.tpl
+++ b/charts/tenant-ui/templates/_helpers.tpl
@@ -89,7 +89,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "traction.fullname" . }}-api
 {{- end -}}
 
-
 {{/*
 Create a default fully qualified acapy name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -105,6 +104,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "acapy.api.secret.name" -}}
 {{ template "acapy.fullname" . }}-api
 {{- end -}}
+
+{{/*
+Create a default fully qualified acapy innkeeper plugin name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "acapy.plugin.innkeeper.name" -}}
+{{ template "acapy.fullname" . }}-plugin-innkeeper
+{{- end -}}
+
 
 {{/*
 Create a default fully qualified traction tenant ui name.

--- a/charts/tenant-ui/templates/tenant_ui_deployment.yaml
+++ b/charts/tenant-ui/templates/tenant_ui_deployment.yaml
@@ -53,7 +53,10 @@ spec:
             - name: FRONTEND_TENANT_PROXY_URL
               value: {{ .Values.tenant_ui.tenant_proxy.endpoint }}
             - name: SERVER_INNKEEPER_KEY
-              value: change-me
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "acapy.plugin.innkeeper.name" . }}
+                  key: walletkey
             {{- include "tenant_ui.configmap.env.vars" . | nindent 10}}
           resources:
             {{- toYaml .Values.tenant_ui.resources | nindent 12 }}

--- a/charts/tenant-ui/templates/tenant_ui_deployment.yaml
+++ b/charts/tenant-ui/templates/tenant_ui_deployment.yaml
@@ -52,6 +52,11 @@ spec:
               value: {{ .Values.tenant_ui.traction_api.endpoint }}
             - name: FRONTEND_TENANT_PROXY_URL
               value: {{ .Values.tenant_ui.tenant_proxy.endpoint }}
+            - name: SERVER_INNKEEPER_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "acapy.plugin.innkeeper.name" . }}
+                  key: tenantid
             - name: SERVER_INNKEEPER_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Alter the tenant ui helm chart settings to pull from the associated deployment's innkeeper plugin secrets to get the wallet ID and key (these settings had changed in the past and needed updating)