### PR TITLE
Do not disable name and email for OIDC reservation

### DIFF
--- a/services/tenant-ui/frontend/src/components/reservation/Reserve.vue
+++ b/services/tenant-ui/frontend/src/components/reservation/Reserve.vue
@@ -37,7 +37,6 @@
           name="email"
           autofocus
           class="w-full"
-          :disabled="config.frontend.showOIDCReservationLogin"
         />
         <span v-if="v$.contact_email.$error && submitted">
           <span v-for="(error, index) of v$.contact_email.$errors" :key="index">
@@ -68,7 +67,6 @@
           autocomplete="full-name"
           name="fullName"
           class="w-full"
-          :disabled="config.frontend.showOIDCReservationLogin"
         />
         <small v-if="v$.contact_name.$invalid && submitted" class="p-error">{{
           v$.contact_name.required.$message


### PR DESCRIPTION
Take away the disabling of the name and email fields for now in the reserve form when using OIDC access.
Had consumers with IDIRs in the platform Keycloak that did not have email addresses unable to continue with reservation.