### PR TITLE
Remove null pointer in oca plugin schema

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/oca/routes.py
@@ -56,7 +56,9 @@ def error_handler(func):
 
 class OcaRecordListQueryStringSchema(OpenAPISchema):
     cred_def_id = fields.Str(
-        required=False, description="Cred Def identifier", **INDY_CRED_DEF_ID
+        required=False, description="Cred Def identifier", 
+        example=INDY_CRED_DEF_ID_EXAMPLE, 
+        validate=INDY_CRED_DEF_ID_VALIDATE
     )
 
 


### PR DESCRIPTION
Not sure when this broke but the variable this schema reference must have been removed.

Weird it didn't throw errors.

Should consider running the `ruff` linting on the plugins to catch something like this.