### PR TITLE
Update local env endorser for dependabot security warnings

### DIFF
--- a/services/endorser/requirements.txt
+++ b/services/endorser/requirements.txt
@@ -6,7 +6,7 @@ asyncpg==0.24.0
 certifi==2023.7.22
 charset-normalizer==2.0.10
 click==8.0.3
-fastapi==0.109.1
+fastapi==0.110.0
 greenlet==1.1.2
 gunicorn==20.1.0
 h11==0.13.0
@@ -22,14 +22,14 @@ psycopg2-binary==2.9.2
 pydantic==1.9.0
 python-dotenv==0.19.2
 python-jose[cryptography]==3.3.0
-python-multipart==0.0.5
+python-multipart==0.0.7
 PyYAML==6.0
 requests==2.27.1
 sniffio==1.2.0
 SQLAlchemy==1.4.27
 sqlalchemy2-stubs==0.0.2a19
 sqlmodel==0.0.6
-starlette==0.35.1
+starlette==0.36.3
 starlette-context==0.3.3
 typing_extensions==4.8.0
 urllib3==1.26.18


### PR DESCRIPTION
For https://github.com/bcgov/traction/pull/1021
and https://github.com/bcgov/traction/pull/1015

also update fastapi to accomodate the Starlette version