### PR TITLE
innkeeper: soft delete tenant

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
@@ -278,6 +278,7 @@ class TenantRecord(BaseRecord):
         created_public_did: List = [],
         auto_issuer: bool = False,
         enable_ledger_switch=False,
+        deleted_at: str = None,
         **kwargs,
     ):
         """Construct record."""
@@ -293,6 +294,7 @@ class TenantRecord(BaseRecord):
         self.auto_issuer = auto_issuer
         self.enable_ledger_switch = enable_ledger_switch
         self.curr_ledger_id = curr_ledger_id
+        self.deleted_at = deleted_at
 
     @property
     def tenant_id(self) -> Optional[str]:
@@ -312,6 +314,7 @@ class TenantRecord(BaseRecord):
                 "auto_issuer",
                 "enable_ledger_switch",
                 "curr_ledger_id",
+                "deleted_at",
             )
         }
 
@@ -352,6 +355,7 @@ class TenantRecord(BaseRecord):
         """
         if self.state != self.STATE_DELETED:
             self.state = self.STATE_DELETED
+            self.deleted_at = datetime_to_str(datetime.utcnow())
             await self.save(session, reason="Soft delete")
 
 
@@ -421,6 +425,11 @@ class TenantRecordSchema(BaseRecordSchema):
     curr_ledger_id = fields.Str(
         required=False,
         description="Current ledger identifier",
+    )
+    deleted_at = fields.Str(
+        required=False,
+        description="Timestamp of the deletion",
+        example="2023-10-30T01:01:01Z",
     )
 
 

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/models.py
@@ -238,7 +238,7 @@ class ReservationRecordSchema(BaseRecordSchema):
         fields.Dict(description="Endorser and ledger config", required=False),
         example=json.dumps(ENDORSER_LEDGER_CONFIG_EXAMPLE),
         required=False,
-        attribute="connect_to_endorsers"
+        attribute="connect_to_endorsers",
     )
 
     create_public_did = fields.List(
@@ -344,6 +344,15 @@ class TenantRecord(BaseRecord):
         if not result:
             raise StorageNotFoundError("No TenantRecord found for the given wallet_id")
         return result[0]
+
+    async def soft_delete(self, session: ProfileSession):
+        """
+        Soft delete the tenant record by setting its state to 'deleted'.
+        Note: This method should be called on an instance of the TenantRecord.
+        """
+        if self.state != self.STATE_DELETED:
+            self.state = self.STATE_DELETED
+            await self.save(session, reason="Soft delete")
 
 
 class TenantRecordSchema(BaseRecordSchema):

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/Tenants.vue
@@ -33,7 +33,10 @@
       <Column :expander="true" header-style="width: 3rem" />
       <Column :sortable="false" :header="$t('common.actions')">
         <template #body="{ data }">
-          <EditConfig :tenant="data" />
+          <div class="container">
+            <EditConfig :tenant="data" />
+            <DeleteTenant :tenant="data" />
+          </div>
         </template>
       </Column>
       <Column
@@ -96,6 +99,7 @@ import { storeToRefs } from 'pinia';
 import { TABLE_OPT, API_PATH } from '@/helpers/constants';
 import { formatDateLong } from '@/helpers';
 import EditConfig from './editConfig/editConfig.vue';
+import DeleteTenant from './deleteTenant/DeleteTenant.vue';
 import MainCardContent from '@/components/layout/mainCard/MainCardContent.vue';
 import RowExpandData from '@/components/common/RowExpandData.vue';
 
@@ -148,3 +152,8 @@ const filter = ref({
 // necessary for expanding rows, we don't do anything with this
 const expandedRows = ref([]);
 </script>
+<style scoped>
+.container {
+  display: flex;
+}
+</style>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/ConfirmTenantDeletion.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/ConfirmTenantDeletion.vue
@@ -1,0 +1,74 @@
+<template>
+  <form @submit.prevent="handleDelete">
+    <div class="modal-content">
+      <h4>
+        {{
+          $t('tenants.settings.confirmDeletion', {
+            tenantName: tenant.tenant_name,
+          })
+        }}
+      </h4>
+      <InputText
+        v-model.trim="confirmationTenantName"
+        type="text"
+        placeholder="Type the tenant name here"
+        class="w-full mb-4"
+      />
+      <Button
+        :disabled="!isTenantNameCorrect"
+        label="Delete"
+        severity="danger"
+        class="w-full"
+        type="submit"
+      />
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, defineProps, defineEmits } from 'vue';
+
+import InputText from 'primevue/inputtext';
+import Button from 'primevue/button';
+
+import { useInnkeeperTenantsStore, useTenantStore } from '@/store';
+import { TenantRecord } from '@/types/acapyApi/acapyInterface';
+
+import { useToast } from 'vue-toastification';
+
+const props = defineProps<{
+  tenant: TenantRecord;
+}>();
+
+const emit = defineEmits(['closed', 'success']);
+
+// Using stores
+const innkeeperTenantsStore = useInnkeeperTenantsStore();
+const tenantStore = useTenantStore();
+
+const confirmationTenantName = ref('');
+const isTenantNameCorrect = computed(
+  () => confirmationTenantName.value === props.tenant.tenant_name
+);
+
+const toast = useToast();
+
+async function handleDelete() {
+  if (!isTenantNameCorrect.value) {
+    toast.error(
+      'Incorrect tenant name. Please confirm the correct name before deletion.'
+    );
+    return;
+  }
+  innkeeperTenantsStore
+    .deleteTenant(props.tenant.tenant_id)
+    .catch((err: string) => {
+      console.log(err);
+      toast.error('Failure: ${err}');
+    });
+
+  emit('success');
+
+  emit('closed');
+}
+</script>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/ConfirmTenantDeletion.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/ConfirmTenantDeletion.vue
@@ -68,7 +68,6 @@ async function handleDelete() {
     });
 
   emit('success');
-
   emit('closed');
 }
 </script>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <Button
+      :title="$t('tenants.settings.editSettings')"
+      icon="pi pi-trash"
+      class="p-button-rounded p-button-icon-only p-button-text"
+      @click="openModal"
+    />
+    <Dialog
+      v-model:visible="displayModal"
+      :style="{ minWidth: '500px' }"
+      :header="'Delete Tenant'"
+      :modal="true"
+      @update:visible="handleClose"
+    >
+      <ConfirmTenantDeletion
+        :tenant="props.tenant"
+        @success="$emit('success')"
+        @closed="handleClose"
+      />
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Types
+import { TenantRecord } from '@/types/acapyApi/acapyInterface';
+
+// Vue
+import { ref } from 'vue';
+// PrimeVue
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
+// Custom Components
+import ConfirmTenantDeletion from './ConfirmTenantDeletion.vue';
+
+defineEmits(['success']);
+
+// Props
+const props = defineProps<{
+  tenant: TenantRecord;
+}>();
+
+const displayModal = ref(false);
+const openModal = async () => {
+  // Kick of the loading asyncs (if needed)
+  displayModal.value = true;
+};
+const handleClose = async () => {
+  // some logic... maybe we shouldn't close?
+  displayModal.value = false;
+};
+</script>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
@@ -4,6 +4,7 @@
       :title="$t('tenants.settings.deleteTenant')"
       icon="pi pi-trash"
       class="p-button-rounded p-button-icon-only p-button-text"
+      :disabled="props.tenant.tenant_name === 'traction_innkeeper'"
       @click="openModal"
     />
     <Dialog

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
@@ -23,31 +23,26 @@
 </template>
 
 <script setup lang="ts">
-// Types
-import { TenantRecord } from '@/types/acapyApi/acapyInterface';
-
-// Vue
 import { ref } from 'vue';
-// PrimeVue
+
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
-// Custom Components
+
 import ConfirmTenantDeletion from './ConfirmTenantDeletion.vue';
+
+import { TenantRecord } from '@/types/acapyApi/acapyInterface';
 
 defineEmits(['success']);
 
-// Props
 const props = defineProps<{
   tenant: TenantRecord;
 }>();
 
 const displayModal = ref(false);
 const openModal = async () => {
-  // Kick of the loading asyncs (if needed)
   displayModal.value = true;
 };
 const handleClose = async () => {
-  // some logic... maybe we shouldn't close?
   displayModal.value = false;
 };
 </script>

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/deleteTenant/DeleteTenant.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Button
-      :title="$t('tenants.settings.editSettings')"
+      :title="$t('tenants.settings.deleteTenant')"
       icon="pi pi-trash"
       class="p-button-rounded p-button-icon-only p-button-text"
       @click="openModal"

--- a/services/tenant-ui/frontend/src/components/innkeeper/tenants/editConfig/editConfig.vue
+++ b/services/tenant-ui/frontend/src/components/innkeeper/tenants/editConfig/editConfig.vue
@@ -4,6 +4,7 @@
       :title="$t('tenants.settings.editSettings')"
       icon="pi pi-cog"
       class="p-button-rounded p-button-icon-only p-button-text"
+      :disabled="props.tenant.tenant_name === 'traction_innkeeper'"
       @click="openModal"
     />
     <Dialog

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -468,7 +468,8 @@
       "enableLedgerSwitch": "Tenant can switch endorser/ledger",
       "endorserAlias": "Endorser Alias:",
       "ledgerName": "Ledger Name:",
-      "success": "Tenant Config Updated"
+      "success": "Tenant Config Updated",
+      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below"
     },
     "tenants": "Tenants"
   },

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/en.json
@@ -469,7 +469,8 @@
       "endorserAlias": "Endorser Alias:",
       "ledgerName": "Ledger Name:",
       "success": "Tenant Config Updated",
-      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below"
+      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below",
+      "deleteTenant": "Delete Tenant"
     },
     "tenants": "Tenants"
   },

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -472,7 +472,8 @@
       "endorserAlias": "Endorser Alias <FR>",
       "ledgerName": "Ledger Name <FR>",
       "success": "Tenant Config Updated <FR>",
-      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below <FR>"
+      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below <FR>",
+      "deleteTenant": "Delete Tenant <FR>"
     },
     "tenants": "Tenants <FR>"
   },

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/fr.json
@@ -471,7 +471,8 @@
       "enableLedgerSwitch": "Tenant can switch endorser/ledger <FR>",
       "endorserAlias": "Endorser Alias <FR>",
       "ledgerName": "Ledger Name <FR>",
-      "success": "Tenant Config Updated <FR>"
+      "success": "Tenant Config Updated <FR>",
+      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below <FR>"
     },
     "tenants": "Tenants <FR>"
   },

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
@@ -472,7 +472,8 @@
       "enableLedgerSwitch": "Tenant can switch endorser/ledger <JA>",
       "endorserAlias": "Endorser Alias <JA>",
       "ledgerName": "Ledger Name <JA>",
-      "success": "Tenant Config Updated <JA>"
+      "success": "Tenant Config Updated <JA>",
+      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below <JA>"
     },
     "tenants": "Tenants <JA>"
   },

--- a/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
+++ b/services/tenant-ui/frontend/src/plugins/i18n/locales/ja.json
@@ -473,7 +473,8 @@
       "endorserAlias": "Endorser Alias <JA>",
       "ledgerName": "Ledger Name <JA>",
       "success": "Tenant Config Updated <JA>",
-      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below <JA>"
+      "confirmDeletion": "To confirm, type \"{tenantName}\" in the box below <JA>",
+      "deleteTenant": "Delete Tenant <JA>"
     },
     "tenants": "Tenants <JA>"
   },

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -355,6 +355,27 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
     return result;
   };
 
+  // Delete a Tenant
+  async function deleteTenant(id: string) {
+    loading.value = true;
+    try {
+      console.log(`Deleting tenant: ${id}`);
+
+      // await acapyApi.deleteHttp(
+      //   API_PATH.INNKEEPER_AUTHENTICATIONS_API_RECORD(id)
+      // );
+      // listApiKeys();
+    } catch (err: any) {
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+    if (error.value != null) {
+      // throw error so $onAction.onError listeners can add their own handler
+      throw error.value;
+    }
+  }
+
   return {
     loading,
     error,
@@ -376,6 +397,7 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
     listReservations,
     updateTenantConfig,
     getDefaultConfigValues,
+    deleteTenant,
   };
 });
 

--- a/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
+++ b/services/tenant-ui/frontend/src/store/innkeeper/innkeeperTenantsStore.ts
@@ -277,6 +277,22 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
     }
   }
 
+  // Delete a Tenant
+  async function deleteTenant(id: string) {
+    loading.value = true;
+    try {
+      await acapyApi.deleteHttp(API_PATH.INNKEEPER_TENANT(id));
+      await listTenants();
+    } catch (err: any) {
+      error.value = err;
+    } finally {
+      loading.value = false;
+    }
+    if (error.value != null) {
+      throw error.value;
+    }
+  }
+
   // Create an API key for a tenant
   async function createApiKey(payload: TenantAuthenticationsApiRequest) {
     error.value = null;
@@ -354,27 +370,6 @@ export const useInnkeeperTenantsStore = defineStore('innkeeperTenants', () => {
     }
     return result;
   };
-
-  // Delete a Tenant
-  async function deleteTenant(id: string) {
-    loading.value = true;
-    try {
-      console.log(`Deleting tenant: ${id}`);
-
-      // await acapyApi.deleteHttp(
-      //   API_PATH.INNKEEPER_AUTHENTICATIONS_API_RECORD(id)
-      // );
-      // listApiKeys();
-    } catch (err: any) {
-      error.value = err;
-    } finally {
-      loading.value = false;
-    }
-    if (error.value != null) {
-      // throw error so $onAction.onError listeners can add their own handler
-      throw error.value;
-    }
-  }
 
   return {
     loading,


### PR DESCRIPTION
Added soft delete
Note: we will need to create a follow up issue for hard delete.
- added delete confirmation thingamabober
  -  <img width="604" alt="869-PR-1" src="https://github.com/bcgov/traction/assets/9407864/31e1e351-7552-4dd9-b893-6b1bd50a0248">
- added query params to `/innkeeper/tenants` which defaults to `active`.  If `all` is supplied as a param it will return all tenants. 
  - <img width="1053" alt="869-PR-2" src="https://github.com/bcgov/traction/assets/9407864/6dcc8329-5fd2-4c7e-acb0-5cea5382d083"> 
- added soft delete endpoint
  - <img width="904" alt="869-PR-3" src="https://github.com/bcgov/traction/assets/9407864/dd296cf9-a828-4de3-a115-84ee996565f7">
