### PR TITLE
Unshallow repo clone for helm-releaser action

### DIFF
--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -62,6 +62,7 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
 
   helm_release:
+    name: Publish Helm Chart
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source

--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -64,10 +64,10 @@ jobs:
   helm_release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Source
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2147483647 # workaround to check-out a non-shallow repo clone
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
See https://stackoverflow.com/questions/6802145/how-to-convert-a-git-shallow-clone-to-a-full-clone/6802238#6802238

Resolves #794 