### PR TITLE
Add exempt issue labels to stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,4 +19,5 @@ jobs:
           days-before-pr-stale: 45
           days-before-issue-close: 5
           days-before-pr-close: 10
+          exempt-issue-labels: pinned, bug
         


### PR DESCRIPTION
The stale action was firing for every single issue, including ones that should in theory be exempt.
Added `pinned`, `bug` labels to the exempt issue list.