### PR TITLE
Update references from develop -> main for branch switch

### DIFF
--- a/.github/workflows/on_pr_closed.yaml
+++ b/.github/workflows/on_pr_closed.yaml
@@ -2,7 +2,7 @@ name: Uninstall PR instance
 on:
   pull_request:
     branches:
-      - develop
+      - main
     paths:
       - 'plugins/**'
       - 'services/tenant-ui/**'

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -2,7 +2,7 @@ name: Install/upgrade PR Instance
 on:
   pull_request:
     branches:
-      - develop
+      - main
     paths:
       - "plugins/**"
       - "services/tenant-ui/**"

--- a/.github/workflows/on_push_services.yaml
+++ b/.github/workflows/on_push_services.yaml
@@ -1,9 +1,9 @@
-name: Push Instance to Develop
+name: Push Instance to main
 on:
   workflow_dispatch:
   push:
     branches:
-      - develop
+      - main
     paths:
       - "plugins/**"
       - "services/tenant-ui/**"

--- a/.github/workflows/test_tenant_ui.yml
+++ b/.github/workflows/test_tenant_ui.yml
@@ -5,9 +5,9 @@ name: Build and Test Tenant UI
 
 on:
   push:
-    branches: ["develop"]
+    branches: ["main"]
   pull_request:
-    branches: ["develop"]
+    branches: ["main"]
 
 jobs:
   backend:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Currently authorized users can create a branch and run a pull request to merge i
 git fetch --all
 git pull
 
-git rebase origin/develop
+git rebase origin/main
 git push --force
 ```
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -23,8 +23,8 @@ helm upgrade -f ./charts/traction/values.yaml -f ./charts/traction/values-pr.yam
 For each set of charts (tenant-ui, traction), there is a base values.yaml file with default production configuration. 
 
 There are instance/deployment overrides for:
-- Pull Requests (-pr). This goes to our dev namespace and is pre-merge to the develop branch.
-- Development (-development). This goes to our dev namespace and is post-merge to the develop branch, pre-promotion to test.
+- Pull Requests (-pr). This goes to our dev namespace and is pre-merge to the main branch.
+- Development (-development). This goes to our dev namespace and is post-merge to the main branch, pre-promotion to test.
 - Test (-test). This goes to our test namespace and is pre-integration.
 - Integration (-int). This goes to our test namespace and is pre-production.
 - Production (-production). This goes to our production namespace. Production for us is not intended for client use; it is to prove out production scenarios before we deliver code to other interested business units to run their own instances.

--- a/charts/traction/templates/_helpers.tpl
+++ b/charts/traction/templates/_helpers.tpl
@@ -217,7 +217,7 @@ curl -d '{\"seed\":\"$(ACAPY_WALLET_SEED)\", \"role\":\"TRUST_ANCHOR\", \"alias\
 generate tails baseUrl
 */}}
 {{- define "acapy.tails.baseUrl" -}}
-{{- $tailsBaseUrl := dict "bosch-test" "https://tails-dev.vonx.io" "bcovrin-test" "https://tails-test.vonx.io" "idu" (printf "https://tails%s" .Values.global.ingressSuffix) -}}
+{{- $tailsBaseUrl := dict "bcovrin-dev" "https://tails-dev.vonx.io" "bcovrin-test" "https://tails-test.vonx.io" "idu" (printf "https://tails%s" .Values.global.ingressSuffix) -}}
 {{ .Values.acapy.tails.baseUrlOverride| default ( get $tailsBaseUrl .Values.global.ledger ) }}
 {{- end }}
 
@@ -225,7 +225,7 @@ generate tails baseUrl
 generate tails uploadUrl
 */}}
 {{- define "acapy.tails.uploadUrl" -}}
-{{- $tailsUploadUrl:= dict "bosch-test" "https://tails-dev.vonx.io" "bcovrin-test" "https://tails-test.vonx.io" "idu" "http://idu-tails:6543" -}}
+{{- $tailsUploadUrl:= dict "bcovrin-dev" "https://tails-dev.vonx.io" "bcovrin-test" "https://tails-test.vonx.io" "idu" "http://idu-tails:6543" -}}
 {{ .Values.acapy.tails.uploadUrlOverride| default ( get $tailsUploadUrl .Values.global.ledger ) }}
 {{- end }}
 

--- a/plugins/demo/README.md
+++ b/plugins/demo/README.md
@@ -42,7 +42,7 @@ Random-Word = "^1.0.11"
 
 script is based on running acapy with traction plugins using the default demo local environment.
 
-see https://github.com/bcgov/traction/tree/develop/plugins/demo
+see https://github.com/bcgov/traction/tree/main/plugins/demo
 """
 
 # default configuration for local development...

--- a/scripts/.env-example
+++ b/scripts/.env-example
@@ -73,8 +73,8 @@ ACAPY_AUTO_PROMOTE_AUTHOR_DID=true
 
 ACAPY_CREATE_REVOCATION_TRANSACTIONS=true
 
-ACAPY_TAILS_SERVER_BASE_URL=https://tails-dev.vonx.io
-ACAPY_TAILS_SERVER_UPLOAD_URL=https://tails-dev.vonx.io
+ACAPY_TAILS_SERVER_BASE_URL=https://tails-test.vonx.io
+ACAPY_TAILS_SERVER_UPLOAD_URL=https://tails-test.vonx.io
 
 ACAPY_NOTIFY_REVOCATION=true
 ACAPY_MONITOR_REVOCATION_NOTIFICATION=true
@@ -177,7 +177,7 @@ UX_SIDEBAR_TITLE=Traction
 UX_COPYRIGHT=2022 © Energy & Mines Digital Trust
 UX_OWNER=Owned and operated by the B.C. Government
 FRONTEND_ARIES_LEDGER_DESCRIPTION=bcovrin-test
-FRONTEND_ACAPY_VERSION_DISPLAY=1.0.0-rc
+FRONTEND_ACAPY_VERSION_DISPLAY=0.8.1
 
 # ------------------------------------------------------------
 # ------------------------------------------------------------

--- a/services/tenant-ui/config/default.json
+++ b/services/tenant-ui/config/default.json
@@ -27,10 +27,10 @@
       }
     },
     "ariesDetails": {
-      "acapyVersion": "1.0.0-rc",
+      "acapyVersion": "0.8.1",
       "ledgerName": "bcovrin-test",
       "ledgerBrowser": "http://test.bcovrin.vonx.io",
-      "tailsServer": "https://tails-dev.vonx.io"
+      "tailsServer": "https://tails-test.vonx.io"
     }
   },
   "image": {


### PR DESCRIPTION
Updating references to move from `develop` to `main` as main branch.

Switch path will be:
- ensuring required changes are pushed by this PR
- testing where possible that things won;t break
- merging PR
- deleting `main` branch and renaming `develop`->`main`
- set `main` as default branch

Branch protection rules appear to be already set-up correctly for `main`.