### PR TITLE
Skip reservation password entry for auto-approve and check in automatically

### DIFF
--- a/charts/traction/values-pr.yaml
+++ b/charts/traction/values-pr.yaml
@@ -21,6 +21,7 @@ acapy:
       printKey: true
       printToken: true
       reservationExpiryMinutes: 2880
+      reservationAutoApprove: true
   resources:
     limits:
       cpu: 200m

--- a/services/tenant-ui/frontend/src/components/reservation/Reserve.vue
+++ b/services/tenant-ui/frontend/src/components/reservation/Reserve.vue
@@ -1,9 +1,12 @@
 <template>
   <!-- Request successful -->
   <div v-if="reservationIdResult">
-    <ProgressSpinner v-if="loading" class="flex justify-content-center" />
+    <div v-if="loading" class="flex flex-column align-items-center">
+      <ProgressSpinner />
+      <p>{{ $t('reservations.loadingCheckIn') }}</p>
+    </div>
     <div v-else>
-      <!-- If auto-approve on the confirmation will come right up -->
+      <!-- If auto-approve on, the confirmation will come right up -->
       <ShowWallet v-if="status === RESERVATION_STATUSES.SHOW_WALLET" />
       <ReservationConfirmation
         v-else

--- a/services/tenant-ui/frontend/src/components/reservation/Reserve.vue
+++ b/services/tenant-ui/frontend/src/components/reservation/Reserve.vue
@@ -1,11 +1,17 @@
 <template>
   <!-- Request successful -->
   <div v-if="reservationIdResult">
-    <ReservationConfirmation
-      :id="reservationIdResult"
-      :email="formFields.contact_email"
-      :pwd="reservationPwdResult"
-    />
+    <ProgressSpinner v-if="loading" class="flex justify-content-center" />
+    <div v-else>
+      <!-- If auto-approve on the confirmation will come right up -->
+      <ShowWallet v-if="status === RESERVATION_STATUSES.SHOW_WALLET" />
+      <ReservationConfirmation
+        v-else
+        :id="reservationIdResult"
+        :email="formFields.contact_email"
+        :pwd="reservationPwdResult"
+      />
+    </div>
   </div>
 
   <!-- Submit Request -->
@@ -146,6 +152,7 @@ import { ref, reactive } from 'vue';
 // PrimeVue/Validation/etc
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
+import ProgressSpinner from 'primevue/progressspinner';
 import Textarea from 'primevue/textarea';
 import { useToast } from 'vue-toastification';
 import { email, required } from '@vuelidate/validators';
@@ -153,6 +160,9 @@ import { useVuelidate } from '@vuelidate/core';
 // State
 import { useReservationStore } from '@/store';
 import { storeToRefs } from 'pinia';
+// Components
+import { RESERVATION_STATUSES } from '@/helpers/constants';
+import ShowWallet from './status/ShowWallet.vue';
 import ReservationConfirmation from './ReservationConfirmation.vue';
 
 const toast = useToast();
@@ -176,7 +186,7 @@ const v$ = useVuelidate(rules, formFields);
 
 // State setup
 const reservationStore = useReservationStore();
-const { loading } = storeToRefs(useReservationStore());
+const { loading, status } = storeToRefs(useReservationStore());
 
 // The reservation return object
 const reservationIdResult: any = ref('');

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -282,6 +282,7 @@
     "enterPassword": "Please enter the reservation password below to validate your account.",
     "history": "History",
     "incorrectEmailOrReservationId": "Incorrect Email or Reservation ID. Please try again.",
+    "loadingCheckIn": "Checking in Reservation",
     "otp": "The password is shown below one-time if you need to communicate it via other means",
     "passwordAvailable": "The reservation password is visible below, please use it to complete your check-in.",
     "passwordValid48Hours": "The reservation password is only valid for 48 hours from the time it was sent to your email address.",

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -282,6 +282,7 @@
     "enterPassword": "Please enter the reservation password below to validate your account. <FR>",
     "history": "History <FR>",
     "incorrectEmailOrReservationId": "Incorrect Email or Reservation ID. Please try again. <FR>",
+    "loadingCheckIn": "Checking in Reservation <FR>",
     "otp": "The password is shown below one-time if you need to communicate it via other means <FR>",
     "passwordAvailable": "The reservation password is visible below, please use it to complete your check-in. <FR>",
     "passwordValid48Hours": "The reservation password is only valid for 48 hours from the time it was sent to your email address. <FR>",

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/jp.json
@@ -282,6 +282,7 @@
     "enterPassword": "Please enter the reservation password below to validate your account. <JP>",
     "history": "History <JP>",
     "incorrectEmailOrReservationId": "Incorrect Email or Reservation ID. Please try again. <JP>",
+    "loadingCheckIn": "Checking in Reservation <JP>",
     "otp": "The password is shown below one-time if you need to communicate it via other means <JP>",
     "passwordAvailable": "The reservation password is visible below, please use it to complete your check-in. <JP>",
     "passwordValid48Hours": "The reservation password is only valid for 48 hours from the time it was sent to your email address. <JP>",


### PR DESCRIPTION
**NOTE: In this PR, auto-approve is on, can undo flag setting before merge**

Bypass reservation ID and PW if the reservation PW comes back to the Tenant UI (IE, auto-approve is on).
Just call check-in with the returned details. Some view changing to handle this flow. Tested it out with auto on and auto off and working fine.
Skips sending the email with the reservation ID and PW since the user has no concept of those in this case. The Wallet ID and Key are handled all the same as before.

![image](https://github.com/bcgov/traction/assets/17445138/7963281c-6729-47c4-8010-152efa125b1a)
--
![image](https://github.com/bcgov/traction/assets/17445138/54ddf6ca-2711-47d8-9076-2c498ebf9073)
--
![image](https://github.com/bcgov/traction/assets/17445138/4d509532-2376-43c5-a08a-781466e0870b)
