### PR TITLE
Revert changes to actions, update dev workflow

### DIFF
--- a/.github/actions/build_acapy/action.yaml
+++ b/.github/actions/build_acapy/action.yaml
@@ -79,6 +79,6 @@ runs:
     - id: values  
       shell: bash
       run: |
-        echo "image_tag=${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}${{ inputs.ref }}" >> $GITHUB_OUTPUT
+        echo "image_tag=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
         echo "image_version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
         echo "buildtime=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}" >> $GITHUB_OUTPUT

--- a/.github/actions/build_ui/action.yaml
+++ b/.github/actions/build_ui/action.yaml
@@ -114,6 +114,6 @@ runs:
     - id: values
       shell: bash
       run: |
-        echo "image_tag=${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}${{ inputs.ref }}" >> $GITHUB_OUTPUT
+        echo "image_tag=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
         echo "image_version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
         echo "buildtime=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -89,11 +89,11 @@ jobs:
 
       - name: Traction Dev Helm
         run: |
-          helm upgrade --install traction -f ./deploy/traction/values-development.yaml --set acapy.image.tag=${{ needs.build_acapy.outputs.image_tag }} --set traction_proxy.image.tag=${{ needs.build_acapy.outputs.image_tag }} ./charts/traction --wait
+          helm upgrade --install traction -f ./deploy/traction/values-development.yaml --set acapy.image.tag=${{ github.ref }} --set traction_proxy.image.tag=${{ needs.build_acapy.outputs.image_tag }} ./charts/traction --wait
 
       - name: Tenant UI Dev Helm
         run: |
-          helm upgrade --install tenant-ui -f ./deploy/tenant-ui/values-development.yaml --set image.tag=${{ needs.build_ui.outputs.image_version }} ./charts/tenant-ui --wait
+          helm upgrade --install tenant-ui -f ./deploy/tenant-ui/values-development.yaml --set image.tag=${{ github.ref }} ./charts/tenant-ui --wait
 
       - name: Restart Deployments
         run: |

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -89,11 +89,11 @@ jobs:
 
       - name: Traction Dev Helm
         run: |
-          helm upgrade --install traction -f ./deploy/traction/values-development.yaml --set acapy.image.tag=${{ github.ref }} --set traction_proxy.image.tag=${{ needs.build_acapy.outputs.image_tag }} ./charts/traction --wait
+          helm upgrade --install traction -f ./deploy/traction/values-development.yaml --set acapy.image.tag=${{ needs.build_acapy.outputs.image_version }} --set traction_proxy.image.tag=${{ needs.build_acapy.outputs.image_version }} ./charts/traction --wait
 
       - name: Tenant UI Dev Helm
         run: |
-          helm upgrade --install tenant-ui -f ./deploy/tenant-ui/values-development.yaml --set image.tag=${{ github.ref }} ./charts/tenant-ui --wait
+          helm upgrade --install tenant-ui -f ./deploy/tenant-ui/values-development.yaml --set image.tag=${{ needs.build_ui.outputs.image_version }} ./charts/tenant-ui --wait
 
       - name: Restart Deployments
         run: |

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -27,6 +27,7 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       image_tag: ${{ steps.builder.outputs.image_tag }}
+      image_version: ${{ steps.builder.outputs.image_version }}
 
   build_acapy:
     name: "Build Traction Aca-Py"
@@ -46,6 +47,7 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       image_tag: ${{ steps.builder.outputs.image_tag }}
+      image_version: ${{ steps.builder.outputs.image_version }}
 
   build_proxy:
     name: "Build Traction Tenant Proxy"
@@ -65,6 +67,7 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       image_tag: ${{ steps.builder.outputs.image_tag }}
+      image_version: ${{ steps.builder.outputs.image_version }}
 
   deploy:
     name: Deploy Dev

--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -8,9 +8,9 @@ acapy:
     pullPolicy: Always
   secret:
     adminApiKey:
-      generated: false
+      generated: true
     pluginInnkeeper:
-      generated: false
+      generated: true
   pluginValues:
     tractionInnkeeper:
       printKey: true


### PR DESCRIPTION
## Fix Build & Deploy Development workflow
- revert changes to `build_ui` and `build_acapy` actions
- update `on_push_main` workflow to use `...outputs.image_version` for image tags.