### PR TITLE
[Helm] Resource allocation and autoscaling tune-up

### DIFF
--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -48,7 +48,7 @@ acapy:
   autoscaling:
     enabled: false
     minReplicas: 1
-    maxReplicas: 10
+    maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
     stabilizationWindowSeconds: 300
@@ -461,7 +461,7 @@ tenant_proxy:
   autoscaling:
     enabled: false
     minReplicas: 1
-    maxReplicas: 5
+    maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
     stabilizationWindowSeconds: 300
@@ -724,7 +724,7 @@ ui:
   autoscaling:
     enabled: false
     minReplicas: 1
-    maxReplicas: 5
+    maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
   ## @param ui.nodeSelector Node labels for tenant-ui pods assignment

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -281,10 +281,10 @@ acapy:
   resources:
     limits:
       cpu: 300m
-      memory: 512Mi
+      memory: 300Mi
     requests:
       cpu: 120m
-      memory: 128Mi
+      memory: 200Mi
   ## @param acapy.podAnnotations Map of annotations to add to the acapy pods
   ##
   podAnnotations: {}

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -706,10 +706,10 @@ ui:
   resources:
     limits:
       cpu: 300m
-      memory: 256Mi
+      memory: 128Mi
     requests:
       cpu: 10m
-      memory: 16Mi
+      memory: 80Mi
   ## @param ui.replicaCount Number of tenant-ui replicas to deploy. Ignored if autoscaling is enabled.
   ##
   replicaCount: 1

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -860,11 +860,11 @@ postgresql:
     ##
     resources:
       limits:
-        cpu: 600m
-        memory: 2600Mi
+        cpu: 500m
+        memory: 500Mi
       requests:
-        cpu: 300m
-        memory: 1300Mi
+        cpu: 100m
+        memory: 100Mi
     ## @param postgresql.primary.service.ports.postgresql PostgreSQL service port
     ##
     service:

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -532,11 +532,11 @@ tenant_proxy:
   ##
   resources:
     limits:
-      cpu: 250m
-      memory: 256Mi
+      cpu: 100m
+      memory: 50Mi
     requests:
-      cpu: 125m
-      memory: 128Mi
+      cpu: 10m
+      memory: 50Mi
 
   ## @section Tenant Proxy NetworkPolicy parameters
 

--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -25,7 +25,7 @@ acapy:
   autoscaling:
     enabled: true
     minReplicas: 2
-    maxReplicas: 5
+    maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
   networkPolicy:
@@ -67,7 +67,7 @@ ui:
   autoscaling:
     enabled: true
     minReplicas: 2
-    maxReplicas: 5
+    maxReplicas: 3
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 ingress:
@@ -76,8 +76,8 @@ ingress:
 postgresql:
   resources:
     limits:
-      cpu: 400m
-      memory: 1600Mi
+      cpu: 500m
+      memory: 500Mi
     requests:
-      cpu: 200m
-      memory: 820Mi
+      cpu: 100m
+      memory: 100Mi

--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -32,7 +32,7 @@ acapy:
   resources:
     limits:
       cpu: 200m
-      memory: 512Mi
+      memory: 300Mi
     requests:
       cpu: 120m
       memory: 128Mi
@@ -68,11 +68,11 @@ ui:
     innkeeperInbox: lucas.o'neil@gov.bc.ca
   resources:
     limits:
-      cpu: 200m
-      memory: 820Mi
+      cpu: 300m
+      memory: 128Mi
     requests:
-      cpu: 120m
-      memory: 400Mi
+      cpu: 10m
+      memory: 80Mi
   ingress:
     annotations:
       route.openshift.io/termination: edge
@@ -90,7 +90,7 @@ postgresql:
     resources:
       limits:
         cpu: 200m
-        memory: 820Mi
+        memory: 128Mi
       requests:
-        cpu: 120m
-        memory: 400Mi
+        cpu: 100m
+        memory: 50Mi


### PR DESCRIPTION
This PR addresses issues with autoscaling, and resource overallocation in deployments.

- Adjust autoscaling defaults
- Adjust `acapy`, `proxy`, `ui`, and `postgres` pods resource requests and limits
- Adjust values for `dev` and `pr` environments