### PR TITLE
Update workflows to fix deployments

### DIFF
--- a/.github/actions/build_acapy/action.yaml
+++ b/.github/actions/build_acapy/action.yaml
@@ -79,6 +79,6 @@ runs:
     - id: values  
       shell: bash
       run: |
-        echo "image_tag=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
+        echo "image_tag=${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}${{ inputs.ref }}" >> $GITHUB_OUTPUT
         echo "image_version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
         echo "buildtime=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}" >> $GITHUB_OUTPUT

--- a/.github/actions/build_ui/action.yaml
+++ b/.github/actions/build_ui/action.yaml
@@ -114,6 +114,6 @@ runs:
     - id: values
       shell: bash
       run: |
-        echo "image_tag=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
+        echo "image_tag=${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}${{ inputs.ref }}" >> $GITHUB_OUTPUT
         echo "image_version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
         echo "buildtime=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_deploy_tenant_ui.yaml
+++ b/.github/workflows/build_deploy_tenant_ui.yaml
@@ -1,4 +1,4 @@
-name: Deploy Tenant UI
+name: Build & Deploy Tenant UI
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -1,4 +1,4 @@
-name: Push Instance to main
+name: Build & Deploy Development
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
- Update `build tenant-ui` and `build acapy` actions to output only the image tag instead of the full image name with registry, repository, and tag. (Should fix the currently failing dev deployment workflow)
- Rename workflows