### PR TITLE
[Hotfix] Fix chart-releaser-action version in Release-Assets workflow

### DIFF
--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -78,6 +78,6 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fix `helm/chart-releaser-action` version reference from `@v1.6.0` to `@v1.5.0`