### PR TITLE
Presentation Requests in Tenant UI

### DIFF
--- a/services/tenant-ui/frontend/src/assets/tenantuiComponents.scss
+++ b/services/tenant-ui/frontend/src/assets/tenantuiComponents.scss
@@ -49,6 +49,7 @@
   &.response,
   &.requested,
   &.request-sent,
+  &.request-received,
   &.offer-sent,
   &.offer-received {
     background-color: $tenant-ui-status-blue-background;

--- a/services/tenant-ui/frontend/src/components/contacts/messageContact/MessageContactList.vue
+++ b/services/tenant-ui/frontend/src/components/contacts/messageContact/MessageContactList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="title">
-    <h2>{{ $t('connect.message.contact', [props.connectionName]) }}</h2>
+    <h2>{{ $t('connect.message.messageContact', [props.connectionName]) }}</h2>
   </div>
   <div class="container">
     <div

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/EnterCredentialValues.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/EnterCredentialValues.vue
@@ -15,11 +15,11 @@
     <div class="flex justify-content-between">
       <div class="flex justify-content-start">
         <label for="credentialValuesEdit">
-          <strong>{{ $t('issuse.credentialFieldValues') }}</strong>
+          <strong>{{ $t('issue.credentialFieldValues') }}</strong>
         </label>
       </div>
       <div class="flex justify-content-end">
-        {{ $t('issue.Json') }}
+        {{ $t('common.json') }}
         <InputSwitch v-model="showRawJson" class="ml-1" @input="toggleJson" />
       </div>
     </div>

--- a/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredentialForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/offerCredential/OfferCredentialForm.vue
@@ -8,7 +8,7 @@
           <label
             for="selectedCred"
             :class="{ 'p-error': v$.selectedCred.$invalid && submitted }"
-            >{{ $t('issue.credentialId') }}
+            >{{ $t('common.credentialId') }}
             <ProgressSpinner v-if="credsLoading" />
           </label>
 
@@ -34,7 +34,7 @@
           <label
             for="selectedContact"
             :class="{ 'p-error': v$.selectedContact.$invalid && submitted }"
-            >{{ $t('issue.contactName') }}
+            >{{ $t('common.contactName') }}
             <ProgressSpinner v-if="contactLoading" />
           </label>
 
@@ -65,8 +65,9 @@
               :class="{
                 'p-error': v$.credentialValuesPretty.$invalid && submitted,
               }"
-              >{{ $t('issue.credentialValues') }}</label
             >
+              {{ $t('issue.credentialFieldValues') }}
+            </label>
             <Button
               label="Enter Credential Value"
               class="p-button-link flex justify-content-end pt-1"

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -53,11 +53,11 @@ const items = ref([
     to: { name: 'MyIssuedCredentials' },
   },
 
-  // {
-  //   label: () => t('verify.verification'),
-  //   icon: 'pi pi-fw pi-check-square',
-  //   to: { name: 'MyPresentations' },
-  // },
+  {
+    label: () => t('verify.verification'),
+    icon: 'pi pi-fw pi-check-square',
+    to: { name: 'MyPresentations' },
+  },
 
   {
     label: () => t('common.credentials'),

--- a/services/tenant-ui/frontend/src/components/oca/createOca/CreateOcaForm.vue
+++ b/services/tenant-ui/frontend/src/components/oca/createOca/CreateOcaForm.vue
@@ -8,7 +8,7 @@
             for="selectedCred"
             :class="{ 'p-error': v$.selectedCred.$invalid && submitted }"
           >
-            {{ $t('oca.credentialId') }}
+            {{ $t('common.credentialId') }}
             <ProgressSpinner v-if="loading" />
           </label>
 

--- a/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
@@ -62,10 +62,14 @@
       </template>
     </Column>
     <template #expansion="{ data }">
-      <PresentationRowExpandData
+      <!-- <PresentationRowExpandData
         :row="data"
         :header="false"
         :show-information="true"
+      /> -->
+      <RowExpandData
+        :id="data.presentation_exchange_id"
+        :url="API_PATH.PRESENT_PROOF_RECORDS"
       />
     </template>
   </DataTable>
@@ -82,13 +86,14 @@ import InputText from 'primevue/inputtext';
 import { FilterMatchMode } from 'primevue/api';
 import { useToast } from 'vue-toastification';
 // Stae
-import { useContactsStore, useVerifierStore } from '../../store';
+import { useContactsStore, useVerifierStore } from '@/store';
 import { storeToRefs } from 'pinia';
 // Components
 import CreateRequest from './createPresentationRequest/CreateRequest.vue';
-import StatusChip from '../common/StatusChip.vue';
-import PresentationRowExpandData from './PresentationRowExpandData.vue';
-import { TABLE_OPT } from '@/helpers/constants';
+// import PresentationRowExpandData from './PresentationRowExpandData.vue';
+import RowExpandData from '@/components/common/RowExpandData.vue';
+import StatusChip from '@/components/common/StatusChip.vue';
+import { API_PATH, TABLE_OPT } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 
 const toast = useToast();

--- a/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/Presentations.vue
@@ -1,12 +1,26 @@
 <template>
-  <h3 class="mt-0">{{ $t('verifiers.verifications') }}</h3>
+  <div class="flex justify-content-between mb-3">
+    <div class="flex justify-content-start">
+      <h3 class="mt-0">{{ $t('verifier.verifications') }}</h3>
+    </div>
+    <div class="flex justify-content-end">
+      <Button
+        icon="pi pi-refresh"
+        title="Refresh table"
+        text
+        rounded
+        aria-label="Filter"
+        @click="loadTable"
+      />
+    </div>
+  </div>
 
   <DataTable
     v-model:selection="selectedPresentation"
     v-model:expandedRows="expandedRows"
     :loading="loading"
     :value="presentations"
-    data-key="verifier_presentation_id"
+    data-key="presentation_exchange_id"
     :paginator="true"
     :rows="TABLE_OPT.ROWS_DEFAULT"
     :rows-per-page-options="TABLE_OPT.ROWS_OPTIONS"
@@ -14,40 +28,32 @@
   >
     <template #header>
       <div class="flex justify-content-between">
-        <div class="flex justify-content-start">
-          <SuperYou
-            :api-url="apiUrl"
-            :template-json="templateJson"
-            text="Create Presentation Request"
-            icon="pi-key"
-            @success="loadTable"
-          />
-        </div>
+        <CreateRequest />
+
         <div class="flex justify-content-end">
-          <span class="p-input-icon-left varification-search">
+          <span class="p-input-icon-left">
             <i class="pi pi-search" />
             <InputText
               v-model="filter.name.value"
               placeholder="Search Verifications"
             />
           </span>
-          <Button
-            icon="pi pi-refresh"
-            class="p-button-rounded p-button-outlined"
-            title="Refresh Table"
-            @click="loadTable"
-          />
         </div>
       </div>
     </template>
     <template #empty>{{ $t('common.noRecordsFound') }}</template>
     <template #loading>{{ $t('common.loading') }}</template>
     <Column :expander="true" header-style="width: 3rem" />
-    <Column :sortable="true" field="name" header="Name" />
-    <Column :sortable="true" field="contact.alias" header="Contact Name" />
+    <Column :sortable="true" field="presentation_request.name" header="Name" />
+    <Column :sortable="true" field="role" header="Role" />
+    <Column :sortable="true" field="connection_id" header="Connection">
+      <template #body="{ data }">
+        {{ findConnectionName(data.connection_id) }}
+      </template>
+    </Column>
     <Column :sortable="true" field="status" header="Status">
       <template #body="{ data }">
-        <StatusChip :status="data.status" />
+        <StatusChip :status="data.state" />
       </template>
     </Column>
     <Column :sortable="true" field="created_at" header="Created at">
@@ -66,60 +72,31 @@
 </template>
 
 <script setup lang="ts">
+// Vue
 import { onMounted, ref } from 'vue';
+// PrimeVue
 import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
 import Button from 'primevue/button';
-import { useToast } from 'vue-toastification';
 import InputText from 'primevue/inputtext';
 import { FilterMatchMode } from 'primevue/api';
-
-import { useVerifierStore } from '../../store';
+import { useToast } from 'vue-toastification';
+// Stae
+import { useContactsStore, useVerifierStore } from '../../store';
 import { storeToRefs } from 'pinia';
-
-import PresentationRowExpandData from './PresentationRowExpandData.vue';
-import { API_PATH, TABLE_OPT } from '@/helpers/constants';
-import { formatDateLong } from '@/helpers';
+// Components
+import CreateRequest from './createPresentationRequest/CreateRequest.vue';
 import StatusChip from '../common/StatusChip.vue';
-import SuperYou from '@/components/common/SuperYou.vue';
+import PresentationRowExpandData from './PresentationRowExpandData.vue';
+import { TABLE_OPT } from '@/helpers/constants';
+import { formatDateLong } from '@/helpers';
+
 const toast = useToast();
 
-const apiUrl = API_PATH.VERIFIER_PRESENTATION_ADHOC_REQUEST;
-
-const templateJson = {
-  contact_id: '67f68781-4dd9-49ad-9a5e-1e9a06e901f4',
-  connection_id: '6530a727-8c05-4818-a1bb-687117afbd44',
-  proof_request: {
-    requested_attributes: [
-      {
-        name: 'string',
-        names: ['string'],
-        non_revoked: {},
-        restrictions: [{}],
-      },
-    ],
-    requested_predicates: [
-      {
-        name: 'string',
-        p_type: '<',
-        p_value: 0,
-        non_revoked: {},
-        restrictions: [{}],
-      },
-    ],
-    non_revoked: {},
-  },
-  name: 'string',
-  version: '1.0.0',
-  external_reference_id: 'string',
-  comment: 'string',
-  tags: [],
-};
-// used by datatable expander behind the scenes
-const expandedRows = ref([]);
-
+// State
+const contactsStore = useContactsStore();
 const verifierStore = useVerifierStore();
-// use the loading state from the store to disable the button...
+const { contacts, findConnectionName } = storeToRefs(useContactsStore());
 const { loading, presentations, selectedPresentation } = storeToRefs(
   useVerifierStore()
 );
@@ -128,26 +105,24 @@ const loadTable = async () => {
   verifierStore.listPresentations().catch((err) => {
     toast.error(`Failure: ${err}`);
   });
+
+  // Load contacts if not already there for display
+  if (!contacts.value || !contacts.value.length) {
+    contactsStore.listContacts().catch((err) => {
+      console.error(err);
+      toast.error(`Failure: ${err}`);
+    });
+  }
 };
 
 onMounted(async () => {
   loadTable();
 });
 
+// used by datatable expander behind the scenes
+const expandedRows = ref([]);
+
 const filter = ref({
   name: { value: null, matchMode: FilterMatchMode.CONTAINS },
 });
 </script>
-
-<style scoped>
-.p-datatable-header input {
-  padding-left: 3rem;
-  margin-right: 1.5rem;
-}
-.varification-search {
-  margin-left: 1.5rem;
-}
-.varification-search input {
-  padding-left: 3rem !important;
-}
-</style>

--- a/services/tenant-ui/frontend/src/components/verifier/createPresentationRequest/CreateRequest.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/createPresentationRequest/CreateRequest.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <Button
+      :label="$t('verify.createRequest')"
+      icon="pi pi-key"
+      @click="openModal"
+    />
+    <Dialog
+      v-model:visible="displayModal"
+      :header="$t('verify.createRequest')"
+      :modal="true"
+      :style="{ width: '600px' }"
+      @update:visible="handleClose"
+    >
+      <CreateRequestForm @success="$emit('success')" @closed="handleClose" />
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { ref } from 'vue';
+// PrimeVue
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
+// Custom Components
+import CreateRequestForm from './CreateRequestForm.vue';
+
+defineEmits(['success']);
+
+const displayModal = ref(false);
+const openModal = async () => {
+  displayModal.value = true;
+};
+const handleClose = async () => {
+  // some logic... maybe we shouldn't close?
+  displayModal.value = false;
+};
+</script>

--- a/services/tenant-ui/frontend/src/components/verifier/createPresentationRequest/CreateRequestForm.vue
+++ b/services/tenant-ui/frontend/src/components/verifier/createPresentationRequest/CreateRequestForm.vue
@@ -1,0 +1,209 @@
+<template>
+  <div>
+    <form @submit.prevent="handleSubmit(!v$.$invalid)">
+      <!-- Contact -->
+      <div class="field">
+        <label
+          for="selectedContact"
+          :class="{ 'p-error': v$.selectedContact.$invalid && submitted }"
+        >
+          {{ $t('verify.connection') }}
+          <ProgressSpinner v-if="contactLoading" />
+        </label>
+
+        <AutoComplete
+          id="selectedContact"
+          v-model="v$.selectedContact.$model"
+          class="w-full"
+          :disabled="contactLoading"
+          :suggestions="filteredContacts"
+          :dropdown="true"
+          option-label="label"
+          force-selection
+          @complete="searchContacts($event)"
+        />
+        <small
+          v-if="v$.selectedContact.$invalid && submitted"
+          class="p-error"
+          >{{ v$.selectedContact.required.$message }}</small
+        >
+      </div>
+
+      <!-- Proof req body -->
+      <span>{{ $t('verify.presentationRequestBody') }}</span>
+      <JsonEditorVue
+        ref="jsonEditorVueRef"
+        v-model="proofRequestJson"
+        v-bind="JSON_EDITOR_DEFAULTS"
+      />
+
+      <!-- Auto Verify -->
+      <div class="field mb-0 mt-2">
+        <label for="autoVerify">
+          {{ $t('verify.autoVerify') }}
+          <i
+            v-tooltip="$t('verify.autoVerifyHelp')"
+            class="pi pi-question-circle"
+          />
+        </label>
+        <InputSwitch id="autoVerify" v-model="v$.autoVerify.$model" />
+      </div>
+
+      <!-- Comment -->
+      <div class="field">
+        <label for="comment">
+          {{ $t('verify.comment') }}
+        </label>
+        <Textarea
+          id="comment"
+          v-model="v$.comment.$model"
+          class="w-full"
+          :auto-resize="true"
+          rows="1"
+        />
+      </div>
+
+      <Button
+        type="submit"
+        :label="$t('common.submit')"
+        class="w-full"
+        :disabled="loading"
+      />
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Types
+import {
+  IndyProofRequest,
+  V10PresentationSendRequestRequest,
+} from '@/types/acapyApi/acapyInterface';
+
+// Vue
+import { reactive, ref } from 'vue';
+// PrimeVue / Validation / etc
+import AutoComplete from 'primevue/autocomplete';
+import Button from 'primevue/button';
+import InputSwitch from 'primevue/inputswitch';
+import Textarea from 'primevue/textarea';
+// import ProgressSpinner from 'primevue/progressspinner';
+import { required } from '@vuelidate/validators';
+import { useVuelidate } from '@vuelidate/core';
+import { useToast } from 'vue-toastification';
+// State
+import { storeToRefs } from 'pinia';
+import { useContactsStore, useVerifierStore } from '@/store';
+// Other imports
+import JsonEditorVue from 'json-editor-vue';
+import { JSON_EDITOR_DEFAULTS } from '@/helpers/constants';
+
+const toast = useToast();
+
+// Store values
+const { loading } = storeToRefs(useVerifierStore());
+const { loading: contactLoading, contactsDropdown } = storeToRefs(
+  useContactsStore()
+);
+const verifierStore = useVerifierStore();
+
+const emit = defineEmits(['closed', 'success']);
+
+// The default placeholder JSON to start with for this form
+const proofRequestJson = ref({
+  name: 'proof-request',
+  version: '1.0',
+  nonce: '1234567890',
+  requested_attributes: {
+    legalname: {
+      name: 'legalName',
+      restrictions: [
+        {
+          issuer_did: 'aaaDIDbbb',
+        },
+      ],
+    },
+    regdate: {
+      name: 'regDate',
+      restrictions: [
+        {
+          issuer_did: 'aaaDIDbbb',
+        },
+      ],
+      non_revoked: {
+        from: 1600001000,
+        to: 1600001000,
+      },
+    },
+  },
+  requested_predicates: {},
+  non_revoked: {
+    from: 1600000000,
+    to: 1600000000,
+  },
+} as IndyProofRequest);
+
+// Autocomplete setup
+// These can maybe be generalized into a util function (for all dropdown searches)
+const searchContacts = (event: any) => {
+  if (!event.query.trim().length) {
+    filteredContacts.value = [...(contactsDropdown as any).value];
+  } else {
+    filteredContacts.value = (contactsDropdown.value as any).filter(
+      (contact: any) => {
+        return contact.label.toLowerCase().includes(event.query.toLowerCase());
+      }
+    );
+  }
+};
+
+// Form Fields
+const filteredContacts = ref();
+const formFields = reactive({
+  autoVerify: false,
+  comment: '',
+  // This is not good typescript but need an object with fields
+  // in a dropdown that displays a string that can be blank. TODO
+  selectedContact: undefined as any,
+});
+const rules = {
+  autoVerify: {},
+  comment: {},
+  selectedContact: { required },
+};
+const v$ = useVuelidate(rules, formFields);
+
+// Form submission
+const submitted = ref(false);
+const handleSubmit = async (isFormValid: boolean) => {
+  submitted.value = true;
+
+  if (!isFormValid) {
+    return;
+  }
+  try {
+    // The json control changes to a string for some reason after editing...
+    const proofRequest: IndyProofRequest =
+      typeof proofRequestJson.value === 'string'
+        ? JSON.parse(proofRequestJson.value)
+        : proofRequestJson.value;
+    // Set up the body with the fields from the form
+    const payload: V10PresentationSendRequestRequest = {
+      connection_id: formFields.selectedContact.value,
+      auto_verify: false,
+      comment: '',
+      trace: false,
+      proof_request: proofRequest,
+    };
+    await verifierStore.sendPresentationRequest(payload);
+    toast.info('Request Sent');
+    emit('success');
+    // close up on success
+    emit('closed');
+  } catch (error) {
+    toast.error(`Failure: ${error}`);
+  } finally {
+    submitted.value = false;
+  }
+};
+</script>

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -81,6 +81,22 @@ export const API_PATH = {
   OCAS: '/oca',
   OCA: (id: string) => `/oca/${id}`,
 
+  PRESENT_PROOF_CREATE_REQUEST: '/present-proof/create-request',
+  PRESENT_PROOF_RECORDS: '/present-proof/records',
+  PRESENT_PROOF_RECORD: (id: string) => `/present-proof/records/${id}`,
+  PRESENT_PROOF_RECORD_CREDENTIALS: (id: string) =>
+    `/present-proof/records/${id}/credentials`,
+  PRESENT_PROOF_RECORD_PROBLEM: (id: string) =>
+    `/present-proof/records/${id}/problem-report`,
+  PRESENT_PROOF_RECORD_SEND_PRESENTATION: (id: string) =>
+    `/present-proof/records/${id}/send-presentation`,
+  PRESENT_PROOF_RECORD_SEND_REQUEST: (id: string) =>
+    `/present-proof/records/${id}/send-request`,
+  PRESENT_PROOF_RECORD_VERIFY: (id: string) =>
+    `/present-proof/records/${id}/verify-presentation`,
+  PRESENT_PROOF_SEND_PROPOSAL: '/present-proof/send-proposal',
+  PRESENT_PROOF_SEND_REQUEST: '/present-proof/send-request',
+
   REVOCATION_REVOKE: '/revocation/revoke',
 
   SCHEMAS: '/schemas',
@@ -146,3 +162,13 @@ export const RESERVATION_STATUSES = {
 };
 
 export const RESERVATION_STATUS_ROUTE = 'check-status';
+
+// json editor config
+export const JSON_EDITOR_DEFAULTS = {
+  mainMenuBar: false,
+  mode: 'text' as any,
+  statusBar: false,
+  navigationBar: false,
+  indentation: 2,
+  tabSize: 2,
+};

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -378,7 +378,12 @@
     "verifications": "Verifications"
   },
   "verify": {
-    "createRequest": "Create Presentation Requests",
+    "autoVerify": "Auto Verify",
+    "autoVerifyHelp": "Verifier choice to auto-verify proof presentation",
+    "comment": "Optional Comment",
+    "connection": "Connection",
+    "createRequest": "Create Presentation Request",
+    "presentationRequestBody": "Proof Request",
     "verification": "Verification",
     "verifications": "Verifications"
   }

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -382,7 +382,12 @@
     "verifications": "Verifications <FR>"
   },
   "verify": {
-    "createRequest": "Create Presentation Requests <FR>",
+    "autoVerify": "Auto Verify <FR>",
+    "autoVerifyHelp": "Verifier choice to auto-verify proof presentation <FR>",
+    "comment": "Optional Comment <FR>",
+    "connection": "Connection <FR>",
+    "createRequest": "Create Presentation Request <FR>",
+    "presentationRequestBody": "Proof Request <FR>",
     "verification": "Verification <FR>",
     "verifications": "Verifications <FR>"
   }

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
@@ -382,8 +382,12 @@
     "verifications": "Verifications <JP>"
   },
   "verify": {
-    "createRequest": "Create Presentation Requests <JP>",
+    "autoVerify": "Auto Verify <JP>",
+    "autoVerifyHelp": "Verifier choice to auto-verify proof presentation <JP>",
+    "comment": "Optional Comment <JP>",
+    "connection": "Connection <JP>",
+    "createRequest": "Create Presentation Request <JP>",
+    "presentationRequestBody": "Proof Request <JP>",
     "verification": "Verification <JP>",
     "verifications": "Verifications <JP>"
   }
-}

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
@@ -391,3 +391,4 @@
     "verification": "Verification <JP>",
     "verifications": "Verifications <JP>"
   }
+}

--- a/services/tenant-ui/frontend/src/store/verifierStore.ts
+++ b/services/tenant-ui/frontend/src/store/verifierStore.ts
@@ -1,10 +1,16 @@
+// Types
+import { V10PresentationSendRequestRequest } from '@/types/acapyApi/acapyInterface';
+
+import { useAcapyApi } from './acapyApi';
 import { API_PATH } from '@/helpers/constants';
 import { defineStore } from 'pinia';
-import { Ref, ref } from 'vue';
+import { ref } from 'vue';
 import { fetchItem } from './utils/fetchItem';
 import { fetchList } from './utils/fetchList';
 
 export const useVerifierStore = defineStore('verifier', () => {
+  const acapyApi = useAcapyApi();
+
   // state
   const presentations: any = ref(null);
   const selectedPresentation: any = ref(null);
@@ -18,7 +24,7 @@ export const useVerifierStore = defineStore('verifier', () => {
   async function listPresentations() {
     selectedPresentation.value = null;
     return fetchList(
-      API_PATH.VERIFIER_PRESENTATIONS,
+      API_PATH.PRESENT_PROOF_RECORDS,
       presentations,
       error,
       loading
@@ -36,6 +42,32 @@ export const useVerifierStore = defineStore('verifier', () => {
     );
   }
 
+  async function sendPresentationRequest(
+    payload: V10PresentationSendRequestRequest
+  ) {
+    loading.value = true;
+    error.value = null;
+
+    let result = null;
+    try {
+      result = await acapyApi.postHttp(
+        API_PATH.PRESENT_PROOF_SEND_REQUEST,
+        payload
+      );
+      listPresentations();
+    } catch (err) {
+      console.log(err);
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+
+    if (error.value != null) {
+      throw error.value;
+    }
+    return result;
+  }
+
   return {
     presentations,
     selectedPresentation,
@@ -43,6 +75,7 @@ export const useVerifierStore = defineStore('verifier', () => {
     error,
     listPresentations,
     getPresentation,
+    sendPresentationRequest,
   };
 });
 


### PR DESCRIPTION
Sample tenants in this PR (with connections and test presentation requests):

**Verifier**
77397d1a-7483-4f46-8c54-42fe76bb2ddb
8ecbecf0-f5f5-46f8-bd44-49b89276520b

**Prover**
74a34bc2-2eb7-4d03-abed-d33622514948
04e67047-4884-4106-959c-288c4e57ed28

Add a "Verification" page where you can create presentation requests.
The proof-request field part of it is just JSON, pre-populates with default data from an AIP concept page sample. Users will have to paste in a valid data here.
Uses the connections drop down so you select which connection to send to
![image](https://github.com/bcgov/traction/assets/17445138/055ec498-d58d-44be-8bf9-b04630d51ec2)

This page serves to show:
- the requests you have made as a **verifier**
- requests sent to you as the **prover**

Probably a lot of UX discussion about how best to display all this. Should these be the same page? Or split (like issuer and holder etc)

**Verifier**
![image](https://github.com/bcgov/traction/assets/17445138/36b84dca-5527-4c18-bf6a-b3bdfb0d3d33)


**Prover**
![image](https://github.com/bcgov/traction/assets/17445138/fb5206e2-2cf8-404c-a670-28591f855d87)
