### PR TITLE
Fix for tenant UI CI/CD on PRs (Add back overrides)

### DIFF
--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -130,6 +130,8 @@ jobs:
 
       - name: Run Tenant UI PR Helm
         run: |
+          yq eval '.global.fullnameOverride = "pr-${{ github.event.number }}-tenant-ui"' -i ./charts/tenant-ui/values-pr.yaml
+          yq eval '.global.tractionNameOverride = "pr-${{ github.event.number }}-traction"' -i ./charts/tenant-ui/values-pr.yaml
           yq eval '.tenant_ui.traction_api.endpoint = "https://pr-${{ github.event.number }}-traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca"' -i ./charts/tenant-ui/values-pr.yaml
           yq eval '.tenant_ui.tenant_proxy.endpoint = "https://pr-${{ github.event.number }}-traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca"' -i ./charts/tenant-ui/values-pr.yaml
           yq eval '.tenant_ui.image.tag = "ghcr.io/${{ github.repository_owner}}/traction-tenant-ui:pr-${{ github.event.number }}"' -i ./charts/tenant-ui/values-pr.yaml


### PR DESCRIPTION
The Tenant UI still appears to need the override altering for fullNameOverride and tractionNameOverride.
Not sure if it was intended to have them taken out in https://github.com/bcgov/traction/pull/556 ?
Seems to be ok in the Traction part after those were removed so maybe there's a different mechanism intended for PR number adjustment.

But we'll need this back in for now at least