### PR TITLE
Remove image.tag value from deployment value overrides

### DIFF
--- a/deploy/tenant-ui/values-development.yaml
+++ b/deploy/tenant-ui/values-development.yaml
@@ -1,6 +1,5 @@
 ingressSuffix: -dev.apps.silver.devops.gov.bc.ca
 image:
-  tag: "0.2.14"
   pullPolicy: Always
 traction:
   pluginInnkeeper:

--- a/deploy/tenant-ui/values-pr.yaml
+++ b/deploy/tenant-ui/values-pr.yaml
@@ -1,6 +1,5 @@
 ingressSuffix: -dev.apps.silver.devops.gov.bc.ca
 image:
-  tag: "0.2.14"
   pullPolicy: Always
 traction:
   apiEndpoint: https://pr-00-traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca

--- a/deploy/tenant-ui/values-production.yaml
+++ b/deploy/tenant-ui/values-production.yaml
@@ -1,6 +1,4 @@
 ingressSuffix: -prod.apps.silver.devops.gov.bc.ca
-image:
-  tag: "0.2.14"
 traction:
   pluginInnkeeper:
     existingSecret: traction-acapy-plugin-innkeeper

--- a/deploy/tenant-ui/values-test.yaml
+++ b/deploy/tenant-ui/values-test.yaml
@@ -1,6 +1,5 @@
 ingressSuffix: -test.apps.silver.devops.gov.bc.ca
 image:
-  tag: "0.2.14"
   pullPolicy: Always
 traction:
   pluginInnkeeper:

--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -4,7 +4,6 @@ config:
     name: bcovrin-test
 acapy:
   image:
-    tag: "0.2.14"
     pullPolicy: Always
   secret:
     adminApiKey:
@@ -31,7 +30,6 @@ acapy:
         network.openshift.io/policy-group: ingress
 tenant_proxy:
   image:
-    tag: "0.2.14"
     pullPolicy: Always
   networkPolicy:
     enabled: true

--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -1,7 +1,6 @@
 ingressSuffix: -dev.apps.silver.devops.gov.bc.ca
 acapy:
   image:
-    tag: "sha-f678ca9"
     pullPolicy: Always
   secret:
     adminApiKey:
@@ -44,7 +43,6 @@ acapy:
         network.openshift.io/policy-group: ingress
 tenant_proxy:
   image:
-    tag: "sha-f678ca9"
     pullPolicy: Always
   networkPolicy:
     enabled: true

--- a/deploy/traction/values-production.yaml
+++ b/deploy/traction/values-production.yaml
@@ -1,7 +1,5 @@
 ingressSuffix: -prod.apps.silver.devops.gov.bc.ca
 acapy:
-  image:
-    tag: "0.2.14"
   networkPolicy:
     enabled: true
     ingress:
@@ -15,8 +13,6 @@ acapy:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 tenant_proxy:
-  image:
-    tag: "0.2.14"
   networkPolicy:
     enabled: true
     ingress:

--- a/deploy/traction/values-test.yaml
+++ b/deploy/traction/values-test.yaml
@@ -1,7 +1,6 @@
 ingressSuffix: -test.apps.silver.devops.gov.bc.ca
 acapy:
   image:
-    tag: "0.2.14"
     pullPolicy: Always
   networkPolicy:
     enabled: true
@@ -17,7 +16,6 @@ acapy:
     targetMemoryUtilizationPercentage: 80
 tenant_proxy:
   image:
-    tag: "0.2.14"
     pullPolicy: Always
   networkPolicy:
     enabled: true


### PR DESCRIPTION
GitHub Actions workflows override the image tag values with `--set` flags when running Helm commands.
Removing the image tag values here to remove potential confusion when manually deploying the chart using these values files.
