### PR TITLE
Auto translate date format based on current i18n Locale

### DIFF
--- a/services/tenant-ui/frontend/src/components/common/LocaleSwitcher.vue
+++ b/services/tenant-ui/frontend/src/components/common/LocaleSwitcher.vue
@@ -5,10 +5,11 @@
 <script setup lang="ts">
 import Dropdown from 'primevue/dropdown';
 import { useI18n } from 'vue-i18n';
+import { i18nLocale } from '@/helpers';
 
 const { locale } = useI18n({ useScope: 'global' });
 
-const localeList = ['en', 'fr', 'jp'];
+const localeList: Array<i18nLocale> = ['en', 'fr', 'jp'];
 </script>
 
 <style lang="scss" scoped>

--- a/services/tenant-ui/frontend/src/components/common/LocaleSwitcher.vue
+++ b/services/tenant-ui/frontend/src/components/common/LocaleSwitcher.vue
@@ -5,11 +5,11 @@
 <script setup lang="ts">
 import Dropdown from 'primevue/dropdown';
 import { useI18n } from 'vue-i18n';
-import { i18nLocale } from '@/helpers';
+import { I18nLocale } from '@/helpers';
 
 const { locale } = useI18n({ useScope: 'global' });
 
-const localeList: Array<i18nLocale> = ['en', 'fr', 'jp'];
+const localeList: Array<I18nLocale> = ['en', 'fr', 'jp'];
 </script>
 
 <style lang="scss" scoped>

--- a/services/tenant-ui/frontend/src/helpers/index.ts
+++ b/services/tenant-ui/frontend/src/helpers/index.ts
@@ -2,22 +2,22 @@ import { format, fromUnixTime, parseJSON } from 'date-fns';
 import { enCA, fr, ja } from 'date-fns/locale';
 import { useI18n } from 'vue-i18n';
 
-export type i18nLocale = 'en' | 'fr' | 'jp';
+export type I18nLocale = 'en' | 'fr' | 'jp';
 
-function i18n2DateLocale(i18nLocal: i18nLocale) {
-  switch (i18nLocal) {
+function i18n2DateLocale(i18nLocale: I18nLocale): Locale {
+  switch (i18nLocale) {
     case 'en':
       return enCA;
     case 'fr':
       return fr;
     case 'jp':
       return ja;
-    default:
-      console.log(
-        `No valid translation found for ${i18nLocal} defaulting to enCA`
-      );
-      return enCA;
   }
+  // This way we can fall back to a default while using typescript to
+  // enforce that all instances of i18nLocale have a corresponding case in the
+  // switch statement
+  /* eslint no-unreachable: "error" */
+  throw new Error('No valid date-fn');
 }
 
 function _dateFnsFormat(value: string, formatter: string) {
@@ -25,9 +25,17 @@ function _dateFnsFormat(value: string, formatter: string) {
   const formatted = '';
   try {
     if (value) {
-      return format(parseJSON(value), formatter, {
-        locale: i18n2DateLocale(locale.value as i18nLocale),
-      });
+      try {
+        return format(parseJSON(value), formatter, {
+          locale: i18n2DateLocale(locale.value as I18nLocale),
+        });
+      } catch {
+        // Incase the locale was never set (used outside of a vue component)
+        console.log(
+          `No valid translation found for ${locale.value} defaulting to enCA`
+        );
+        return format(parseJSON(value), formatter, { locale: enCA });
+      }
     }
   } catch (error) {
     console.error(`_dateFnsFormat: Error parsing ${value} to ${error}`);

--- a/services/tenant-ui/frontend/src/helpers/index.ts
+++ b/services/tenant-ui/frontend/src/helpers/index.ts
@@ -1,10 +1,33 @@
 import { format, fromUnixTime, parseJSON } from 'date-fns';
+import { enCA, fr, ja } from 'date-fns/locale';
+import { useI18n } from 'vue-i18n';
+
+export type i18nLocale = 'en' | 'fr' | 'jp';
+
+function i18n2DateLocale(i18nLocal: i18nLocale) {
+  switch (i18nLocal) {
+    case 'en':
+      return enCA;
+    case 'fr':
+      return fr;
+    case 'jp':
+      return ja;
+    default:
+      console.log(
+        `No valid translation found for ${i18nLocal} defaulting to enCA`
+      );
+      return enCA;
+  }
+}
 
 function _dateFnsFormat(value: string, formatter: string) {
+  const { locale } = useI18n();
   const formatted = '';
   try {
     if (value) {
-      return format(parseJSON(value), formatter);
+      return format(parseJSON(value), formatter, {
+        locale: i18n2DateLocale(locale.value as i18nLocale),
+      });
     }
   } catch (error) {
     console.error(`_dateFnsFormat: Error parsing ${value} to ${error}`);


### PR DESCRIPTION
Resolves #593 the solution simply translates the i18n locale to the corresponding local supported by date-fns. I created a new type  that is also used in the `LocaleSwitcher` to ensure that when ever a new i18n locale is added the corresponding translation is also implemented. 

To better enforce this the conversion function will throw an exception. This is only necessary to handle cases where _dateFnsFormat is used outside of a vue component (which is likely never)


![image](https://github.com/bcgov/traction/assets/34443260/bcadc0c8-2cb0-4887-a885-344d16846203)

![image](https://github.com/bcgov/traction/assets/34443260/bd1fab0a-fb26-4578-96ae-1d0167f603aa)

![image](https://github.com/bcgov/traction/assets/34443260/917efd2a-9493-4fa2-a2b7-16fc3bf3b6e9)
