### PR TITLE
TEMP: test ui for autoissue

### DIFF
--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -28,7 +28,7 @@ acapy:
       reservation:
         expiry_minutes: 2880
         auto_approve: false
-        auto_issuer: false
+        auto_issuer: true
   resources:
     limits:
       cpu: 200m

--- a/services/tenant-ui/frontend/src/views/tenant/Profile.vue
+++ b/services/tenant-ui/frontend/src/views/tenant/Profile.vue
@@ -16,7 +16,7 @@
           <img v-if="isIssuer" src="/img/badges/issuer.png" />
         </div>
       </div>
-      <hr class="mb-4" />
+      <hr class="mb-5" />
       <ProfileFooter />
     </div>
   </MainCardContent>


### PR DESCRIPTION
Throwaway to flip helm val to confirm some Tenant UI things when auto issuer is on. Quicker to do on a PR in current situation.