### PR TITLE
Normalize tenant fields

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
@@ -219,10 +219,11 @@ class ReservationRecordSchema(BaseRecordSchema):
         example=UUIDFour.EXAMPLE,
     )
 
-    connect_to_endorsers = fields.List(
+    connect_to_endorser = fields.List(
         fields.Dict(description="Endorser and ledger config", required=False),
         example=json.dumps(ENDORSER_LEDGER_CONFIG_EXAMPLE),
         required=False,
+        attribute="connect_to_endorsers"
     )
 
     create_public_did = fields.List(
@@ -363,10 +364,11 @@ class TenantRecordSchema(BaseRecordSchema):
         example=UUIDFour.EXAMPLE,
     )
 
-    connected_to_endorsers = fields.List(
+    connect_to_endorser = fields.List(
         fields.Dict(description="Endorser and ledger config", required=False),
         example=json.dumps(ENDORSER_LEDGER_CONFIG_EXAMPLE),
         required=False,
+        attribute="connected_to_endorsers",
     )
 
     created_public_did = fields.List(

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
@@ -117,7 +117,7 @@ const formattedTenants = computed(() =>
   tenants.value.map((ten: any) => ({
     tenant_id: ten.tenant_id,
     tenant_name: ten.tenant_name,
-    connected_to_endorsers: ten.connected_to_endorsers,
+    connect_to_endorser: ten.connect_to_endorser,
     created_public_did: ten.created_public_did,
     created: formatDateLong(ten.created_at),
     created_at: ten.created_at,

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/editConfig/editConfigForm.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/editConfig/editConfigForm.vue
@@ -137,7 +137,7 @@ onMounted(() => {
   // Determine if the Tenant already has the config permission
   // This will change in the future for multi-ledger support but
   // for now determine by the fields being set.
-  formFields.canConnectEndorser = !!props.tenant.connected_to_endorsers?.length;
+  formFields.canConnectEndorser = !!props.tenant.connect_to_endorser?.length;
   formFields.canRegisterDid = !!props.tenant.created_public_did?.length;
 
   // Fetch the configured instance endorser details

--- a/services/tenant-ui/frontend/src/types/acapyApi/acapyInterface.ts
+++ b/services/tenant-ui/frontend/src/types/acapyApi/acapyInterface.ts
@@ -3090,7 +3090,7 @@ export interface ReservationList {
 
 export interface ReservationRecord {
   /** @example "{"endorser_alias": " ... ", "ledger_id": " ... "}" */
-  connect_to_endorsers?: object[];
+  connect_to_endorser?: object[];
   /** Contact email for this tenant request */
   contact_email: string;
   /** Contact name for this tenant request */
@@ -3638,7 +3638,7 @@ export interface TenantRecord {
   /** True if tenant can make itself issuer, false if only innkeeper can */
   auto_issuer?: boolean;
   /** @example "{"endorser_alias": " ... ", "ledger_id": " ... "}" */
-  connected_to_endorsers?: object[];
+  connect_to_endorser?: object[];
   /**
    * Time of record creation
    * @pattern ^\d{4}-\d\d-\d\d[T ]\d\d:\d\d(?:\:(?:\d\d(?:\.\d{1,6})?))?(?:[+-]\d\d:?\d\d|Z|)$

--- a/services/tenant-ui/frontend/test/__mocks__/api/responses/innkeeper/tenant.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/api/responses/innkeeper/tenant.ts
@@ -1,7 +1,7 @@
 const reservations = {
   results: [
     {
-      connect_to_endorsers: {
+      connect_to_endorser: {
         endorser_alias: ' ... ',
         ledger_id: ' ... ',
       },
@@ -33,7 +33,7 @@ const denyReservation = {
 const tenants = {
   results: [
     {
-      connected_to_endorsers: {
+      connect_to_endorser: {
         endorser_alias: ' ... ',
         ledger_id: ' ... ',
       },
@@ -49,7 +49,7 @@ const tenants = {
 };
 
 const updateTenant = {
-  connected_to_endorsers: {
+  connect_to_endorser: {
     endorser_alias: ' ... ',
     ledger_id: ' ... ',
   },

--- a/services/tenant-ui/frontend/test/__mocks__/api/responses/reservation.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/api/responses/reservation.ts
@@ -15,7 +15,7 @@ const checkIn = {
 };
 
 const reservation = {
-  connect_to_endorsers: {
+  connect_to_endorser: {
     endorser_alias: ' ... ',
     ledger_id: ' ... ',
   },

--- a/services/tenant-ui/frontend/test/__mocks__/api/responses/tenant.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/api/responses/tenant.ts
@@ -2,7 +2,7 @@ const self = {
   wallet_id: 'ec8fd0b2-d4c7-4579-a213-14b753ef3b53',
   state: 'active',
   updated_at: '2023-06-26T22:27:20.725045Z',
-  connected_to_endorsers: [
+  connect_to_endorser: [
     {
       endorser_alias: 'endorser',
       ledger_id: 'bcovrin-test',

--- a/services/tenant-ui/frontend/test/__mocks__/store/innkeeper/tenants.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/store/innkeeper/tenants.ts
@@ -3,7 +3,7 @@ import { vi } from 'vitest';
 const tenant = {
   created_public_did: ['bcovrin-test'],
   wallet_id: 'ec8fd0b2-d4c7-4579-a213-14b753ef3b53',
-  connected_to_endorsers: [
+  connect_to_endorser: [
     {
       endorser_alias: 'endorser',
       ledger_id: 'bcovrin-test',


### PR DESCRIPTION
Changed the models selialized values from `connected_to_endorsers` and `connect_to_endorsers` to `connect_to_endorser` for consistency and updated the ui.

Note: The attribute field used to change the serialization value will break if the python library `marshmallow` get upgraded to version ^3.0.0