### PR TITLE
Add browser storage and router middleware for logout/refresh

### DIFF
--- a/charts/traction/templates/ui/configmap.yaml
+++ b/charts/traction/templates/ui/configmap.yaml
@@ -13,6 +13,8 @@ data:
   FRONTEND_INNKEEPER_OIDC_LABEL: {{ .Values.ui.oidc.label | quote }}
   FRONTEND_INNKEEPER_SHOW_ADMIN: {{ .Values.ui.oidc.showInnkeeperAdminLogin | quote }}
   FRONTEND_TENANT_SHOW_WRITABLE_COMPONENTS: {{ .Values.ui.oidc.showWritableComponents | quote }}
+  FRONTEND_SESSION_TIMEOUT_SECONDS: {{ .Values.ui.oidc.session.timeoutSeconds | quote }}
+  FRONTEND_SESSION_COUNTDOWN_SECONDS: {{ .Values.ui.oidc.session.countdownSeconds | quote }}
   FRONTEND_TENANT_PROXY_URL: https://{{ include "tenant_proxy.host" . }}
   SERVER_OIDC_JWKS: {{ .Values.ui.oidc.jwksUri | quote }}
   SERVER_OIDC_REALM: {{ .Values.ui.oidc.realm | quote }}

--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -48,6 +48,9 @@ ui:
     active: true
     showInnkeeperAdminLogin: true
     showWritableComponents: true
+    session:
+      timeoutSeconds: 600
+      countdownSeconds: 30
     authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
     jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
   ariesDetails:

--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -55,6 +55,9 @@ ui:
     active: true
     showInnkeeperAdminLogin: true
     showWritableComponents: true
+    session:
+      timeoutSeconds: 600
+      countdownSeconds: 30
     authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
     jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
   ariesDetails:

--- a/deploy/traction/values-production.yaml
+++ b/deploy/traction/values-production.yaml
@@ -30,6 +30,9 @@ ui:
     active: true
     showInnkeeperAdminLogin: true
     showWritableComponents: false
+    session:
+      timeoutSeconds: 600
+      countdownSeconds: 30
     authority: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
     jwksUri: https://loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
   ariesDetails:

--- a/deploy/traction/values-test.yaml
+++ b/deploy/traction/values-test.yaml
@@ -36,6 +36,9 @@ ui:
     active: true
     showInnkeeperAdminLogin: true
     showWritableComponents: true
+    session:
+      timeoutSeconds: 600
+      countdownSeconds: 30
     authority: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
     jwksUri: https://test.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
   ariesDetails:

--- a/services/tenant-ui/config/custom-environment-variables.json
+++ b/services/tenant-ui/config/custom-environment-variables.json
@@ -4,6 +4,10 @@
     "showInnkeeperReservationPassword": "FRONTEND_INNKEEPER_SHOW_RESERVATION_PASSWORD",
     "showInnkeeperAdminLogin": "FRONTEND_INNKEEPER_SHOW_ADMIN",
     "showWritableComponents": "FRONTEND_TENANT_SHOW_WRITABLE_COMPONENTS",
+    "session": {
+      "timeoutSeconds": "FRONTEND_SESSION_TIMEOUT_SECONDS",
+      "countdownSeconds": "FRONTEND_SESSION_COUNTDOWN_SECONDS"
+    },
     "matomoUrl": "FRONTEND_MATOMO_URL",
     "oidc": {
       "active": "FRONTEND_INNKEEPER_OIDC_ACTIVE",

--- a/services/tenant-ui/config/default.json
+++ b/services/tenant-ui/config/default.json
@@ -8,6 +8,10 @@
     "showInnkeeperAdminLogin": true,
     "showOIDCReservationLogin": false,
     "showWritableComponents": true,
+    "session": {
+      "timeoutSeconds": "600",
+      "countdownSeconds": "30"
+    },
     "oidc": {
       "active": false,
       "authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm",

--- a/services/tenant-ui/frontend/src/App.vue
+++ b/services/tenant-ui/frontend/src/App.vue
@@ -1,13 +1,31 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia';
 import ConfirmPopup from 'primevue/confirmpopup';
 import { onMounted } from 'vue';
-import { storeToRefs } from 'pinia';
-import { useConfigStore } from './store';
+import {
+  useConfigStore,
+  useInnkeeperTokenStore,
+  useTenantStore,
+  useTokenStore,
+} from './store';
 
 const { config } = storeToRefs(useConfigStore());
 
 onMounted(() => {
   document.title = config.value.frontend.ux.appTitle;
+
+  // This is used to remove localStorage data when the user driectly accesses the app as a new window or tab.
+  // The token is still in the browser localstorage before this, so it is a superficial security measure.
+  if (sessionStorage.getItem('reloaded') == null) {
+    if (window.location.href.includes('/innkeeper'))
+      useInnkeeperTokenStore().clearToken();
+    else {
+      useTokenStore().clearToken();
+      useTenantStore().clearTenant();
+    }
+  }
+
+  sessionStorage.setItem('reloaded', 'true');
 });
 </script>
 

--- a/services/tenant-ui/frontend/src/components/LoginForm.vue
+++ b/services/tenant-ui/frontend/src/components/LoginForm.vue
@@ -113,6 +113,7 @@
 <script setup lang="ts">
 //Vue
 import { ref, reactive } from 'vue';
+import { useRouter } from 'vue-router';
 // PrimeVue/Validation/etc
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
@@ -127,6 +128,7 @@ import { useTenantStore, useTokenStore } from '../store';
 import { storeToRefs } from 'pinia';
 
 const toast = useToast();
+const router = useRouter();
 
 // Tabs
 const activeTab = ref(0);
@@ -206,6 +208,7 @@ const handleSubmit = async (isFormValid: boolean) => {
           throw result.reason;
         }
       });
+      router.push({ name: 'Dashboard' });
     } catch (err) {
       console.error(err);
       toast.error(`Failure getting tenant info: ${err}`);

--- a/services/tenant-ui/frontend/src/components/common/SessionTimer.vue
+++ b/services/tenant-ui/frontend/src/components/common/SessionTimer.vue
@@ -1,0 +1,91 @@
+<template>
+  <Dialog
+    v-model:visible="displaySessionWarning"
+    :header="$t('session.header')"
+    :style="{ width: '30vw' }"
+  >
+    <div style="text-align: center">
+      <p>{{ $t('session.countdown', { seconds: countDown }) }}</p>
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import Dialog from 'primevue/dialog';
+import { onBeforeUnmount, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import { useConfigStore } from '@/store/configStore';
+
+const {
+  config: {
+    value: {
+      frontend: {
+        session: { countdownSeconds, timeoutSeconds },
+      },
+    },
+  },
+} = storeToRefs(useConfigStore());
+
+let inactivityCount = 0;
+const displaySessionWarning = ref(false);
+const countDown = ref(countdownSeconds);
+let countDownInterval: string | number | NodeJS.Timeout | undefined;
+const route = useRoute();
+
+onBeforeUnmount(() => {
+  clearInterval(interval);
+  clearInterval(countDownInterval);
+});
+
+const createListeners = () => {
+  window.addEventListener('mousemove', resetTimer);
+  window.addEventListener('mousedown', resetTimer);
+  window.addEventListener('keypress', resetTimer);
+  window.addEventListener('touchmove', resetTimer);
+};
+
+const resetTimer = () => {
+  inactivityCount = 0;
+};
+
+const inactivityCountInterval = () => {
+  checkForRecentActivity();
+  inactivityCount += 1;
+  createCountDownIfNecessary();
+  logoutOnTimeout();
+};
+
+const checkForRecentActivity = () => {
+  if (inactivityCount === 0) {
+    clearInterval(countDownInterval);
+    displaySessionWarning.value = false;
+    countDown.value = countdownSeconds;
+  }
+};
+
+const createCountDownIfNecessary = () => {
+  if (
+    inactivityCount >= timeoutSeconds - countdownSeconds &&
+    !displaySessionWarning.value
+  ) {
+    displaySessionWarning.value = true;
+    countDownInterval = setInterval(() => {
+      countDown.value -= 1;
+    }, 1000);
+  }
+};
+
+const logoutOnTimeout = () => {
+  if (inactivityCount >= timeoutSeconds) {
+    if (route.path.includes('innkeeper'))
+      window.location.href = '/innkeeper/logout';
+    else window.location.href = '/logout';
+  }
+};
+
+const interval = setInterval(inactivityCountInterval, 1000);
+
+createListeners();
+</script>

--- a/services/tenant-ui/frontend/src/components/innkeeper/InnkeeperBadge.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/InnkeeperBadge.vue
@@ -27,7 +27,7 @@ const items = [
   {
     label: 'Logout',
     class: 'logout-menu-item',
-    url: '/innkeeper', // TODO: this should be a logout route
+    url: '/innkeeper/logout',
   },
 ];
 </script>

--- a/services/tenant-ui/frontend/src/components/innkeeper/InnkeeperLoginForm.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/InnkeeperLoginForm.vue
@@ -55,6 +55,7 @@
 <script setup lang="ts">
 //Vue
 import { ref, reactive } from 'vue';
+import { useRouter } from 'vue-router';
 // PrimeVue/Validation/etc
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
@@ -66,6 +67,7 @@ import { useInnkeeperTokenStore } from '@/store';
 import { storeToRefs } from 'pinia';
 
 const toast = useToast();
+const router = useRouter();
 
 // Login Form and validation
 const formFields = reactive({
@@ -93,6 +95,7 @@ const handleSubmit = async (isFormValid: boolean): Promise<void> => {
   }
   try {
     await innkeeperTokenStore.login(formFields);
+    router.push({ name: 'InnkeeperTenants' });
   } catch (err) {
     console.error(err);
     toast.error(`Failure getting token: ${err}`);

--- a/services/tenant-ui/frontend/src/components/layout/Header.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Header.vue
@@ -12,8 +12,8 @@
 
     <template #end>
       <LocaleSwitcher />
-
       <ProfileButton />
+      <SessionTimer />
     </template>
   </Toolbar>
 </template>
@@ -22,6 +22,7 @@
 import Toolbar from 'primevue/toolbar';
 import ProfileButton from '@/components/profile/ProfileButton.vue';
 import LocaleSwitcher from '../common/LocaleSwitcher.vue';
+import SessionTimer from '../common/SessionTimer.vue';
 
 // State
 import { storeToRefs } from 'pinia';

--- a/services/tenant-ui/frontend/src/components/layout/innkeeper/Header.vue
+++ b/services/tenant-ui/frontend/src/components/layout/innkeeper/Header.vue
@@ -13,6 +13,7 @@
     <template #end>
       <LocaleSwitcher />
       <InnkeeperBadge />
+      <SessionTimer />
     </template>
   </Toolbar>
 </template>
@@ -21,6 +22,7 @@
 import Toolbar from 'primevue/toolbar';
 import InnkeeperBadge from '@/components/innkeeper/InnkeeperBadge.vue';
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue';
+import SessionTimer from '@/components/common/SessionTimer.vue';
 
 // State
 import { storeToRefs } from 'pinia';

--- a/services/tenant-ui/frontend/src/components/profile/ProfileButton.vue
+++ b/services/tenant-ui/frontend/src/components/profile/ProfileButton.vue
@@ -49,7 +49,7 @@ const items = [
   {
     label: t('common.logout'),
     class: 'logout-menu-item',
-    url: '/', // TODO: this should be a logout route
+    url: '/logout',
   },
 ];
 </script>

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -426,5 +426,9 @@
     "presentationRequestBody": "Proof Request",
     "verification": "Verification",
     "verifications": "Verifications"
+  },
+  "session": {
+    "countdown": "You are going to be logged out in { seconds } seconds...",
+    "header": "Session timing out"
   }
 }

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -431,5 +431,9 @@
     "presentationRequestBody": "Proof Request <FR>",
     "verification": "Verification <FR>",
     "verifications": "Verifications <FR>"
+  },
+  "session": {
+    "countdown": "Vous allez être déconnecté dans { seconds } secondes...",
+    "header": "Expiration du délai de session"
   }
 }

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
@@ -431,5 +431,9 @@
     "presentationRequestBody": "Proof Request <JA>",
     "verification": "Verification <JA>",
     "verifications": "Verifications <JA>"
+  },
+  "session": {
+    "countdown": "You are going to be logged out in { seconds } seconds... <JA>",
+    "header": "Session timing out <JA>"
   }
 }

--- a/services/tenant-ui/frontend/src/router/innkeeperRoutes.ts
+++ b/services/tenant-ui/frontend/src/router/innkeeperRoutes.ts
@@ -13,8 +13,11 @@ const innkeeperRoutes = [
     component: InnkeeperUi,
     meta: { isInnkeeper: true },
     children: [
-      // Blank route uses dashboard view
-      { path: '', name: 'InnkeeperTenants', component: InnkeeperTenants },
+      {
+        path: 'tenants',
+        name: 'InnkeeperTenants',
+        component: InnkeeperTenants,
+      },
 
       // Reservations
       {

--- a/services/tenant-ui/frontend/src/router/tenantRoutes.ts
+++ b/services/tenant-ui/frontend/src/router/tenantRoutes.ts
@@ -34,8 +34,7 @@ const tenantRoutes = [
     name: 'TenantUi',
     component: TenantUi,
     children: [
-      // Blank route uses dashboard view
-      { path: '', name: 'Dashboard', component: Dashboard },
+      { path: 'dashboard', name: 'Dashboard', component: Dashboard },
 
       // About
       {

--- a/services/tenant-ui/frontend/src/store/acapyApi.ts
+++ b/services/tenant-ui/frontend/src/store/acapyApi.ts
@@ -61,8 +61,6 @@ export const useAcapyApi = defineStore('acapyApi', () => {
 
   acapyApi.interceptors.response.use(
     (response) => {
-      // console.log('acapyApi.response.fulfilled');
-      // console.log(response);
       return response;
     },
     (error: any) => {
@@ -71,7 +69,11 @@ export const useAcapyApi = defineStore('acapyApi', () => {
       if (error.response.status === 401) {
         tokenStore.clearToken();
         tenantStore.clearTenant();
-        return Promise.reject(`Unauthorized: ${error.response.data.reason}`);
+        return Promise.reject(
+          `Unauthorized ${
+            ': ' + error.response.data.reason ? error.response.data.reason : ''
+          }`
+        );
       }
       return Promise.reject(error);
     }

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperOidcStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperOidcStore.ts
@@ -49,6 +49,7 @@ export const useInnkeeperOidcStore = defineStore('innkeeperOidcStore', () => {
         loginCfg
       );
       token.value = response.data.token;
+      if (token.value) localStorage.setItem('token-innkeeper', token.value);
 
       // strip the oidc return params
       window.history.pushState({}, document.title, '/innkeeper');

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTokenStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTokenStore.ts
@@ -47,6 +47,7 @@ export const useInnkeeperTokenStore = defineStore(
         .post(API_PATH.MULTITENANCY_TENANT_TOKEN(params.adminName), payload)
         .then((res) => {
           token.value = res.data.token;
+          if (token.value) localStorage.setItem('innkeeper-token', token.value);
         })
         .catch((err) => {
           error.value = err;
@@ -68,7 +69,14 @@ export const useInnkeeperTokenStore = defineStore(
     function clearToken(): void {
       console.log('> clearToken');
       token.value = null;
+      localStorage.removeItem('innkeeper-token');
       console.log('< clearToken');
+    }
+
+    function setToken(newToken: string) {
+      console.log('> setToken');
+      token.value = newToken;
+      console.log('< setToken');
     }
 
     return {
@@ -76,6 +84,7 @@ export const useInnkeeperTokenStore = defineStore(
       error,
       innkeeperReady,
       clearToken,
+      setToken,
       login,
     };
   }

--- a/services/tenant-ui/frontend/src/store/tenantStore.ts
+++ b/services/tenant-ui/frontend/src/store/tenantStore.ts
@@ -42,12 +42,19 @@ export const useTenantStore = defineStore('tenant', () => {
   function clearTenant() {
     console.log('> clearTenant');
     tenant.value = null;
+    localStorage.removeItem('tenant');
+    localStorage.removeItem('tenantConfig');
+    localStorage.removeItem('tenantTaa');
+    localStorage.removeItem('tenantEndorserInfo');
+    localStorage.removeItem('tenantEndorserConnection');
     console.log('< clearTenant');
   }
 
   async function getSelf() {
     tenant.value = await fetchItem(API_PATH.TENANT_SELF, '', error, loading);
+    localStorage.setItem('tenant', JSON.stringify(tenant.value));
   }
+
   async function getTenantConfig() {
     tenantConfig.value = await fetchItem(
       API_PATH.TENANT_CONFIG,
@@ -55,6 +62,7 @@ export const useTenantStore = defineStore('tenant', () => {
       error,
       loading
     );
+    localStorage.setItem('tenantConfig', JSON.stringify(tenantConfig.value));
   }
 
   async function getIssuanceStatus() {
@@ -91,6 +99,10 @@ export const useTenantStore = defineStore('tenant', () => {
       .getHttp(API_PATH.TENANT_ENDORSER_CONNECTION)
       .then((res: any) => {
         endorserConnection.value = res.data;
+        localStorage.setItem(
+          'tenantEndorserConnection',
+          JSON.stringify(endorserConnection.value)
+        );
       })
       .catch((err) => {
         endorserConnection.value = null;
@@ -124,6 +136,10 @@ export const useTenantStore = defineStore('tenant', () => {
       .getHttp(API_PATH.TENANT_ENDORSER_INFO)
       .then((res: any) => {
         endorserInfo.value = res.data;
+        localStorage.setItem(
+          'tenantEndorderInfo',
+          JSON.stringify(endorserInfo.value)
+        );
       })
       .catch((err) => {
         error.value = err;
@@ -174,6 +190,7 @@ export const useTenantStore = defineStore('tenant', () => {
       error,
       !loadingIssuance.value ? loadingIssuance : ref(false)
     );
+    localStorage.setItem('tenantPublicDid', JSON.stringify(publicDid.value));
   }
 
   async function registerPublicDid() {
@@ -313,6 +330,7 @@ export const useTenantStore = defineStore('tenant', () => {
       error,
       !loadingIssuance.value ? loadingIssuance : ref(false)
     );
+    localStorage.setItem('tenantTaa', JSON.stringify(taa.value));
   }
 
   async function acceptTaa(payload: object) {
@@ -335,6 +353,42 @@ export const useTenantStore = defineStore('tenant', () => {
     }
   }
 
+  function setTenantLoginDataFromLocalStorage() {
+    console.log('> setTenantFromLocalStorage');
+    try {
+      const savedTenant = localStorage.getItem('tenant');
+      tenant.value = savedTenant ? JSON.parse(savedTenant) : null;
+
+      const savedTenantConfig = localStorage.getItem('tenantConfig');
+      tenantConfig.value = savedTenantConfig
+        ? JSON.parse(savedTenantConfig)
+        : null;
+
+      const savedTaa = localStorage.getItem('tenantTaa');
+      taa.value = savedTaa ? JSON.parse(savedTaa) : null;
+
+      const savedEndorserInfo = localStorage.getItem('tenantEndorserInfo');
+      endorserInfo.value = savedEndorserInfo
+        ? JSON.parse(savedEndorserInfo)
+        : null;
+
+      const savedEndorserConnection = localStorage.getItem(
+        'tenantEndorserConnection'
+      );
+      endorserConnection.value = savedEndorserConnection
+        ? JSON.parse(savedEndorserConnection)
+        : null;
+
+      const savedPublicDid = localStorage.getItem('tenantPublicDid');
+      publicDid.value = savedPublicDid ? JSON.parse(savedPublicDid) : null;
+    } catch (err) {
+      console.info('Error processing tenant info from local storage');
+      console.error(err);
+    }
+
+    console.log('< setTenantFromLocalStorage');
+  }
+
   return {
     loading,
     loadingIssuance,
@@ -354,6 +408,7 @@ export const useTenantStore = defineStore('tenant', () => {
     getTenantConfig,
     getIssuanceStatus,
     clearTenant,
+    setTenantLoginDataFromLocalStorage,
     getEndorserConnection,
     getEndorserInfo,
     getTenantDefaultSettings,

--- a/services/tenant-ui/frontend/src/store/tokenStore.ts
+++ b/services/tenant-ui/frontend/src/store/tokenStore.ts
@@ -40,6 +40,7 @@ export const useTokenStore = defineStore('token', () => {
       .then((res) => {
         console.log(res);
         token.value = res.data.token;
+        if (token.value) localStorage.setItem('token', token.value);
       })
       .catch((err) => {
         error.value = err;
@@ -61,10 +62,17 @@ export const useTokenStore = defineStore('token', () => {
   function clearToken() {
     console.log('> clearToken');
     token.value = null;
+    localStorage.removeItem('token');
     console.log('< clearToken');
   }
 
-  return { token, loading, error, clearToken, login };
+  function setToken(newToken: string) {
+    console.log('> setToken');
+    token.value = newToken;
+    console.log('< setToken');
+  }
+
+  return { token, loading, error, clearToken, setToken, login };
 });
 
 export default {

--- a/services/tenant-ui/frontend/test/App.test.ts
+++ b/services/tenant-ui/frontend/test/App.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import { describe, expect, test } from 'vitest';
+
+import { useInnkeeperTokenStore, useTenantStore, useTokenStore } from '@/store';
+import App from '@/App.vue';
+
+const mountApp = () =>
+  mount(App, {
+    global: {
+      plugins: [PrimeVue],
+      stubs: ['router-view'],
+    },
+  });
+
+describe('App', () => {
+  test('document title is set', async () => {
+    mountApp();
+
+    expect(document.title).toEqual('Tenant UI');
+  });
+
+  test('when app opens without refresh should call clear tenant local storage functions', async () => {
+    mountApp();
+
+    expect(useTenantStore().clearTenant).toHaveBeenCalled();
+    expect(useTokenStore().clearToken).toHaveBeenCalled();
+  });
+
+  test.todo(
+    'Should test refresh does not call clear local storage functions (not sure if possible with session storage)'
+  );
+});

--- a/services/tenant-ui/frontend/test/__mocks__/store/config.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/store/config.ts
@@ -25,12 +25,17 @@ const store: { [key: string]: any } = {
       showOIDCReservationLogin: false,
       showInnkeeperAdminLogin: true,
       showWritableComponents: true,
+      session: {
+        timeoutSeconds: '600',
+        countdownSeconds: '30',
+      },
     },
     image: {
       tag: '1.0',
       version: '1.0',
       buildtime: '2021-01-01',
     },
+    // These mocks are used for storeToRefs in the components
     value: {
       frontend: {
         ux: {
@@ -52,6 +57,10 @@ const store: { [key: string]: any } = {
           authority: 'authority',
         },
         tenantProxyPath: API_PATH.TEST_TENANT_PROXY,
+        session: {
+          timeoutSeconds: '3600',
+          countdownSeconds: '10',
+        },
       },
     },
   },

--- a/services/tenant-ui/frontend/test/__mocks__/store/innkeeper/token.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/store/innkeeper/token.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 const store: { [key: string]: any } = {
+  clearToken: vi.fn(),
   innkeeperReady: vi.fn().mockResolvedValue(false),
   login: vi.fn().mockResolvedValue('success'),
 };

--- a/services/tenant-ui/frontend/test/__mocks__/store/tenant.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/store/tenant.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 const store: { [key: string]: any } = {
+  clearTenant: vi.fn(),
   tenant: {
     value: {
       tenant_name: 'test',

--- a/services/tenant-ui/frontend/test/__mocks__/store/token.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/store/token.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 const store: { [key: string]: any } = {
+  clearToken: vi.fn(),
   login: vi.fn().mockResolvedValue({}),
   token: {
     value: 'token',

--- a/services/tenant-ui/frontend/test/__snapshots__/App.test.ts.snap
+++ b/services/tenant-ui/frontend/test/__snapshots__/App.test.ts.snap
@@ -1,8 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`App Component > renders as snapshot 1`] = `
-"<router-view-stub data-v-7a7a37b1=\\"\\"></router-view-stub>
-<!-- Shared confirm popup  -->
-<!--teleport start-->
-<!--teleport end-->"
-`;

--- a/services/tenant-ui/frontend/test/components/common/SessionTimer.test.ts
+++ b/services/tenant-ui/frontend/test/components/common/SessionTimer.test.ts
@@ -1,0 +1,41 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import { describe, expect, test, vi } from 'vitest';
+
+import SessionTimer from '@/components/common/SessionTimer.vue';
+
+const mountSessionTimer = () =>
+  mount(SessionTimer, {
+    global: {
+      plugins: [PrimeVue, createTestingPinia()],
+      stubs: ['Dialog', 'router-location'],
+    },
+  });
+
+describe('SessionTimer', () => {
+  test('mounting creates the event listeners', async () => {
+    const spy = vi.spyOn(window, 'addEventListener');
+    mountSessionTimer();
+
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+
+  test('unmounting clears the intervals', async () => {
+    const spy = vi.spyOn(global, 'clearInterval');
+    const wrapper = mountSessionTimer();
+    await wrapper.unmount();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  test('modal is hidden when countdown is false', async () => {
+    const wrapper = mountSessionTimer();
+
+    expect(wrapper.getComponent({ name: 'Dialog' }).attributes().visible).toBe(
+      'false'
+    );
+  });
+
+  test.todo('test the interval functionality');
+});

--- a/services/tenant-ui/frontend/test/components/innkeeper/InnkeeperLoginForm.test.ts
+++ b/services/tenant-ui/frontend/test/components/innkeeper/InnkeeperLoginForm.test.ts
@@ -7,9 +7,22 @@ import InnkeeperLoginForm from '@/components/innkeeper/InnkeeperLoginForm.vue';
 import { useInnkeeperTokenStore } from '@/store';
 
 import { innkeeperLogin } from '../../__mocks__/validation/forms';
+import { beforeEach } from 'node:test';
 
 // Mocks
 vi.mock('@vuelidate/core');
+
+vi.mock('vue-router');
+
+const mockRouter = async (name = 'test') => {
+  const routerMock = await import('vue-router');
+  routerMock.useRoute = vi.fn().mockReturnValue({
+    name,
+  });
+  routerMock.useRouter = vi.fn().mockReturnValue({
+    push: vi.fn(),
+  });
+};
 
 const mockVuelidate = async (values: object = innkeeperLogin) => {
   const vuelidateMock = await import('@vuelidate/core');
@@ -26,6 +39,7 @@ const mountLoginForm = () =>
 
 describe('InnkeeperLoginForm', async () => {
   test('renders with expected inner components', async () => {
+    await mockRouter();
     await mockVuelidate();
     const wrapper = mountLoginForm();
 
@@ -34,6 +48,7 @@ describe('InnkeeperLoginForm', async () => {
   });
 
   test('invalid admin name renders error message', async () => {
+    await mockRouter();
     const loginValues = JSON.parse(JSON.stringify(innkeeperLogin));
     loginValues.adminName.$invalid = true;
     loginValues.$invalid = true;
@@ -44,6 +59,7 @@ describe('InnkeeperLoginForm', async () => {
   });
 
   test('invalid admin key renders error message', async () => {
+    await mockRouter();
     const loginValues = JSON.parse(JSON.stringify(innkeeperLogin));
     loginValues.adminKey.$invalid = true;
     loginValues.$invalid = true;
@@ -54,6 +70,7 @@ describe('InnkeeperLoginForm', async () => {
   });
 
   test('successful login triggers expected methods', async () => {
+    await mockRouter();
     await mockVuelidate();
     const wrapper = mountLoginForm();
     const wrapperVm = wrapper.vm as unknown as typeof InnkeeperLoginForm;
@@ -67,6 +84,7 @@ describe('InnkeeperLoginForm', async () => {
   });
 
   test('if login call fails, toast error triggered in catch block', async () => {
+    await mockRouter();
     const wrapper = mountLoginForm();
     const wrapperVm = wrapper.vm as unknown as typeof InnkeeperLoginForm;
     const toastSpy = vi.spyOn(wrapperVm.toast, 'error');

--- a/services/tenant-ui/frontend/test/components/layout/__snapshots__/Header.test.ts.snap
+++ b/services/tenant-ui/frontend/test/components/layout/__snapshots__/Header.test.ts.snap
@@ -9,6 +9,7 @@ exports[`Header > mount matches snapshot with expected values 1`] = `
   <div class=\\"p-toolbar-group-end p-toolbar-group-right\\" data-pc-section=\\"end\\">
     <locale-switcher-stub data-v-243d8871=\\"\\"></locale-switcher-stub>
     <profile-button-stub data-v-243d8871=\\"\\"></profile-button-stub>
+    <session-timer-stub data-v-243d8871=\\"\\"></session-timer-stub>
   </div>
 </div>"
 `;

--- a/services/tenant-ui/frontend/test/components/layout/innkeeper/Header.test.ts
+++ b/services/tenant-ui/frontend/test/components/layout/innkeeper/Header.test.ts
@@ -3,7 +3,7 @@ import PrimeVue from 'primevue/config';
 import { describe, expect, test } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
-import Header from '@/components/layout/Header.vue';
+import Header from '@/components/layout/innkeeper/Header.vue';
 
 describe('Header', async () => {
   test('mount matches snapshot with expected values', async () => {

--- a/services/tenant-ui/frontend/test/components/layout/innkeeper/__snapshots__/Header.test.ts.snap
+++ b/services/tenant-ui/frontend/test/components/layout/innkeeper/__snapshots__/Header.test.ts.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Header > mount matches snapshot with expected values 1`] = `
+"<div data-v-46812836=\\"\\" class=\\"p-toolbar p-component traction-header\\" role=\\"toolbar\\" data-pc-name=\\"toolbar\\" data-pc-section=\\"root\\">
+  <div class=\\"p-toolbar-group-start p-toolbar-group-left\\" data-pc-section=\\"start\\">
+    <div data-v-46812836=\\"\\" class=\\"hamburger\\" title=\\"layout.header.toggleSideMenu\\"><i data-v-46812836=\\"\\" class=\\"pi pi-bars p-toolbar-separator mr-2\\"></i></div>
+  </div>
+  <div class=\\"p-toolbar-group-center\\" data-pc-section=\\"center\\"></div>
+  <div class=\\"p-toolbar-group-end p-toolbar-group-right\\" data-pc-section=\\"end\\">
+    <locale-switcher-stub data-v-46812836=\\"\\"></locale-switcher-stub>
+    <div data-v-165ddc1c=\\"\\" class=\\"parent\\"><button data-v-165ddc1c=\\"\\" class=\\"p-button p-component p-button-rounded\\" type=\\"button\\" data-pc-name=\\"button\\" data-pc-section=\\"root\\" data-pd-ripple=\\"true\\">
+        <div data-v-165ddc1c=\\"\\" class=\\"badge-img\\"></div>
+      </button></div>
+    <!---->
+    <session-timer-stub data-v-46812836=\\"\\"></session-timer-stub>
+  </div>
+</div>"
+`;

--- a/services/tenant-ui/frontend/test/components/messages/createMessage/CreateMessage.test.ts
+++ b/services/tenant-ui/frontend/test/components/messages/createMessage/CreateMessage.test.ts
@@ -17,7 +17,6 @@ describe('CreateMessage', () => {
     const wrapper = mountCreateMessage();
 
     wrapper.getComponent({ name: 'Button', props: { icon: 'pi pi-envelope' } });
-    const dialog = wrapper.getComponent({ name: 'Dialog' });
     expect(wrapper.getComponent({ name: 'Dialog' }).attributes().visible).toBe(
       'false'
     );
@@ -33,7 +32,6 @@ describe('CreateMessage', () => {
       .getComponent({ name: 'Button', props: { icon: 'pi pi-envelope' } })
       .trigger('click');
 
-    const dialog = wrapper.getComponent({ name: 'Dialog' });
     expect(wrapper.getComponent({ name: 'Dialog' }).attributes().visible).toBe(
       'true'
     );

--- a/services/tenant-ui/frontend/test/router/index.test.ts
+++ b/services/tenant-ui/frontend/test/router/index.test.ts
@@ -1,0 +1,52 @@
+import router from '@/router';
+import { flushPromises } from '@vue/test-utils';
+import { expect, test, vi } from 'vitest';
+
+import { useInnkeeperTokenStore, useTenantStore, useTokenStore } from '@/store';
+
+vi.mock('@/router', async () => {
+  const router = await vi.importActual<typeof import('@/router')>('@/router');
+
+  return {
+    ...router,
+  };
+});
+
+test('/logout clears token and tenant data', async () => {
+  const tokenStore = useTokenStore();
+  const tenantStore = useTenantStore();
+  router.push('/');
+  await router.isReady();
+
+  router.push({ path: '/logout' });
+  await flushPromises();
+
+  expect(tokenStore.clearToken).toHaveBeenCalled();
+  expect(tenantStore.clearTenant).toHaveBeenCalled();
+});
+
+test('/innkeeper/logout clears innkeeper token', async () => {
+  const tokenStore = useInnkeeperTokenStore();
+  router.push('/');
+  await router.isReady();
+
+  router.push({ path: '/innkeeper/logout' });
+  await flushPromises();
+
+  expect(tokenStore.clearToken).toHaveBeenCalled();
+});
+
+test('non-logout path does not clear any token or tenant data', async () => {
+  const innkeeperTokenStore = useInnkeeperTokenStore();
+  const tokenStore = useTokenStore();
+  const tenantStore = useTenantStore();
+  router.push('/');
+  await router.isReady();
+
+  router.push({ path: '/issuance/credentials' });
+  await flushPromises();
+
+  expect(innkeeperTokenStore.clearToken).toHaveBeenCalled();
+  expect(tokenStore.clearToken).toHaveBeenCalled();
+  expect(tenantStore.clearTenant).toHaveBeenCalled();
+});

--- a/services/tenant-ui/frontend/test/store/tenantStore.test.ts
+++ b/services/tenant-ui/frontend/test/store/tenantStore.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { useTenantStore } from '@/store/tenantStore';
 import { testErrorResponse, testSuccessResponse } from '../../test/commonTests';
@@ -7,12 +7,26 @@ import { restHandlersUnknownError, server } from '../setupApi';
 
 import { tokenStore } from '../../test/__mocks__/store';
 
+vi.mock('global.localStorage', () => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+}));
+
+const setLocalStorageSpy = vi.spyOn(Storage.prototype, 'setItem');
+const removeLocalStorageSpy = vi.spyOn(Storage.prototype, 'removeItem');
+
 let store: any;
 
 describe('tenantStore', () => {
   beforeEach(async () => {
     setActivePinia(createPinia());
     store = useTenantStore();
+  });
+
+  afterEach(() => {
+    setLocalStorageSpy.mockClear();
+    removeLocalStorageSpy.mockClear();
+    localStorage.clear();
   });
 
   test("initial values haven't changed from expected", () => {
@@ -72,37 +86,50 @@ describe('tenantStore', () => {
     test('getSelf sets tenant', async () => {
       await store.getSelf();
       expect(store.tenant).not.toBeNull();
+      // local storage is called 3 times by vitest
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(4);
     });
 
     test('getTenantConfig sets tenantConfig', async () => {
       await store.getTenantConfig();
       expect(store.tenantConfig).not.toBeNull();
+      // local storage is called 3 times by vitest
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(4);
     });
 
     test('getTaa sets taa', async () => {
       await store.getTaa();
       expect(store.taa).not.toBeNull();
+      // local storage is called 3 times by vitest
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(4);
     });
 
     test('getEndorserInfo sets endorser info', async () => {
       await store.getEndorserInfo();
       expect(store.endorserInfo).not.toBeNull();
+      // local storage is called 3 times by vitest
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(4);
     });
 
     test('getEndorserConnection sets endorser connection', async () => {
       await store.getEndorserConnection();
       expect(store.endorserConnection).not.toBeNull();
+      // local storage is called 3 times by vitest
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(4);
     });
 
     test('getPublicDid sets public did', async () => {
       await store.getPublicDid();
       expect(store.publicDid).not.toBeNull();
+      // local storage is called 3 times by vitest
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(4);
     });
 
     test('clearTenant set tenant to null', async () => {
       store.tenant = 'something';
       store.clearTenant();
       expect(store.tenant).toBeNull();
+      expect(removeLocalStorageSpy).toHaveBeenCalledTimes(5);
     });
 
     test('getIssuanceStatus sets taa, endorser info/connection and public did and loading properly', async () => {
@@ -148,12 +175,16 @@ describe('tenantStore', () => {
       store.tenant = null;
       await expect(store.getSelf()).rejects.toThrow();
       expect(store.tenant).toBeNull();
+      // local storage is called 3 times by vitest, this is same as not called
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(3);
     });
 
     test('getTenantConfig handles error correctly and does not change tenantConfig', async () => {
       store.tenantConfig = null;
       await expect(store.getTenantConfig()).rejects.toThrow();
       expect(store.tenantConfig).toBeNull();
+      // local storage is called 3 times by vitest, this is same as not called
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(3);
     });
 
     test('getIssuanceStatus handles error correctly and does not change issuanceStatus', async () => {
@@ -165,6 +196,8 @@ describe('tenantStore', () => {
       await expect(store.getEndorserConnection()).rejects.toThrow();
       expect(store.error).not.toBeNull();
       store.endorserConnection = null;
+      // local storage is called 3 times by vitest, this is same as not called
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(3);
     });
 
     test('getEndorserInfo handles error correctly and set info to null', async () => {
@@ -175,12 +208,16 @@ describe('tenantStore', () => {
         'loadingIssuance'
       );
       store.endorserInfo = null;
+      // local storage is called 3 times by vitest, this is same as not called
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(3);
     });
 
     test('getPublicDid handles error correctly and does not change publicDid', async () => {
       store.publicDid = null;
       await expect(store.getPublicDid()).rejects.toThrow();
       expect(store.publicDid).toBeNull();
+      // local storage is called 3 times by vitest, this is same as not called
+      expect(setLocalStorageSpy).toHaveBeenCalledTimes(3);
     });
 
     test('registerPublicDid handles error correctly', async () => {


### PR DESCRIPTION
Features:

- Prevents user needing to login after refresh by saving token and tenant data in local storage.
- Creates router middleware to better handle logout path.
- Creates inactivity timer that will log the user out if they haven't used the app for a configured amount of time (5 mins). This was attached to the Header component.
- Creates a modal countdown to warn the user they are about to be logged out (10 seconds)
- If the users access token expires they receive a toast notification with the reason (This is unlikely with inactivity session)
- If the user closes the app and opens it again they will need to login again. This doesn't prevent a bad agent from stealing the access token but does prevent them just navigating back to the app and not needing to login.
- Added some unit tests. More advanced ones could be added for the inactivity session but don't have the time right now.

Unknowns:

- Didn't test with the OIDC login. I don't anticipate problems but i'm not sure how to set that up right now and don't really have the time to figure it out. Should definitely be looked at before going to prod.

Think I looked at the other comments and didn't see any issues.

Screen-shots:

- inactivity with countdown stopped and then let expire (set to 5 seconds)

[Screencast from 2023-08-30 11:54:31 AM.webm](https://github.com/bcgov/traction/assets/31809382/289cebb4-7c72-4ad5-b823-de9687d3dc36)

- refreshing and exiting the application

[Screencast from 2023-08-30 11:57:06 AM.webm](https://github.com/bcgov/traction/assets/31809382/9ac36f09-c3b3-4781-a5ff-ea09b55ef897)

Not sure why you can't see my mouse on these. Makes it a bit hard to understand what i'm doing.
