### PR TITLE
Innkeeper Auth Key CRUD

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
@@ -370,3 +370,111 @@ class TenantRecordSchema(BaseRecordSchema):
         fields.Str(description="Ledger id"),
         required=False,
     )
+
+
+class TenantAuthenticationUserRecord(BaseRecord):
+    """Innkeeper Tenant Authentication - User Record Schema"""
+
+    class Meta:
+        """TenantAuthenticationUserRecord Meta."""
+
+        schema_class = "TenantAuthenticationUserSchema"
+
+    RECORD_TYPE = "tenant_authentication_user"
+    RECORD_ID_NAME = "tenant_authentication_user_id"
+    TAG_NAMES = {
+        "tenant_id",
+        "user_id",
+    }
+
+    def __init__(
+        self,
+        *,
+        tenant_authentication_user_id: str = None,
+        tenant_id: str = None,
+        user_id: str = None,
+        user_name: str = None,
+        user_email: str = None,
+        **kwargs,
+    ):
+        """Construct record."""
+        super().__init__(tenant_authentication_user_id, **kwargs)
+        self.tenant_id = tenant_id
+        self.user_id = user_id
+        self.user_name = user_name
+        self.user_email = user_email
+        self.user_id = user_id
+
+    @property
+    def tenant_authentication_user_id(self) -> Optional[str]:
+        """Return record id."""
+        return uuid.UUID(self._id).hex
+
+    @classmethod
+    async def query_by_tenant_id(
+        cls,
+        session: ProfileSession,
+        tenant_id: str,
+    ) -> "TenantAuthenticationUserRecord":
+        """Retrieve TenantAuthenticationUserRecord by tenant_id.
+        Args:
+            session: the profile session to use
+            tenant_id: the tenant_id by which to filter
+        """
+        tag_filter = {
+            **{"tenant_id": tenant_id for _ in [""] if tenant_id},
+        }
+
+        result = await cls.query(session, tag_filter)
+        return result
+
+    @property
+    def record_value(self) -> dict:
+        """Return record value."""
+        return {
+            prop: getattr(self, prop)
+            for prop in (
+                "tenant_authentication_user_id",
+                "tenant_id",
+                "user_id",
+                "user_name",
+                "user_email",
+            )
+        }
+
+class TenantAuthenticationUserRecordSchema(BaseRecordSchema):
+    """Innkeeper Tenant Authentication - User Record Schema."""
+
+    class Meta:
+        """TenantAuthenticationUserSchema Meta."""
+
+        model_class = "TenantAuthenticationUser"
+        unknown = EXCLUDE
+
+    tenant_authentication_user_id = fields.Str(
+        required=True,
+        description="Tenant Authentication User Record identifier",
+        example=UUIDFour.EXAMPLE,
+    )
+
+    tenant_id = fields.Str(
+        required=False,
+        description="Tenant Record identifier",
+        example=UUIDFour.EXAMPLE,
+    )
+
+    user_id = fields.Str(
+        required=True,
+        description="Externally associable user identifier",
+        example="000000-1111111-aaaaa-bbbbb",
+    )
+
+    user_name = fields.Str(
+        required=True,
+        description="Contact name for this external user",
+    )
+
+    user_email = fields.Str(
+        required=True,
+        description="Contact email for this tenant request",
+    )

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
@@ -372,41 +372,37 @@ class TenantRecordSchema(BaseRecordSchema):
     )
 
 
-class TenantAuthenticationUserRecord(BaseRecord):
-    """Innkeeper Tenant Authentication - User Record Schema"""
+class TenantAuthenticationApiRecord(BaseRecord):
+    """Innkeeper Tenant Authentication - API Record Schema"""
 
     class Meta:
-        """TenantAuthenticationUserRecord Meta."""
+        """TenantAuthenticationApiRecord Meta."""
 
-        schema_class = "TenantAuthenticationUserSchema"
+        schema_class = "TenantAuthenticationApiSchema"
 
-    RECORD_TYPE = "tenant_authentication_user"
-    RECORD_ID_NAME = "tenant_authentication_user_id"
+    RECORD_TYPE = "tenant_authentication_api"
+    RECORD_ID_NAME = "tenant_authentication_api_id"
     TAG_NAMES = {
         "tenant_id",
-        "user_id",
     }
 
     def __init__(
         self,
         *,
-        tenant_authentication_user_id: str = None,
+        tenant_authentication_api_id: str = None,
         tenant_id: str = None,
-        user_id: str = None,
-        user_name: str = None,
-        user_email: str = None,
+        api_key: str = None,
+        alias: str = None,
         **kwargs,
     ):
         """Construct record."""
-        super().__init__(tenant_authentication_user_id, **kwargs)
+        super().__init__(tenant_authentication_api_id, **kwargs)
         self.tenant_id = tenant_id
-        self.user_id = user_id
-        self.user_name = user_name
-        self.user_email = user_email
-        self.user_id = user_id
+        self.api_key = api_key
+        self.alias = alias
 
     @property
-    def tenant_authentication_user_id(self) -> Optional[str]:
+    def tenant_authentication_api_id(self) -> Optional[str]:
         """Return record id."""
         return uuid.UUID(self._id).hex
 
@@ -415,8 +411,8 @@ class TenantAuthenticationUserRecord(BaseRecord):
         cls,
         session: ProfileSession,
         tenant_id: str,
-    ) -> "TenantAuthenticationUserRecord":
-        """Retrieve TenantAuthenticationUserRecord by tenant_id.
+    ) -> "TenantAuthenticationApiRecord":
+        """Retrieve TenantAuthenticationApiRecord by tenant_id.
         Args:
             session: the profile session to use
             tenant_id: the tenant_id by which to filter
@@ -436,24 +432,23 @@ class TenantAuthenticationUserRecord(BaseRecord):
             for prop in (
                 "tenant_authentication_user_id",
                 "tenant_id",
-                "user_id",
-                "user_name",
-                "user_email",
+                "api_key",
+                "alias",
             )
         }
 
-class TenantAuthenticationUserRecordSchema(BaseRecordSchema):
-    """Innkeeper Tenant Authentication - User Record Schema."""
+class TenantAuthenticationApiRecordSchema(BaseRecordSchema):
+    """Innkeeper Tenant Authentication - API Record Schema."""
 
     class Meta:
-        """TenantAuthenticationUserSchema Meta."""
+        """TenantAuthenticationApiRecordSchema Meta."""
 
-        model_class = "TenantAuthenticationUser"
+        model_class = "TenantAuthenticationApi"
         unknown = EXCLUDE
 
-    tenant_authentication_user_id = fields.Str(
+    tenant_authentication_api_id = fields.Str(
         required=True,
-        description="Tenant Authentication User Record identifier",
+        description="Tenant Authentication API Record identifier",
         example=UUIDFour.EXAMPLE,
     )
 
@@ -463,18 +458,13 @@ class TenantAuthenticationUserRecordSchema(BaseRecordSchema):
         example=UUIDFour.EXAMPLE,
     )
 
-    user_id = fields.Str(
+    api_key = fields.Str(
         required=True,
         description="Externally associable user identifier",
         example="000000-1111111-aaaaa-bbbbb",
     )
 
-    user_name = fields.Str(
-        required=True,
-        description="Contact name for this external user",
-    )
-
-    user_email = fields.Str(
-        required=True,
-        description="Contact email for this tenant request",
+    alias = fields.Str(
+        required=False,
+        description="Alias description for this API key",
     )

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/utils.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/utils.py
@@ -7,7 +7,11 @@ from aries_cloudagent.core.profile import Profile
 from aries_cloudagent.messaging.models.openapi import OpenAPISchema
 from marshmallow import fields
 
-from .models import ReservationRecord
+from .models import (
+    ReservationRecord,
+    TenantAuthenticationApiRecord
+)
+
 
 from . import TenantManager
 
@@ -87,5 +91,36 @@ async def approve_reservation(
     return _pwd
 
 
+def generate_api_key_data():
+    _key = str(uuid.uuid4().hex)
+    LOGGER.info(f"_key = {_key}")
+
+    _salt = bcrypt.gensalt()
+    LOGGER.info(f"_salt = {_salt}")
+
+    _hash = bcrypt.hashpw(_key.encode("utf-8"), _salt)
+    LOGGER.info(f"_hash = {_hash}")
+
+    return _key, _salt, _hash
+
+
+async def create_api_key(
+    rec: TenantAuthenticationApiRecord, manager: TenantManager
+):
+    async with manager.profile.session() as session:
+        _key, _salt, _hash = generate_api_key_data()
+        rec.api_key_token_salt = _salt.decode("utf-8")
+        rec.api_key_token_hash = _hash.decode("utf-8")
+        await rec.save(session)
+        LOGGER.info(rec)
+
+    # return the generated key and the created record id
+    return _key, rec.tenant_authentication_api_id
+
+
 class ReservationException(Exception):
+    pass
+
+
+class TenantApiKeyException(Exception):
     pass


### PR DESCRIPTION
Innkeeper endpoints to manage API keys for Tenant IDs

![image](https://github.com/bcgov/traction/assets/17445138/9fc0df1c-393c-4c6e-b4fe-20b27b4db4ea)

Put under the `innkeeper/authentications/api` structure to differentiate from future alternate authentication methods we may add (OIDC user etc).

Creating a key does a salt/hash for the persistence layer and returns the API Key to the response. This is a similar usage we do for Reservation password.

Next steps for API Key

- Basic Innkeeper UI management https://github.com/bcgov/traction/issues/741
- Get a token with this key https://github.com/bcgov/traction/issues/742
- Allow tenant to manage keys themselves?
