### PR TITLE
Release Helm Chart using main branch when triggered by release/tag

### DIFF
--- a/.github/actions/chart_releaser/cr.sh
+++ b/.github/actions/chart_releaser/cr.sh
@@ -248,27 +248,15 @@ install_chart_releaser() {
 
 lookup_latest_tag() {
   git fetch --tags >/dev/null 2>&1
+  latest_tag=$(git tag --sort=-creatordate | sed -n '2p')
 
-  if git symbolic-ref --short -q HEAD; then
-    if ! git describe --tags --abbrev=0 HEAD~ 2>/dev/null; then
-      git rev-list --max-parents=0 --first-parent HEAD
-    fi
+  if [ -z "$latest_tag" ]; then
+    # If no tags are found, return the initial commit hash
+    git rev-list --max-parents=0 --first-parent HEAD
   else
-    # In a detached HEAD state, such as when the pipeline
-    # is triggered by a push on a tag commit, we need to look back
-    # by date
-    current_commit=$(git rev-parse HEAD)
-    for tag in $(git tag --sort=-creatordate); do
-      if [ $(git rev-parse "$tag") = "$current_commit" ]; then
-        continue
-      else
-        echo "$tag"
-        break
-      fi
-    done
+    echo "$latest_tag"
   fi
 }
-
 
 filter_charts() {
   while read -r chart; do

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'ref to checkout:'
+        required: false
+        default: 'main'
 
 jobs:
   # Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo
@@ -32,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.event.inputs.ref }}
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          with: main
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          with: main
+          ref: main
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
- Fix `lookup_latest_tag()` function in `cr.ch`
  - previous code would return incorrectly formatted string which broke the function
- Force `chart-release` step to checkout `main` branch when triggered by new `tag` push event.
- Allow manually specifying `ref` to checkout for `chart-release` step, default to `main`