### PR TITLE
Allow manually triggering release assets workflow

### DIFF
--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   packages: write


### PR DESCRIPTION
Adding `workflow_dispatch` to `release_assets` workflow.