### PR TITLE
Add unit tests for showing/hiding ui elements with config flag

### DIFF
--- a/services/tenant-ui/frontend/test/__mocks__/store/config.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/store/config.ts
@@ -24,7 +24,7 @@ const store: { [key: string]: any } = {
       tenantProxyPath: API_PATH.TEST_TENANT_PROXY,
       showOIDCReservationLogin: false,
       showInnkeeperAdminLogin: true,
-      showWritableComponents: false,
+      showWritableComponents: true,
     },
     image: {
       tag: '1.0',

--- a/services/tenant-ui/frontend/test/components/about/Acapy.test.ts
+++ b/services/tenant-ui/frontend/test/components/about/Acapy.test.ts
@@ -22,5 +22,6 @@ describe('Acapy', async () => {
     const store = useConfigStore();
     const wrapper = createWrapper();
     wrapper.getComponent({ name: 'Accordion' }).trigger('click');
+    expect(store.getPluginList).toHaveBeenCalled();
   });
 });

--- a/services/tenant-ui/frontend/test/components/issuance/issuedCredentials.test.ts
+++ b/services/tenant-ui/frontend/test/components/issuance/issuedCredentials.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from 'vitest';
 
 import IssuedCredentials from '@/components/issuance/IssuedCredentials.vue';
 
+import { configStore } from '../../__mocks__/store';
+
 const mountIssuedCredentials = () =>
   mount(IssuedCredentials, {
     global: {
@@ -18,6 +20,16 @@ describe('IssuedCredentials', () => {
     const wrapper = mountIssuedCredentials();
 
     wrapper.getComponent({ name: 'DataTable' });
+    wrapper.getComponent({ name: 'OfferCredential' });
+  });
+
+  test('mount with showWritableComponents false does not have OfferCredential component', async () => {
+    configStore.config.frontend.showWritableComponents = false;
+    const wrapper = mountIssuedCredentials();
+
+    expect(wrapper.findComponent({ name: 'OfferCredential' }).exists()).toBe(
+      false
+    );
   });
 
   test('table body is rendered with expected values', async () => {

--- a/services/tenant-ui/frontend/test/components/messages/Messages.test.ts
+++ b/services/tenant-ui/frontend/test/components/messages/Messages.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, test } from 'vitest';
 
 import Messages from '@/components/messages/Messages.vue';
 
+import { configStore } from '../../__mocks__/store';
+
 const mountMessages = () =>
   mount(Messages, {
     global: {
@@ -16,6 +18,16 @@ describe('Messages', async () => {
   test('mount has expected components', () => {
     const wrapper = mountMessages();
     wrapper.getComponent({ name: 'DataTable' });
+    wrapper.getComponent({ name: 'CreateMessage' });
+  });
+
+  test('mount with showWritableComponents false does not have CreateMessage component', async () => {
+    configStore.config.frontend.showWritableComponents = false;
+    const wrapper = mountMessages();
+
+    expect(wrapper.findComponent({ name: 'CreateMessage' }).exists()).toBe(
+      false
+    );
   });
 
   test('table body is rendered with expected values', async () => {

--- a/services/tenant-ui/frontend/test/components/verifier/Presentations.test.ts
+++ b/services/tenant-ui/frontend/test/components/verifier/Presentations.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from 'vitest';
 
 import Presentations from '@/components/verifier/Presentations.vue';
 
+import { configStore } from '../../__mocks__/store';
+
 const mountPresentations = () =>
   mount(Presentations, {
     global: {
@@ -18,6 +20,20 @@ describe('Presentations', () => {
     const wrapper = mountPresentations();
 
     wrapper.getComponent({ name: 'DataTable' });
+    wrapper.getComponent({ name: 'CreateRequest' });
+    wrapper.getComponent({ name: 'DeleteExchangeRecord' });
+  });
+
+  test('mount with showWritableComponents false does not have CreateRequest or DeleteExchangeRecord components', async () => {
+    configStore.config.frontend.showWritableComponents = false;
+    const wrapper = mountPresentations();
+
+    expect(wrapper.findComponent({ name: 'CreateRequest' }).exists()).toBe(
+      false
+    );
+    expect(
+      wrapper.findComponent({ name: 'DeleteExchangeRecord' }).exists()
+    ).toBe(false);
   });
 
   test('table body is rendered with expected values', async () => {


### PR DESCRIPTION
Added unit tests for important ui components that get hidden by the showWritableComponents flag.

Can be used as an example for changing the config store values.