### PR TITLE
Fix public fetch of OCA list endpoint

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/oca_service.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/oca_service.py
@@ -127,7 +127,7 @@ class OcaService:
         is_root_profile = issuer_profile == self.profile
         public_info = await self.get_public_did_info(issuer_profile)
         tag_filter = self.build_tag_filter(schema_id, cred_def_id)
-        post_filter = {} if is_root_profile == True else self.build_post_filter(public_info)
+        post_filter = {} if is_root_profile else self.build_post_filter(public_info)
         records = []
         if is_root_profile or public_info:
             self.logger.info(f"post_filter = {post_filter}")

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/oca_service.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/oca_service.py
@@ -127,7 +127,7 @@ class OcaService:
         is_root_profile = issuer_profile == self.profile
         public_info = await self.get_public_did_info(issuer_profile)
         tag_filter = self.build_tag_filter(schema_id, cred_def_id)
-        post_filter = self.build_post_filter(public_info)
+        post_filter = {} if is_root_profile == True else self.build_post_filter(public_info)
         records = []
         if is_root_profile or public_info:
             self.logger.info(f"post_filter = {post_filter}")

--- a/services/tenant-ui/frontend/src/components/holder/Credentials.vue
+++ b/services/tenant-ui/frontend/src/components/holder/Credentials.vue
@@ -65,8 +65,7 @@ import Button from 'primevue/button';
 import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from 'vue-toastification';
 // State
-import { useContactsStore, useHolderStore } from '@/store';
-import { storeToRefs } from 'pinia';
+import { useHolderStore } from '@/store';
 // Other components
 import CredentialsCards from './CredentialsCards.vue';
 import CredentialsTable from './CredentialsTable.vue';
@@ -75,8 +74,6 @@ const toast = useToast();
 const confirm = useConfirm();
 
 // State
-const contactsStore = useContactsStore();
-const { contacts } = storeToRefs(useContactsStore());
 const holderStore = useHolderStore();
 
 // Table/card view toggle

--- a/services/tenant-ui/frontend/src/components/holder/CredentialsCards.vue
+++ b/services/tenant-ui/frontend/src/components/holder/CredentialsCards.vue
@@ -30,9 +30,6 @@ import { storeToRefs } from 'pinia';
 import OcaCard from './credentialOcaCard/OcaCard.vue';
 import SkeletonCard from '@/components/common/SkeletonCard.vue';
 
-// The emits it can do (common things between table and card view handled in parent)
-// defineEmits(['accept', 'delete', 'reject']);
-
 const toast = useToast();
 
 // State
@@ -42,7 +39,7 @@ const holderStore = useHolderStore();
 onMounted(async () => {
   holderStore.listCredentials();
   // Get the oca list avaliable, each card will fetch it's OCA though
-  holderStore.listOcas().catch((err) => {
+  holderStore.listOcas(true).catch((err) => {
     console.error(err);
     toast.error(`Failed to load Credentials from your wallet: ${err}`);
   });

--- a/services/tenant-ui/frontend/src/store/acapyApi.ts
+++ b/services/tenant-ui/frontend/src/store/acapyApi.ts
@@ -34,14 +34,20 @@ export const useAcapyApi = defineStore('acapyApi', () => {
   // need to add authorization before we make traction tenant requests...
   acapyApi.interceptors.request.use(
     async (dataConfig: any) => {
-      // console.log('acapyApi.request.fulfilled');
+      // if the consumer provides an auth header (even blank) in options, then use it, otherwise default to the token
+      let auth = `Bearer ${tokenStore.token}`;
+      const authOverride = dataConfig.headers?.Authorization;
+      if (authOverride || authOverride === '') {
+        auth = authOverride;
+      }
+
       const result = {
         ...dataConfig,
         headers: {
           'Content-Type': 'application/json',
           accept: 'application/json',
           ...dataConfig.headers,
-          Authorization: `Bearer ${tokenStore.token}`,
+          Authorization: auth,
         },
       };
       return result;

--- a/services/tenant-ui/frontend/src/store/holderStore.ts
+++ b/services/tenant-ui/frontend/src/store/holderStore.ts
@@ -44,8 +44,12 @@ export const useHolderStore = defineStore('holder', () => {
     return fetchList(API_PATH.CREDENTIALS, credentials, error, loading);
   }
 
-  async function listOcas() {
-    return fetchList(API_PATH.OCAS, ocas, error, loadingOca);
+  async function listOcas(fetchPublic?: boolean) {
+    // If getting public, don't use the default auth token from the axios instance
+    const options = fetchPublic
+      ? { headers: { Authorization: '' } }
+      : undefined;
+    return fetchList(API_PATH.OCAS, ocas, error, loadingOca, {}, options);
   }
 
   async function listHolderCredentialExchanges() {

--- a/services/tenant-ui/frontend/src/store/utils/fetchList.ts
+++ b/services/tenant-ui/frontend/src/store/utils/fetchList.ts
@@ -7,10 +7,11 @@ export async function fetchList<T>(
   list: Ref<T[]>,
   error: Ref<any>,
   loading: Ref<boolean>,
-  params: object = {}
+  params: object = {},
+  options?: object
 ) {
   const acapyApi = useAcapyApi();
-  return fetchListFromAPI(acapyApi, url, list, error, loading, params);
+  return fetchListFromAPI(acapyApi, url, list, error, loading, params, options);
 }
 
 export async function fetchListFromAPI<T>(
@@ -19,7 +20,8 @@ export async function fetchListFromAPI<T>(
   list: Ref<T[]>,
   error: Ref<any>,
   loading: Ref<boolean>,
-  params: object = {}
+  params: object = {},
+  options?: object
 ): Promise<T[]> {
   console.log(`> fetchList(${url})`);
   list.value = [];
@@ -27,7 +29,7 @@ export async function fetchListFromAPI<T>(
   loading.value = true;
   params = { ...params };
   await api
-    .getHttp(url, params)
+    .getHttp(url, params, options)
     .then((res: AxiosRequestConfig): void => {
       if (res.data.results) {
         list.value = res.data.results;


### PR DESCRIPTION
Don't filter if root profile (no tenant token provided). If the endpoint is called as intended publicly, do not filter on a DID.
So this will allow (as designed)
- You to call /oca to get the directory of public OCA-cred associations from Traction as anybody
- You to call it authenticated with your token to get your OCAs that you manage.

Also adjust (and refactor to make it less verbose to do) the Tenant UI to call the OCA endpoint unauthed when appropriate

There's a separate weirdness here being investigated where the base wallet on deployed (but not local docker) Traction instances is coming back with a public DID that was exposing this. Unrelated, but will look into that more. Regardless, the auauthed call to this endpoint shouldn't be looking for a DID to compare anyways.