### PR TITLE
Add Candy dev ledger to DEV

### DIFF
--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -621,10 +621,6 @@ ui:
       messageLevel: info
       ## @param ui.ux.infoBanner.showMessage Show the info banner <boolean>
       showMessage: false
-      ## @param ui.ux.infoBanner.environmentName Environment name to be displayed eg. "Development"
-      environmentName: ""
-      ## @param ui.ux.infoBanner.showEnvironmentName Show the environment name <boolean>
-      showEnvironmentName: false
 
   ariesDetails:
     ## @param ui.ariesDetails.ledgerDescription Ledger description

--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -86,6 +86,11 @@ ui:
   showOIDCReservationLogin: true
   image:
     pullPolicy: Always
+  ux:
+    infoBanner:
+      message: "Traction DEV Environment"
+      messageLevel: info
+      showMessage: true
   oidc:
     active: true
     authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm

--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -20,6 +20,12 @@ acapy:
       genesis_url: "http://dev.bcovrin.vonx.io/genesis"
       endorser_did: "N5bxk3jWkpZ2tEaMtjPjPa"
       endorser_alias: "bcovrin-dev-endorser"
+    - id: candy-dev
+      is_production: true
+      is_write: true
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/dev/pool_transactions_genesis"
+      endorser_did: "85DZerr49BLCuG5wWyDviy"
+      endorser_alias: "candy-dev-endorser"
     - id: sovrin-testnet
       is_production: true
       is_write: true
@@ -36,11 +42,14 @@ acapy:
             ledger_id: bcovrin-test
           - endorser_alias: bcovrin-dev-endorser
             ledger_id: bcovrin-dev
+          - endorser_alias: candy-dev-endorser
+            ledger_id: candy-dev
           - endorser_alias: sovrin-testnet-endorser
             ledger_id: sovrin-testnet
         create_public_did:
           - bcovrin-test
           - bcovrin-dev
+          - candy-dev
           - sovrin-testnet
       reservation:
         expiry_minutes: 7200

--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -78,6 +78,11 @@ ui:
   quickConnectEndorserName: "bcovrin-test-endorser"
   image:
     pullPolicy: Always
+  ux:
+    infoBanner:
+      message: "Traction Pull Request Environment"
+      messageLevel: info
+      showMessage: true
   oidc:
     active: true
     authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm

--- a/services/tenant-ui/config/default.json
+++ b/services/tenant-ui/config/default.json
@@ -35,9 +35,7 @@
       "infoBanner": {
         "message": "",
         "messageLevel": "info",
-        "showMessage": false,
-        "environmentName": "",
-        "showEnvironmentName": false
+        "showMessage": false
       }
     },
     "ariesDetails": {

--- a/services/tenant-ui/frontend/package-lock.json
+++ b/services/tenant-ui/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "axios": "^1.5.1",
         "date-fns": "^2.29.3",
         "dompurify": "^3.0.6",
-        "json-editor-vue": "^0.10.19",
+        "json-editor-vue": "^0.11.0",
         "marked": "^9.1.2",
         "oidc-client-ts": "^2.3.0",
         "pinia": "^2.1.7",
@@ -34,7 +34,6 @@
         "@intlify/eslint-plugin-vue-i18n": "^2.0.0",
         "@pinia/testing": "^0.1.3",
         "@types/dompurify": "^3.0.4",
-        "@types/marked": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
         "@typescript-eslint/parser": "^6.9.0",
         "@vitejs/plugin-vue": "^4.4.0",
@@ -54,7 +53,7 @@
         "typescript": "^5.2.2",
         "vite": "^4.5.0",
         "vitest": "^0.34.6",
-        "vue-tsc": "^1.8.20",
+        "vue-tsc": "^1.8.21",
         "whatwg-fetch": "^3.6.19"
       }
     },
@@ -71,7 +70,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
       "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -516,6 +514,27 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.2.tgz",
+      "integrity": "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -794,7 +813,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -808,7 +826,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -822,7 +839,6 @@
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
       "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -832,7 +848,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -840,8 +855,7 @@
     "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jsonforms/core": {
       "version": "3.1.0",
@@ -1154,16 +1168,6 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
-    },
-    "node_modules/@types/marked": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-6.0.0.tgz",
-      "integrity": "sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==",
-      "deprecated": "This is a stub types definition. marked provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "marked": "*"
-      }
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -1527,30 +1531,30 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.10.4.tgz",
-      "integrity": "sha512-Na69qA6uwVIdA0rHuOc2W3pHtVQQO8hCNim7FOaKNpRJh0oAFnu5r9i7Oopo5C4cnELZkPNjTrbmpcCTiW+CMQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.10.5.tgz",
+      "integrity": "sha512-xD71j4Ee0Ycq8WsiAE6H/aCThGdTobiZZeD+jFD+bvmbopa1Az296pqJysr3Ck8c7n5+GGF+xlKCS3WxRFYgSQ==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "1.10.4"
+        "@volar/source-map": "1.10.5"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.10.4.tgz",
-      "integrity": "sha512-RxZdUEL+pV8p+SMqnhVjzy5zpb1QRZTlcwSk4bdcBO7yOu4rtEWqDGahVCEj4CcXour+0yJUMrMczfSCpP9Uxg==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.10.5.tgz",
+      "integrity": "sha512-s4kgo66SA1kMzYvF9HFE6Vc1rxtXLUmcLrT2WKnchPDvLne+97Kw+xoR2NxJFmsvHoL18vmu/YGXYcN+Q5re1g==",
       "dev": true,
       "dependencies": {
         "muggle-string": "^0.3.1"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.10.4.tgz",
-      "integrity": "sha512-BCCUEBASBEMCrz7qmNSi2hBEWYsXD0doaktRKpmmhvb6XntM2sAWYu6gbyK/MluLDgluGLFiFRpWgobgzUqolg==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.10.5.tgz",
+      "integrity": "sha512-kfDehpeLJku9i1BgsFOYIczPmFFH4herl+GZrLGdvX5urTqeCKsKYlF36iNmFaADzjMb9WlENcUZzPjK8MxNrQ==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "1.10.4"
+        "@volar/language-core": "1.10.5"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -1643,13 +1647,13 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "1.8.20",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.20.tgz",
-      "integrity": "sha512-vNJaqjCTSrWEr+erSq6Rq0CqDC8MOAwyxirxwK8esOxd+1LmAUJUTG2p7I84Mj1Izy5uHiHQAkRTVR2QxMBY+A==",
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.21.tgz",
+      "integrity": "sha512-dKQJc1xfWIZfv6BeXyxz3SSNrC7npJpDIN/VOb1rodAm4o247TElrXOHYAJdV9x1KilaEUo3YbnQE+WA3vQwMw==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "~1.10.4",
-        "@volar/source-map": "~1.10.4",
+        "@volar/language-core": "~1.10.5",
+        "@volar/source-map": "~1.10.5",
         "@vue/compiler-dom": "^3.3.0",
         "@vue/shared": "^3.3.0",
         "computeds": "^0.0.1",
@@ -1763,16 +1767,6 @@
         "@vue/server-renderer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vue/typescript": {
-      "version": "1.8.20",
-      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.20.tgz",
-      "integrity": "sha512-F0XX1wK71Fo9ewtzLSCSo5dfOuwKrSi/dR2AlI00iTJ4Bfk0wq1BNTRgnlvfx4kz/vQovaGXqwpIkif14W9KrA==",
-      "dev": true,
-      "dependencies": {
-        "@volar/typescript": "~1.10.4",
-        "@vue/language-core": "1.8.20"
       }
     },
     "node_modules/@vuelidate/core": {
@@ -2050,6 +2044,14 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2093,6 +2095,14 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
+      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/balanced-match": {
@@ -2440,6 +2450,26 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/code-red": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.10.0",
+        "estree-walker": "^3.0.3",
+        "periscopic": "^3.1.0"
+      }
+    },
+    "node_modules/code-red/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2530,9 +2560,21 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2702,6 +2744,14 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/diff-sequences": {
@@ -3791,6 +3841,11 @@
       "integrity": "sha512-oGXzbEDem9OOpDWZu88jGiYCvIsLHMvGw+8OXlpsvTFvIQplQbjg1B1cvKg8f7Hoch6+NGjpPsH1Fr+Mc2D1aA==",
       "dev": true
     },
+    "node_modules/immutable-json-patch": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-5.1.3.tgz",
+      "integrity": "sha512-95AsF9hJTPpwtBGAnHmw57PASL672tb+vGHR5xLhH2VPuHSsLho7grjlfgQ65DIhHP+UmLCjdmuuA6L1ndJbZg=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4060,6 +4115,14 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-reference": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -4323,16 +4386,19 @@
       }
     },
     "node_modules/json-editor-vue": {
-      "version": "0.10.19",
-      "resolved": "https://registry.npmjs.org/json-editor-vue/-/json-editor-vue-0.10.19.tgz",
-      "integrity": "sha512-LuoN+iCHAiXtg3jC07+ATn1u56loyA4S12fDyN/uODqZ7e7dTuH0Kqkm9rDGsQZYASgi7E5lWwnn0yoXDNdLDw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/json-editor-vue/-/json-editor-vue-0.11.0.tgz",
+      "integrity": "sha512-qqVXOenijghZwBkj3HG3LixSC8TdMQRuSJYexQbfez0xnPBXJ+pZ00O2uwD/TsXeYE+GwlZ6pwTux77wiEzV5A==",
       "hasInstallScript": true,
       "dependencies": {
-        "vue-demi": "latest"
+        "vanilla-jsoneditor": "^0.18.10",
+        "vue-demi": "^0.14.6"
+      },
+      "engines": {
+        "npm": ">=8.3.0"
       },
       "peerDependencies": {
         "@vue/composition-api": ">=1",
-        "vanilla-jsoneditor": ">=0",
         "vue": "2||3"
       },
       "peerDependenciesMeta": {
@@ -4342,9 +4408,9 @@
       }
     },
     "node_modules/json-editor-vue/node_modules/vue-demi": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
-      "integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -4440,6 +4506,11 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4537,6 +4608,11 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5067,6 +5143,24 @@
         "node": "*"
       }
     },
+    "node_modules/periscopic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "is-reference": "^3.0.0"
+      }
+    },
+    "node_modules/periscopic/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5370,7 +5464,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5917,6 +6010,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/svelte": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.2.tgz",
+      "integrity": "sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^3.2.1",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/svelte/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -6221,10 +6345,35 @@
       }
     },
     "node_modules/vanilla-jsoneditor": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/vanilla-jsoneditor/-/vanilla-jsoneditor-0.17.10.tgz",
-      "integrity": "sha512-2ScoLNqq3kRSJ1+sG8rzbh4YtetrgEXbRX0OYxOk1Lqlg6tSkELGPsTA4KADFwk1s84oPj2ozMmFY6SwbZRJhg==",
-      "peer": true
+      "version": "0.18.10",
+      "resolved": "https://registry.npmjs.org/vanilla-jsoneditor/-/vanilla-jsoneditor-0.18.10.tgz",
+      "integrity": "sha512-56tBVGVYNgoNvN0qbR9usI23bSLEh5kGfKcNg3dkBiDkKAgHq7JG0yI8lJqapGKbygnyz7fx8LzqKs89NEL98Q==",
+      "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^6.4.2",
+        "ajv": "^8.12.0",
+        "immutable-json-patch": "^5.1.3",
+        "svelte": "^4.2.1"
+      }
+    },
+    "node_modules/vanilla-jsoneditor/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/vanilla-jsoneditor/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/vite": {
       "version": "4.5.0",
@@ -6495,13 +6644,13 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "1.8.20",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.20.tgz",
-      "integrity": "sha512-bIADlyxJl+1ZWQQHAi47NZoi2iTiw/lBwQLL98wXROcQlUuGVtyroAIiqvto9pJotcyhtU0JbGvsHN6JN0fYfg==",
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.21.tgz",
+      "integrity": "sha512-gc9e+opdeF0zKixaadXT5v2s+x+77oqpuza/vwqDhdDyEeLZUOmZaVeb9noZpkdhFaLq7t7ils/7lFU8E/Hgew==",
       "dev": true,
       "dependencies": {
-        "@vue/language-core": "1.8.20",
-        "@vue/typescript": "1.8.20",
+        "@volar/typescript": "~1.10.5",
+        "@vue/language-core": "1.8.21",
         "semver": "^7.5.4"
       },
       "bin": {

--- a/services/tenant-ui/frontend/package.json
+++ b/services/tenant-ui/frontend/package.json
@@ -24,7 +24,7 @@
     "axios": "^1.5.1",
     "date-fns": "^2.29.3",
     "dompurify": "^3.0.6",
-    "json-editor-vue": "^0.10.19",
+    "json-editor-vue": "^0.11.0",
     "marked": "^9.1.2",
     "oidc-client-ts": "^2.3.0",
     "pinia": "^2.1.7",
@@ -42,7 +42,6 @@
     "@intlify/eslint-plugin-vue-i18n": "^2.0.0",
     "@pinia/testing": "^0.1.3",
     "@types/dompurify": "^3.0.4",
-    "@types/marked": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "@vitejs/plugin-vue": "^4.4.0",
@@ -62,7 +61,7 @@
     "typescript": "^5.2.2",
     "vite": "^4.5.0",
     "vitest": "^0.34.6",
-    "vue-tsc": "^1.8.20",
+    "vue-tsc": "^1.8.21",
     "whatwg-fetch": "^3.6.19"
   }
 }


### PR DESCRIPTION
Set Candy Dev as a ledger/endorser option in Traction DEV.

Set banner for PR and Dev envs too.

Clear a dependabot alert with package update. Remove types package that is warned as deprecated.