### PR TITLE
[Helm] Bump version

### DIFF
--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Run Traction PR Helm
         run: |
-          helm upgrade --install pr-${{ github.event.number }}-traction -f ./deploy/traction/values-pr.yaml --set acapy.image.tag=pr-${{ github.event.number }} --set traction_proxy.image.tag=pr-${{ github.event.number }} --set ui.image.tag=pr-${{ github.event.number }} ./charts/traction --wait
+          helm upgrade --install pr-${{ github.event.number }}-traction -f ./deploy/traction/values-pr.yaml --set acapy.image.tag=pr-${{ github.event.number }} --set tenant_proxy.image.tag=pr-${{ github.event.number }} --set ui.image.tag=pr-${{ github.event.number }} ./charts/traction --wait
 
       - name: Restart Traction PR Pods
         run: |

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Traction Dev Helm
         run: |
-          helm upgrade --install traction -f ./deploy/traction/values-development.yaml --set acapy.image.tag=${{ needs.build_acapy.outputs.image_version }} --set traction_proxy.image.tag=${{ needs.build_acapy.outputs.image_version }} --set ui.image.tag=${{ needs.build_ui.outputs.image_version }} ./charts/traction --wait
+          helm upgrade --install traction -f ./deploy/traction/values-development.yaml --set acapy.image.tag=${{ needs.build_acapy.outputs.image_version }} --set tenant_proxy.image.tag=${{ needs.build_acapy.outputs.image_version }} --set ui.image.tag=${{ needs.build_ui.outputs.image_version }} ./charts/traction --wait
 
       - name: Restart Deployments
         run: |

--- a/charts/traction/Chart.yaml
+++ b/charts/traction/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traction
 description: The Traction service allows organizations to verify, hold, and issue verifiable credentials. The Traction Tenant UI allows tenants to manage their agent.
 type: application
-version: 0.2.8
-appVersion: 0.3.6
+version: 0.2.9
+appVersion: 0.3.7
 home: "https://github.com/bcgov/traction"
 sources: ["https://github.com/bcgov/traction"]
 icon: "https://github.com/bcgov/traction/raw/main/docs/assets/readme-logo.png"

--- a/charts/traction/README.md
+++ b/charts/traction/README.md
@@ -1,6 +1,6 @@
 # Traction
 
-![version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.6](https://img.shields.io/badge/AppVersion-0.3.6-informational?style=flat-square)
+![version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.7](https://img.shields.io/badge/AppVersion-0.3.7-informational?style=flat-square)
 
 The Traction service allows organizations to verify, hold, and issue verifiable credentials.
 

--- a/services/endorser/requirements.txt
+++ b/services/endorser/requirements.txt
@@ -6,7 +6,7 @@ asyncpg==0.24.0
 certifi==2023.7.22
 charset-normalizer==2.0.10
 click==8.0.3
-fastapi==0.72.0
+fastapi==0.109.1
 greenlet==1.1.2
 gunicorn==20.1.0
 h11==0.13.0
@@ -29,9 +29,9 @@ sniffio==1.2.0
 SQLAlchemy==1.4.27
 sqlalchemy2-stubs==0.0.2a19
 sqlmodel==0.0.6
-starlette==0.17.1
+starlette==0.35.1
 starlette-context==0.3.3
-typing_extensions==4.0.1
+typing_extensions==4.8.0
 urllib3==1.26.18
 uvicorn==0.17.0
 uvloop==0.16.0


### PR DESCRIPTION
With the nodemailer auth feature, both tenant-ui and the helm chart were updated.

**New versions:**
Chart version: `0.2.9`
  App version: `0.3.7`