### PR TITLE
Update endorser-acapy-args.yml

### DIFF
--- a/scripts/endorser-acapy-args.yml
+++ b/scripts/endorser-acapy-args.yml
@@ -9,6 +9,7 @@ plugin: 'aries_cloudagent.messaging.jsonld'
 outbound-transport: http
 log-level: info
 endorser-protocol-role: endorser
+requests-through-public-did: true
 #endorser-public-did: <for author>
 #endorser-alias: <for author>
 #auto-request-endorsement: <for author>


### PR DESCRIPTION
Adds a setting for the Endorser to allow it to accept "implicit invitation" connection requests -- another agent requesting a connection by looking up the Endorser agent's public DID.

Addresses this comment an issue of Traction: https://github.com/bcgov/traction/issues/650#issuecomment-1579430307

This was a breaking change in ACA-Py as per -- https://github.com/hyperledger/aries-cloudagent-python/pull/2034

