### PR TITLE
Fix OOB Invitation API call with multi-use

### DIFF
--- a/services/tenant-ui/frontend/src/store/connectionStore.ts
+++ b/services/tenant-ui/frontend/src/store/connectionStore.ts
@@ -107,7 +107,9 @@ export const useConnectionStore = defineStore('connection', () => {
     // need the await here since the returned invitationData is not one of our stored refs...
     await acapyApi
       .postHttp(API_PATH.OUT_OF_BAND_CREATE, payload, {
-        multi_use: multiUse,
+        params: {
+          multi_use: multiUse,
+        },
       })
       .then((res) => {
         console.log(res);


### PR DESCRIPTION
Creating an invitation for an OOB connection is not passing the query param properly in the Tenant UI.

This scenario:
![image](https://github.com/bcgov/traction/assets/17445138/ec2c44b1-f9ec-40ca-abaa-0723f0d17c96)
