### PR TITLE
Switch KC realms

### DIFF
--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -94,8 +94,8 @@ ui:
       showMessage: true
   oidc:
     active: true
-    authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
-    jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
+    authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
+    jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
     reservationForm: >-
       {
         "formDataSchema": {

--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -85,8 +85,8 @@ ui:
       showMessage: true
   oidc:
     active: true
-    authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm
-    jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs
+    authority: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz
+    jwksUri: https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs
     reservationForm: >-
       {
         "formDataSchema": {

--- a/services/tenant-ui/config/default.json
+++ b/services/tenant-ui/config/default.json
@@ -15,7 +15,7 @@
     },
     "oidc": {
       "active": false,
-      "authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm",
+      "authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz",
       "client": "innkeeper-frontend",
       "label": "IDIR"
     },
@@ -53,8 +53,8 @@
     "staticFiles": "../../frontend/dist",
     "tractionUrl": "http://localhost:5100",
     "oidc": {
-      "jwksUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm/protocol/openid-connect/certs",
-      "realm": "digitaltrust-nrm",
+      "jwksUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz/protocol/openid-connect/certs",
+      "realm": "digitaltrust-citz",
       "roleName": "innkeeper"
     },
     "innkeeper": {

--- a/services/tenant-ui/frontend/test/__mocks__/api/responses/config.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/api/responses/config.ts
@@ -9,7 +9,7 @@ const config = {
     oidc: {
       active: false,
       authority:
-        'https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-nrm',
+        'https://dev.loginproxy.gov.bc.ca/auth/realms/digitaltrust-citz',
       client: 'innkeeper-frontend',
       label: 'IDIR',
     },


### PR DESCRIPTION
In order to deprecate the digitaltrust-nrm custom realm we will use digitaltrust-citz for the Tenant UI IDIR gates (innkeeper and reservation).

I've moved the clients/roles/groups over there and have tested out locally. Setting default values and dev/pr helm vals here.

Will PR to the trust-over-ip repo for test and prod