### PR TITLE
Create Helm Chart Repo. Publish helm chart on new tag

### DIFF
--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -1,4 +1,4 @@
-name: Update Assets
+name: Release Assets
 
 on:
   push:
@@ -59,3 +59,24 @@ jobs:
           registry: ghcr.io
           registry_username: ${{ github.repository_owner}}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
+
+  helm_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
- Cleanup `gh-pages` branch to prepare for `helm-chart-releaser` gha action
- Rename `Update Assets` workflow to `Release Assets`
- Use the `helm-chart-releaser` gha action to publish Helm Chart releases