### PR TITLE
Issuer badge display issue with TAA

### DIFF
--- a/services/tenant-ui/frontend/package-lock.json
+++ b/services/tenant-ui/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tenant-ui-frontend",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/services/tenant-ui/frontend/src/components/about/Traction.vue
+++ b/services/tenant-ui/frontend/src/components/about/Traction.vue
@@ -3,10 +3,10 @@
     <div class="col-12 md:col-6">
       <strong>{{ $t('about.traction.info') }}</strong>
       <p class="my-0">
-        {{ $t('about.traction.tractionVersion', { version: '0.3.6' }) }}
+        {{ $t('about.traction.tractionVersion', { version: '0.3.7' }) }}
       </p>
       <p class="mt-0">
-        {{ $t('about.traction.uiVersion', { version: '0.3.6' }) }}
+        {{ $t('about.traction.uiVersion', { version: '0.3.7' }) }}
       </p>
     </div>
 

--- a/services/tenant-ui/frontend/src/store/tenantStore.ts
+++ b/services/tenant-ui/frontend/src/store/tenantStore.ts
@@ -31,12 +31,11 @@ export const useTenantStore = defineStore('tenant', () => {
   const tenantReady = computed(() => {
     return token.value != null;
   });
-  const isIssuer = computed(() => {
+  const isIssuer: Ref<boolean> = computed(() => {
     return (
-      endorserConnection.value &&
-      endorserConnection.value.state === 'active' &&
-      publicDid.value &&
-      publicDid.value.did
+      endorserConnection.value?.state === 'active' &&
+      publicDid.value?.did &&
+      (!taa.value?.taa_required || taa.value?.taa_accepted)
     );
   });
 

--- a/services/tenant-ui/frontend/test/store/tenantStore.test.ts
+++ b/services/tenant-ui/frontend/test/store/tenantStore.test.ts
@@ -53,16 +53,60 @@ describe('tenantStore', () => {
     expect(store.tenantReady).toEqual(true);
   });
 
-  // Should this function return a boolean?
-  test('isIssuer is truthy when endorderConnection active and has did', () => {
+  test('isIssuer is true when endorderConnection active and has did and TAA not required', () => {
     store.endorserConnection = {
       state: 'active',
     };
     store.publicDid = {
       did: 'did',
     };
+    store.taa = {
+      taa_required: false,
+    };
     expect(store.isIssuer).toBeTruthy();
-    expect(store.isIssuer).toEqual('did');
+    expect(store.isIssuer).toEqual(true);
+  });
+
+  test('isIssuer is true when endorderConnection active and has did and TAA accepted', () => {
+    store.endorserConnection = {
+      state: 'active',
+    };
+    store.publicDid = {
+      did: 'did',
+    };
+    store.taa = {
+      taa_required: true,
+      taa_accepted: true,
+    };
+    expect(store.isIssuer).toBeTruthy();
+    expect(store.isIssuer).toEqual(true);
+  });
+
+  test('isIssuer is false when the TAA is not accepted ', () => {
+    store.endorserConnection = {
+      state: 'active',
+    };
+    store.publicDid = {
+      did: 'did',
+    };
+    store.taa = {
+      taa_required: true,
+      taa_accepted: false,
+    };
+    expect(store.isIssuer).toBeFalsy();
+  });
+
+  test('isIssuer is false when the taa_accepted is not there ', () => {
+    store.endorserConnection = {
+      state: 'active',
+    };
+    store.publicDid = {
+      did: 'did',
+    };
+    store.taa = {
+      taa_required: true,
+    };
+    expect(store.isIssuer).toBeFalsy();
   });
 
   test('isIssuer is falsy when endorserConnection is not-active', () => {

--- a/services/tenant-ui/package.json
+++ b/services/tenant-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tenant-ui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
Take the appropriate TAA status into account for whether to display the issuance status in the Tenant UI.

Also bump version display for after next release cut. (Go to 0.3.7, as 0.3.6 is now cut)