### PR TITLE
Self serve API key mgmt

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
@@ -220,18 +220,18 @@ class TenantAuthenticationsApiRequestSchema(OpenAPISchema):
     )
 
     alias = fields.Str(
-        required=False,
-        description="Optional alias/label",
-        example="API key for sample line of buisness",
+        required=True,
+        description="Alias/label",
+        example="API key for sample line of business",
     )
 
 
 class TenantAuthenticationsApiResponseSchema(OpenAPISchema):
     """Response schema for api auth record."""
 
-    reservation_id = fields.Str(
+    tenant_authentication_api_id = fields.Str(
         required=True,
-        description="The reservation record identifier",
+        description="The API key record identifier",
         example=UUIDFour.EXAMPLE,
     )
 
@@ -689,7 +689,7 @@ async def innkeeper_authentications_api(request: web.BaseRequest):
     body = await request.json()
     rec: TenantAuthenticationApiRecord = TenantAuthenticationApiRecord(**body)
 
-    # reservations are under base/root profile, use Tenant Manager profile
+    # keys are under base/root profile, use Tenant Manager profile
     mgr = context.inject(TenantManager)
     profile = mgr.profile
 

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
@@ -216,7 +216,7 @@ class TenantAuthenticationsApiRequestSchema(OpenAPISchema):
     tenant_id = fields.Str(
         required=True,
         description="Tenant ID",
-        example="000000-000000-00000-00000000",
+        example=UUIDFour.EXAMPLE,
     )
 
     alias = fields.Str(
@@ -233,6 +233,12 @@ class TenantAuthenticationsApiResponseSchema(OpenAPISchema):
         required=True,
         description="The API key record identifier",
         example=UUIDFour.EXAMPLE,
+    )
+
+    api_key = fields.Str(
+        required=True,
+        description="The API key",
+        example="3bd14a1e8fb645ddadf9913c0922ff3b",
     )
 
 

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tenant/routes.py
@@ -3,6 +3,7 @@ import logging
 from aiohttp import web
 from aiohttp_apispec import (
     docs,
+    match_info_schema,
     response_schema,
     request_schema,
 )
@@ -14,6 +15,7 @@ from aries_cloudagent.multitenant.admin.routes import (
     get_extra_settings_dict_per_tenant,
 )
 from aries_cloudagent.multitenant.base import BaseMultitenantManager
+from aries_cloudagent.storage.error import StorageNotFoundError
 from aries_cloudagent.wallet.models.wallet_record import (
     WalletRecordSchema,
     WalletRecord,
@@ -22,8 +24,11 @@ from marshmallow import fields, validate
 
 from ..innkeeper.routes import (
     error_handler,
+    TenantAuthenticationApiIdMatchInfoSchema,
     TenantAuthenticationApiListSchema,
-    TenantAuthenticationsApiResponseSchema
+    TenantAuthenticationApiRecordSchema,
+    TenantAuthenticationsApiResponseSchema,
+    TenantAuthenticationApiOperationResponseSchema
 )
 from ..innkeeper.tenant_manager import TenantManager
 from ..innkeeper.models import (
@@ -50,7 +55,7 @@ class CustomUpdateWalletRequestSchema(UpdateWalletRequestSchema):
         validate=validate.URL(),
     )
 
-class TenantAuthenticationsApiRequestSchema(OpenAPISchema):
+class TenantApiKeyRequestSchema(OpenAPISchema):
     """Request schema for api auth record."""
 
     alias = fields.Str(
@@ -185,7 +190,7 @@ async def tenant_wallet_update(request: web.BaseRequest):
 
 
 @docs(tags=[SWAGGER_CATEGORY], summary="Create API Key Record")
-@request_schema(TenantAuthenticationsApiRequestSchema())
+@request_schema(TenantApiKeyRequestSchema())
 @response_schema(TenantAuthenticationsApiResponseSchema(), 200, description="")
 @error_handler
 async def tenant_api_key(request: web.BaseRequest):
@@ -219,6 +224,37 @@ async def tenant_api_key(request: web.BaseRequest):
     )
 
 
+@docs(tags=[SWAGGER_CATEGORY], summary="Read API Key Record")
+@match_info_schema(TenantAuthenticationApiIdMatchInfoSchema())
+@response_schema(TenantAuthenticationApiRecordSchema(), 200, description="")
+@error_handler
+async def tenant_api_key_get(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    wallet_id = context.profile.settings.get("wallet.id")
+    tenant_authentication_api_id = request.match_info["tenant_authentication_api_id"]
+
+    # records are under base/root profile, use Tenant Manager profile
+    mgr = context.inject(TenantManager)
+    profile = mgr.profile
+
+    async with profile.session() as session:
+        # use the id from the Tenant record and fetch associated api key
+        rec = await TenantRecord.query_by_wallet_id(session, wallet_id)
+        LOGGER.debug(rec)
+        tenant_id = rec.tenant_id
+
+        rec = await TenantAuthenticationApiRecord.retrieve_by_auth_api_id(
+            session, tenant_authentication_api_id
+        )
+        LOGGER.info(rec)
+
+        # if rec tenant_id does not match the tenant_id from the wallet, raise 404
+        if rec.tenant_id != tenant_id:
+            raise web.HTTPNotFound(reason="No such record")
+        
+    return web.json_response(rec.serialize())
+
+
 @docs(tags=[SWAGGER_CATEGORY], summary="List tenant API Key Records")
 @response_schema(TenantAuthenticationApiListSchema(), 200, description="")
 @error_handler
@@ -245,6 +281,48 @@ async def tenant_api_key_list(request: web.BaseRequest):
     return web.json_response({"results": results})
 
 
+@docs(tags=[SWAGGER_CATEGORY], summary="Delete API Key")
+@match_info_schema(TenantAuthenticationApiIdMatchInfoSchema)
+@response_schema(TenantAuthenticationApiOperationResponseSchema, 200, description="")
+@error_handler
+async def tenant_api_key_delete(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+    wallet_id = context.profile.settings.get("wallet.id")
+    tenant_authentication_api_id = request.match_info["tenant_authentication_api_id"]
+
+    # records are under base/root profile, use Tenant Manager profile
+    mgr = context.inject(TenantManager)
+    profile = mgr.profile
+
+    result = False
+    async with profile.session() as session:
+        # use the id from the Tenant record and fetch associated api key
+        rec = await TenantRecord.query_by_wallet_id(session, wallet_id)
+        LOGGER.debug(rec)
+        tenant_id = rec.tenant_id
+
+        rec = await TenantAuthenticationApiRecord.retrieve_by_auth_api_id(
+            session, tenant_authentication_api_id
+        )
+        LOGGER.debug(rec)
+
+        # if rec tenant_id does not match the tenant_id from the wallet, raise 404
+        if rec.tenant_id != tenant_id:
+            raise web.HTTPNotFound(reason="No such record")
+
+        await rec.delete_record(session)
+
+        try:
+            await TenantAuthenticationApiRecord.retrieve_by_auth_api_id(
+                session, tenant_authentication_api_id
+            )
+        except StorageNotFoundError:
+            # this is to be expected... do nothing, do not log
+            result = True
+
+    return web.json_response({"success": result})
+
+
 async def register(app: web.Application):
     """Register routes."""
     LOGGER.info("> registering routes")
@@ -258,6 +336,8 @@ async def register(app: web.Application):
 
             web.post("/tenant/authentications/api", tenant_api_key),
             web.get("/tenant/authentications/api/", tenant_api_key_list, allow_head=False),
+            web.get("/tenant/authentications/api/{tenant_authentication_api_id}", tenant_api_key_get, allow_head=False),
+            web.delete("/tenant/authentications/api/{tenant_authentication_api_id}", tenant_api_key_delete),
         ]
     )
     LOGGER.info("< registering routes")

--- a/services/tenant-ui/frontend/src/components/authentications/ApiKeys.vue
+++ b/services/tenant-ui/frontend/src/components/authentications/ApiKeys.vue
@@ -1,0 +1,153 @@
+<template>
+  <MainCardContent :title="$t('apiKey.apiKeys')" :refresh-callback="loadTable">
+    <DataTable
+      v-model:expandedRows="expandedRows"
+      v-model:filters="filter"
+      :loading="loading"
+      :value="formattedApiKeys"
+      :paginator="true"
+      :rows="TABLE_OPT.ROWS_DEFAULT"
+      :rows-per-page-options="TABLE_OPT.ROWS_OPTIONS"
+      selection-mode="single"
+      data-key="tenant_authentication_api_id"
+      sort-field="created_at"
+      :sort-order="-1"
+      filter-display="menu"
+    >
+      <template #header>
+        <div class="flex justify-content-between">
+          <div class="flex justify-content-start">
+            <CreateApiKey @success="loadTable" />
+          </div>
+          <div class="flex justify-content-end">
+            <span class="p-input-icon-left">
+              <i class="pi pi-search ml-0" />
+              <InputText
+                v-model="filter.global.value"
+                :placeholder="$t('apiKey.search')"
+              />
+            </span>
+          </div>
+        </div>
+      </template>
+      <template #empty>{{ $t('common.noRecordsFound') }}</template>
+      <template #loading>{{ $t('common.loading') }}</template>
+      <Column :expander="true" header-style="width: 3rem" />
+      <Column header="Actions">
+        <template #body="{ data }">
+          <DeleteApiKey :record-id="data.tenant_authentication_api_id" />
+        </template>
+      </Column>
+      <Column
+        :sortable="true"
+        field="alias"
+        header="Alias"
+        filter-field="alias"
+        :show-filter-match-modes="false"
+      >
+        <template #filter="{ filterModel, filterCallback }">
+          <InputText
+            v-model="filterModel.value"
+            type="text"
+            class="p-column-filter"
+            placeholder="Filter"
+            @input="filterCallback()"
+          />
+        </template>
+      </Column>
+      <Column
+        :sortable="true"
+        field="created"
+        header="Created at"
+        filter-field="created"
+        :show-filter-match-modes="false"
+      >
+        <template #body="{ data }">
+          {{ data.created }}
+        </template>
+        <template #filter="{ filterModel, filterCallback }">
+          <InputText
+            v-model="filterModel.value"
+            type="text"
+            class="p-column-filter"
+            placeholder="Filter"
+            @input="filterCallback()"
+          />
+        </template>
+      </Column>
+      <template #expansion="{ data }">
+        <RowExpandData
+          :id="data.tenant_authentication_api_id"
+          :url="API_PATH.TENANT_AUTHENTICATIONS_API"
+        />
+      </template>
+    </DataTable>
+  </MainCardContent>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { onMounted, ref, computed } from 'vue';
+// PrimeVue
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
+import InputText from 'primevue/inputtext';
+import { FilterMatchMode } from 'primevue/api';
+import { useToast } from 'vue-toastification';
+// State
+import { useKeyManagementStore } from '@/store';
+import { storeToRefs } from 'pinia';
+// Other components
+import { TABLE_OPT, API_PATH } from '@/helpers/constants';
+import { formatDateLong, formatGuid } from '@/helpers';
+import CreateApiKey from './createApiKey/CreateApiKey.vue';
+import DeleteApiKey from './DeleteApiKey.vue';
+import MainCardContent from '@/components/layout/mainCard/MainCardContent.vue';
+import RowExpandData from '@/components/common/RowExpandData.vue';
+
+const toast = useToast();
+
+const keyManagementStore = useKeyManagementStore();
+
+// Populating the Table
+const { loading, apiKeys } = storeToRefs(useKeyManagementStore());
+const loadTable = async () => {
+  keyManagementStore.listApiKeys().catch((err: string) => {
+    console.error(err);
+    toast.error(`Failure: ${err}`);
+  });
+};
+
+// Formatting the table row
+const formattedApiKeys = computed(() =>
+  apiKeys.value.map((api: any) => ({
+    tenant_authentication_api_id: formatGuid(api.tenant_authentication_api_id),
+    alias: api.alias,
+    created: formatDateLong(api.created_at),
+    created_at: api.created_at,
+  }))
+);
+
+onMounted(async () => {
+  loadTable();
+});
+
+// Filter for search
+const filter = ref({
+  global: {
+    value: null,
+    matchMode: FilterMatchMode.CONTAINS,
+  },
+  alias: {
+    value: null,
+    matchMode: FilterMatchMode.CONTAINS,
+  },
+  created: {
+    value: null,
+    matchMode: FilterMatchMode.CONTAINS,
+  },
+});
+
+// necessary for expanding rows, we don't do anything with this
+const expandedRows = ref([]);
+</script>

--- a/services/tenant-ui/frontend/src/components/authentications/DeleteApiKey.vue
+++ b/services/tenant-ui/frontend/src/components/authentications/DeleteApiKey.vue
@@ -1,0 +1,59 @@
+<template>
+  <Button
+    :title="$t('apiKey.delete')"
+    icon="pi pi-trash"
+    class="p-button-rounded p-button-icon-only p-button-text"
+    @click="deleteRecord($event)"
+  />
+</template>
+
+<script setup lang="ts">
+// Vue
+import { PropType } from 'vue';
+// PrimeVue
+import Button from 'primevue/button';
+import { useConfirm } from 'primevue/useconfirm';
+import { useToast } from 'vue-toastification';
+// State
+import { useInnkeeperTenantsStore } from '@/store';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+const confirm = useConfirm();
+const toast = useToast();
+
+const innkeeperTenantsStore = useInnkeeperTenantsStore();
+
+// Props
+const props = defineProps({
+  recordId: {
+    type: String as PropType<string>,
+    required: true,
+  },
+});
+
+// Delete the API key by the ID
+const deleteRecord = (event: any) => {
+  confirm.require({
+    target: event.currentTarget,
+    message: t('apiKey.deleteConfirmation'),
+    header: t('common.confirmation'),
+    icon: 'pi pi-exclamation-triangle',
+    accept: () => {
+      doDelete();
+    },
+  });
+};
+const doDelete = () => {
+  innkeeperTenantsStore
+    .deleteApiKey(props.recordId)
+    .then(() => {
+      toast.success(t('apiKey.deleteSuccess'));
+    })
+    .catch((err) => {
+      console.error(err);
+      toast.error(`Failure: ${err}`);
+    });
+};
+</script>

--- a/services/tenant-ui/frontend/src/components/authentications/createApiKey/CreateApiKey.vue
+++ b/services/tenant-ui/frontend/src/components/authentications/createApiKey/CreateApiKey.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <Button
+      :label="$t('apiKey.createApiKey')"
+      icon="pi pi-plus"
+      @click="openModal"
+    />
+    <Dialog
+      v-model:visible="displayModal"
+      :style="{ minWidth: '600px' }"
+      :header="$t('apiKey.createApiKey')"
+      :modal="true"
+      @update:visible="handleClose"
+    >
+      <CreateApiKeyForm @success="$emit('success')" @closed="handleClose" />
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Vue
+import { ref } from 'vue';
+// PrimeVue
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
+// Custom Components
+import CreateApiKeyForm from './CreateApiKeyForm.vue';
+// Other Imports
+
+defineEmits(['success']);
+
+const displayModal = ref(false);
+const openModal = async () => {
+  displayModal.value = true;
+};
+const handleClose = async () => {
+  displayModal.value = false;
+};
+</script>

--- a/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
+++ b/services/tenant-ui/frontend/src/components/layout/Sidebar.vue
@@ -98,6 +98,12 @@ const items = ref([
   },
 
   {
+    label: () => t('apiKey.apiKeys'),
+    icon: 'pi pi-fw pi-key',
+    to: { name: 'ApiKeys' },
+  },
+
+  {
     label: () => t('about.about'),
     icon: 'pi pi-fw pi-question-circle',
     to: { name: 'About' },

--- a/services/tenant-ui/frontend/src/helpers/constants.ts
+++ b/services/tenant-ui/frontend/src/helpers/constants.ts
@@ -125,6 +125,11 @@ export const API_PATH = {
   TENANT_WALLET: '/tenant/wallet',
   TENANT_CONFIG: '/tenant/config',
 
+  TENANT_AUTHENTICATIONS_API: '/tenant/authentications/api/',
+  TENANT_AUTHENTICATIONS_API_RECORD: (id: string) =>
+    `/tenant/authentications/api/${id}`,
+  TENANT_AUTHENTICATIONS_API_POST: '/tenant/authentications/api',
+
   TENANT_SETTINGS: '/settings',
 
   WALLET_DID_PUBLIC: '/wallet/did/public',

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -39,7 +39,8 @@
     "deleteConfirmation": "Are you sure you want to delete this API Key?",
     "deleteSuccess": "API Key deleted",
     "generatedKey": "The generated API key is shown below. This dialog is the only time this key will be shown and can not be retrieved again.",
-    "generatedKeyMessage": "An API Key has been generated for Tenant ID {key}",
+    "generatedKeyMessage": "An API Key has been generated for your Tenant",
+    "generatedKeyMessageInnkeeper": "An API Key has been generated for Tenant ID {key}",
     "search": "Search API Keys"
   },
   "common": {

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -40,6 +40,7 @@
     "deleteSuccess": "API Key deleted <FR>",
     "generatedKey": "The generated API key is shown below one-time. This dialog is the only time this key will be shown and can not be retrieved again. <FR>",
     "generatedKeyMessage": "An API Key has been generated for Tenant ID {key} <FR>",
+    "generatedKeyMessageInnkeeper": "An API Key has been generated for Tenant ID {key} <FR>",
     "search": "Search API Keys <FR>"
   },
   "common": {

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
@@ -40,6 +40,7 @@
     "deleteSuccess": "API Key deleted <JA>",
     "generatedKey": "The generated API key is shown below one-time. This dialog is the only time this key will be shown and can not be retrieved again. <JA>",
     "generatedKeyMessage": "An API Key has been generated for Tenant ID {key} <JA>",
+    "generatedKeyMessageInnkeeper": "An API Key has been generated for Tenant ID {key} <JA>",
     "search": "Search API Keys <JA>"
   },
   "common": {

--- a/services/tenant-ui/frontend/src/router/tenantRoutes.ts
+++ b/services/tenant-ui/frontend/src/router/tenantRoutes.ts
@@ -22,6 +22,8 @@ import MyHeldCredentials from '@/views/holder/MyHeldCredentials.vue';
 import MyMessages from '@/views/messages/MyMessages.vue';
 // OCA
 import Oca from '@/views/oca/Oca.vue';
+// API Keys
+import ApiKeys from '@/views/ApiKeys.vue';
 // Const
 import { RESERVATION_STATUS_ROUTE } from '@/helpers/constants';
 
@@ -149,6 +151,13 @@ const tenantRoutes = [
             component: MyMessages,
           },
         ],
+      },
+
+      // Tenant - API Keys
+      {
+        path: 'authentications/keys',
+        name: 'ApiKeys',
+        component: ApiKeys,
       },
     ],
   },

--- a/services/tenant-ui/frontend/src/store/index.ts
+++ b/services/tenant-ui/frontend/src/store/index.ts
@@ -4,6 +4,7 @@ export { useConnectionStore } from './connectionStore';
 export { useGovernanceStore } from './governanceStore';
 export { useHolderStore } from './holderStore';
 export { useIssuerStore } from './issuerStore';
+export { useKeyManagementStore } from './keyManagementStore';
 export { useTenantStore } from './tenantStore';
 export { useTokenStore } from './tokenStore';
 export { useVerifierStore } from './verifierStore';

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -3,6 +3,7 @@ import {
   ReservationRecord,
   TenantAuthenticationApiRecord,
   TenantAuthenticationsApiRequest,
+  TenantAuthenticationsApiResponse,
   TenantConfig,
   TenantRecord,
 } from '@/types/acapyApi/acapyInterface';
@@ -226,13 +227,14 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
     error.value = null;
     loading.value = true;
 
-    // TODO: fix response type in plugin swagger generation
-    let createResponse: any = {};
+    let createResponse: TenantAuthenticationsApiResponse | undefined;
     try {
-      createResponse = await acapyApi.postHttp(
-        API_PATH.INNKEEPER_AUTHENTICATIONS_API_POST,
-        payload
-      );
+      createResponse = (
+        await acapyApi.postHttp(
+          API_PATH.INNKEEPER_AUTHENTICATIONS_API_POST,
+          payload
+        )
+      ).data;
       // Reload the keys list after updating
       await listApiKeys();
     } catch (err: any) {

--- a/services/tenant-ui/frontend/src/store/issuerStore.ts
+++ b/services/tenant-ui/frontend/src/store/issuerStore.ts
@@ -5,9 +5,9 @@ import {
 
 import { defineStore } from 'pinia';
 import { Ref, ref } from 'vue';
-import { fetchList } from './utils/fetchList.js';
 import { useAcapyApi } from './acapyApi';
 import { fetchItem } from './utils/fetchItem';
+import { fetchList } from './utils/fetchList.js';
 import { API_PATH } from '@/helpers/constants';
 
 export const useIssuerStore = defineStore('issuer', () => {

--- a/services/tenant-ui/frontend/src/store/keyManagementStore.ts
+++ b/services/tenant-ui/frontend/src/store/keyManagementStore.ts
@@ -1,0 +1,82 @@
+// Types
+import {
+  TenantAuthenticationApiRecord,
+  TenantApiKeyRequest,
+  TenantAuthenticationsApiResponse,
+} from '@/types/acapyApi/acapyInterface';
+
+import { defineStore } from 'pinia';
+import { ref, Ref } from 'vue';
+import { useAcapyApi } from './acapyApi';
+import { fetchList } from './utils/fetchList.js';
+import { API_PATH } from '@/helpers/constants';
+
+export const useKeyManagementStore = defineStore('keyManagement', () => {
+  const acapyApi = useAcapyApi();
+
+  // state
+  const apiKeys: Ref<TenantAuthenticationApiRecord[]> = ref([]);
+  const loading: any = ref(false);
+  const error: any = ref(null);
+
+  // getters
+
+  // actions
+  async function listApiKeys() {
+    return fetchList(
+      `${API_PATH.TENANT_AUTHENTICATIONS_API}`,
+      apiKeys,
+      error,
+      loading
+    );
+  }
+
+  // Create an API key
+  async function createApiKey(payload: TenantApiKeyRequest) {
+    error.value = null;
+    loading.value = true;
+
+    let createResponse: TenantAuthenticationsApiResponse | undefined;
+    try {
+      createResponse = (
+        await acapyApi.postHttp(
+          API_PATH.TENANT_AUTHENTICATIONS_API_POST,
+          payload
+        )
+      ).data;
+      // Reload the keys list after updating
+      await listApiKeys();
+    } catch (err: any) {
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+
+    // return the key
+    return createResponse;
+  }
+
+  // Delete an API Key
+  async function deleteApiKey(id: string) {
+    loading.value = true;
+    try {
+      await acapyApi.deleteHttp(API_PATH.TENANT_AUTHENTICATIONS_API_RECORD(id));
+      listApiKeys();
+    } catch (err: any) {
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+  }
+
+  return { apiKeys, loading, createApiKey, deleteApiKey, listApiKeys };
+});

--- a/services/tenant-ui/frontend/src/types/acapyApi/acapyInterface.ts
+++ b/services/tenant-ui/frontend/src/types/acapyApi/acapyInterface.ts
@@ -3544,6 +3544,14 @@ export interface TailsDeleteResponse {
   message?: string;
 }
 
+export interface TenantApiKeyRequest {
+  /**
+   * Alias/label
+   * @example "API key for my Tenant"
+   */
+  alias: string;
+}
+
 export interface TenantAuthenticationApiList {
   /** List of reservations */
   results?: TenantAuthenticationApiRecord[];
@@ -3556,7 +3564,7 @@ export interface TenantAuthenticationApiOperationResponse {
 
 export interface TenantAuthenticationApiRecord {
   /** Alias description for this API key */
-  alias?: string;
+  alias: string;
   /**
    * Time of record creation
    * @pattern ^\d{4}-\d\d-\d\d[T ]\d\d:\d\d(?:\:(?:\d\d(?:\.\d{1,6})?))?(?:[+-]\d\d:?\d\d|Z|)$
@@ -3588,23 +3596,28 @@ export interface TenantAuthenticationApiRecord {
 
 export interface TenantAuthenticationsApiRequest {
   /**
-   * Optional alias/label
-   * @example "API key for sample line of buisness"
+   * Alias/label
+   * @example "API key for sample line of business"
    */
-  alias?: string;
+  alias: string;
   /**
    * Tenant ID
-   * @example "000000-000000-00000-00000000"
+   * @example "3fa85f64-5717-4562-b3fc-2c963f66afa6"
    */
   tenant_id: string;
 }
 
 export interface TenantAuthenticationsApiResponse {
   /**
-   * The reservation record identifier
+   * The API key
+   * @example "3bd14a1e8fb645ddadf9913c0922ff3b"
+   */
+  api_key: string;
+  /**
+   * The API key record identifier
    * @example "3fa85f64-5717-4562-b3fc-2c963f66afa6"
    */
-  reservation_id: string;
+  tenant_authentication_api_id: string;
 }
 
 export interface TenantConfig {

--- a/services/tenant-ui/frontend/src/views/ApiKeys.vue
+++ b/services/tenant-ui/frontend/src/views/ApiKeys.vue
@@ -1,0 +1,7 @@
+<template>
+  <ApiKeys />
+</template>
+
+<script setup lang="ts">
+import ApiKeys from '@/components/authentications/ApiKeys.vue';
+</script>

--- a/services/tenant-ui/frontend/test/components/layout/__snapshots__/Sidebar.test.ts.snap
+++ b/services/tenant-ui/frontend/test/components/layout/__snapshots__/Sidebar.test.ts.snap
@@ -153,13 +153,25 @@ exports[`Sidebar > mount matches snapshot with expected values 1`] = `
       </transition-stub>
     </div>
     <div class=\\"p-panelmenu-panel\\" data-pc-section=\\"panel\\">
-      <div id=\\"undefined_7_header\\" class=\\"p-panelmenu-header\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"about.about\\" aria-expanded=\\"false\\" aria-controls=\\"undefined_7_content\\" data-pc-section=\\"header\\" data-p-highlight=\\"false\\">
+      <div id=\\"undefined_7_header\\" class=\\"p-panelmenu-header\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"apiKey.apiKeys\\" aria-expanded=\\"false\\" aria-controls=\\"undefined_7_content\\" data-pc-section=\\"header\\" data-p-highlight=\\"false\\">
         <div class=\\"p-panelmenu-header-content\\" data-pc-section=\\"headercontent\\">
           <router-link-stub to=\\"[object Object]\\" custom=\\"\\"></router-link-stub>
         </div>
       </div>
       <transition-stub name=\\"p-toggleable-content\\" appear=\\"false\\" persisted=\\"false\\" css=\\"true\\">
         <div id=\\"undefined_7_content\\" class=\\"p-toggleable-content\\" role=\\"region\\" aria-labelledby=\\"undefined_7_header\\" data-pc-section=\\"toggleablecontent\\" style=\\"display: none;\\">
+          <!---->
+        </div>
+      </transition-stub>
+    </div>
+    <div class=\\"p-panelmenu-panel\\" data-pc-section=\\"panel\\">
+      <div id=\\"undefined_8_header\\" class=\\"p-panelmenu-header\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"about.about\\" aria-expanded=\\"false\\" aria-controls=\\"undefined_8_content\\" data-pc-section=\\"header\\" data-p-highlight=\\"false\\">
+        <div class=\\"p-panelmenu-header-content\\" data-pc-section=\\"headercontent\\">
+          <router-link-stub to=\\"[object Object]\\" custom=\\"\\"></router-link-stub>
+        </div>
+      </div>
+      <transition-stub name=\\"p-toggleable-content\\" appear=\\"false\\" persisted=\\"false\\" css=\\"true\\">
+        <div id=\\"undefined_8_content\\" class=\\"p-toggleable-content\\" role=\\"region\\" aria-labelledby=\\"undefined_8_header\\" data-pc-section=\\"toggleablecontent\\" style=\\"display: none;\\">
           <!---->
         </div>
       </transition-stub>


### PR DESCRIPTION
**Traction backend**
- Innkeeper plugin, add relevant TENANT endpoints for API key CRUD 
![image](https://github.com/bcgov/traction/assets/17445138/7ec372fb-9380-4345-a94d-068f1728b5f0)
- All the same code paths for managing keys as the Innkeeper ones I created recently (though only for a specific Tenant obviously)
- Same as Innkeeper, keys are salt/hash, only returned in the POST result then not fetchable again
- Thoroughly tested you can only operate on keys for the token for the wallet you are operating on
- Innkeeper can still delete your keys and see records (though not password itself)
- You can manage keys an Innkeeper creates for you

**Tenant UI**
- Frontend for key CRUD, again same as shown Innkeeper one
- Added as as sidebar item and page, though I'm not convinced this is the right place for this in the UI.
The main pages and sidebar items are really for wallet functionality, maybe this belongs better in Settings or somewhere under the profile badge? We should UX review this along with lots of other stuff. But doing it here for now is the simplest.
- Need to add some unit tests, but will see if component organization gets reconfigured to move elsewhere first....
- Probably some code duplication resulting here since similar components as the Innkeeper are used, but different enough to not reuse.
![image](https://github.com/bcgov/traction/assets/17445138/10b07f03-27f4-4fe8-9382-e321cf79e10c)
