### PR TITLE
fix: docker images

### DIFF
--- a/services/aca-py/Dockerfile.acapy
+++ b/services/aca-py/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM traction:plugins-acapy
+FROM ghcr.io/bcgov/traction-plugins-acapy:sha-10e54d4
 
 USER root
 

--- a/services/endorser/Dockerfile
+++ b/services/endorser/Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.10-slim-buster
 WORKDIR /app
 ENV ENDORSER_API_PORT=5000
 COPY requirements.txt requirements.txt
+
+RUN apt-get update && \ 
+  apt-get install gcc python3-dev -y
+
 RUN pip3 install -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
To get "docker compose up" working I had to make a few small changes to the Dockerfile(s):

- I added `gcc` and `python3-devel` to `services/endorser/Dockerfile` because `pip3` failed to install the requirements because `gcc` was missing.

- I don't think any images for are stored in DockerHub so in `services/aca-py/Dockerfile.acapy` I sourced the image as follows: `FROM ghcr.io/bcgov/traction-plugins-acapy:sha-10e54d4`. These probably need proper image tags with versions or latest.