### PR TITLE
Correct ToggleJson support for creating schemas

### DIFF
--- a/services/tenant-ui/frontend/src/assets/primevueOverrides/inputSwitch.scss
+++ b/services/tenant-ui/frontend/src/assets/primevueOverrides/inputSwitch.scss
@@ -2,20 +2,20 @@
 
 // Input Switches
 .p-inputswitch {
-  &.p-inputswitch-checked .p-inputswitch-slider {
+  &[data-p-highlight="true"] .p-inputswitch-slider {
     background: darken($tenant-ui-status-green-background, 20%);
     &::before {
       background-color: white !important;
     }
   }
-  .p-inputswitch-slider {
+  &[data-p-highlight="false"] .p-inputswitch-slider {
     background: darken($tenant-ui-status-red-background, 20%);
   }
   &:hover {
-    &.p-inputswitch-checked .p-inputswitch-slider {
+    &[data-p-highlight="true"] .p-inputswitch-slider {
       background: darken($tenant-ui-status-green-background, 40%) !important;
     }
-    .p-inputswitch-slider {
+    &[data-p-highlight="false"] .p-inputswitch-slider {
       background: darken($tenant-ui-status-red-background, 40%) !important;
     }
   }

--- a/services/tenant-ui/frontend/src/components/common/ToggleJson.vue
+++ b/services/tenant-ui/frontend/src/components/common/ToggleJson.vue
@@ -2,12 +2,12 @@
   <div class="mt-2">
     <div class="flex justify-content-end">
       {{ $t('common.json') }}
-      <InputSwitch v-model="displayAsForm" class="ml-1" @input="toggleJson" />
+      <InputSwitch v-model="showRawJson" class="ml-1" @input="toggleJson" />
     </div>
-    <div v-show="displayAsForm">
+    <div v-show="!showRawJson">
       <slot></slot>
     </div>
-    <div v-show="!displayAsForm">
+    <div v-show="showRawJson">
       <Textarea
         id="credentialValuesEdit"
         v-model="valuesJson"
@@ -27,7 +27,7 @@ import { ref } from 'vue';
 import InputSwitch from 'primevue/inputswitch';
 import Textarea from 'primevue/textarea';
 
-const displayAsForm = ref<boolean>(true);
+const showRawJson = ref<boolean>(false);
 const valuesJson = ref<string>('');
 
 // Undefined indicates that the conversion was a failure
@@ -39,21 +39,21 @@ const props = defineProps<{
 }>();
 
 defineExpose({
-  displayAsForm,
+  showRawJson,
   valuesJson,
 });
 
 const toggleJson = () => {
-  if (displayAsForm.value) {
+  if (!showRawJson.value) {
     const res = props.toJson();
     if (res) {
       valuesJson.value = res;
     } else {
-      displayAsForm.value = !displayAsForm.value;
+      showRawJson.value = !showRawJson.value;
     }
   } else {
     if (!props.fromJson(valuesJson.value)) {
-      displayAsForm.value = !displayAsForm.value;
+      showRawJson.value = !showRawJson.value;
     }
   }
 };

--- a/services/tenant-ui/frontend/src/components/common/ToggleJson.vue
+++ b/services/tenant-ui/frontend/src/components/common/ToggleJson.vue
@@ -2,12 +2,12 @@
   <div class="mt-2">
     <div class="flex justify-content-end">
       {{ $t('common.json') }}
-      <InputSwitch v-model="showRawJson" class="ml-1" @input="toggleJson" />
+      <InputSwitch v-model="displayAsForm" class="ml-1" @input="toggleJson" />
     </div>
-    <div v-show="!showRawJson">
+    <div v-show="displayAsForm">
       <slot></slot>
     </div>
-    <div v-show="showRawJson">
+    <div v-show="!displayAsForm">
       <Textarea
         id="credentialValuesEdit"
         v-model="valuesJson"
@@ -27,7 +27,7 @@ import { ref } from 'vue';
 import InputSwitch from 'primevue/inputswitch';
 import Textarea from 'primevue/textarea';
 
-const showRawJson = ref<boolean>(false);
+const displayAsForm = ref<boolean>(true);
 const valuesJson = ref<string>('');
 
 // Undefined indicates that the conversion was a failure
@@ -39,21 +39,21 @@ const props = defineProps<{
 }>();
 
 defineExpose({
-  showRawJson,
+  displayAsForm,
   valuesJson,
 });
 
 const toggleJson = () => {
-  if (showRawJson.value) {
+  if (displayAsForm.value) {
     const res = props.toJson();
     if (res) {
       valuesJson.value = res;
     } else {
-      showRawJson.value = !showRawJson.value;
+      displayAsForm.value = !displayAsForm.value;
     }
   } else {
     if (!props.fromJson(valuesJson.value)) {
-      showRawJson.value = !showRawJson.value;
+      displayAsForm.value = !displayAsForm.value;
     }
   }
 };

--- a/services/tenant-ui/frontend/src/components/issuance/credentials/EnterCredentialValues.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/credentials/EnterCredentialValues.vue
@@ -88,7 +88,7 @@ function jsonToCredentialValue(
     credentialValuesRaw.value = parsed;
     return parsed;
   } else {
-    toast.warning('The JSON you inputted has invalid syntax');
+    toast.warning('This JSON is invalid syntax');
     return undefined;
   }
 }

--- a/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
@@ -74,7 +74,6 @@ import ToggleJson from '@/components/common/ToggleJson.vue';
 const toast = useToast();
 const { t } = useI18n();
 
-const other = ref(false);
 const governanceStore = useGovernanceStore();
 const { loading, selectedSchema } = storeToRefs(useGovernanceStore());
 

--- a/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
@@ -204,7 +204,7 @@ function jsonToSchema(jsonString: string): SchemaSendRequest | undefined {
     formFields.version = parsed.schema_version;
     return parsed;
   } else {
-    toast.error('The JSON you inputted has invalid syntax');
+    toast.error('Invalid JSON detected');
     return undefined;
   }
 }

--- a/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
@@ -54,7 +54,6 @@
 
 <script setup lang="ts">
 // Libraries
-import Tester from '@/components/common/./Tester.vue';
 import { useVuelidate } from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
 import { storeToRefs } from 'pinia';
@@ -214,11 +213,8 @@ function jsonToSchema(jsonString: string): SchemaSendRequest | undefined {
 const submitted = ref(false);
 const handleSubmit = async (isFormValid: boolean) => {
   submitted.value = true;
-  console.log('trying to validate');
   try {
-    console.log('is valid?');
     if (!isFormValid) return;
-    console.log('valid');
 
     const payload: SchemaSendRequest | undefined = jsonVal.value.showRawJson
       ? jsonToSchema(jsonVal.value.valuesJson)

--- a/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
+++ b/services/tenant-ui/frontend/src/components/issuance/schemas/CreateSchemaForm.vue
@@ -54,6 +54,7 @@
 
 <script setup lang="ts">
 // Libraries
+import Tester from '@/components/common/./Tester.vue';
 import { useVuelidate } from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
 import { storeToRefs } from 'pinia';
@@ -74,6 +75,7 @@ import ToggleJson from '@/components/common/ToggleJson.vue';
 const toast = useToast();
 const { t } = useI18n();
 
+const other = ref(false);
 const governanceStore = useGovernanceStore();
 const { loading, selectedSchema } = storeToRefs(useGovernanceStore());
 
@@ -212,9 +214,11 @@ function jsonToSchema(jsonString: string): SchemaSendRequest | undefined {
 const submitted = ref(false);
 const handleSubmit = async (isFormValid: boolean) => {
   submitted.value = true;
-
+  console.log('trying to validate');
   try {
+    console.log('is valid?');
     if (!isFormValid) return;
+    console.log('valid');
 
     const payload: SchemaSendRequest | undefined = jsonVal.value.showRawJson
       ? jsonToSchema(jsonVal.value.valuesJson)

--- a/services/tenant-ui/frontend/test/components/common/ToggleJson.test.ts
+++ b/services/tenant-ui/frontend/test/components/common/ToggleJson.test.ts
@@ -38,7 +38,6 @@ describe('Properly Toggle Json Input', () => {
     const fromJson = vi.spyOn(wrapperVm.props, 'fromJson');
 
     expect(wrapper.findComponent({ name: 'Textarea' }).isVisible()).toBe(false);
-    // displayAsForm;
     expect(wrapper.findComponent({ name: 'InputSwitch' }).exists()).toBe(true);
 
     expect(wrapper.findComponent({ name: 'CreateSchema' }).exists()).toBe(true);

--- a/services/tenant-ui/frontend/test/components/common/ToggleJson.test.ts
+++ b/services/tenant-ui/frontend/test/components/common/ToggleJson.test.ts
@@ -42,24 +42,23 @@ describe('Properly Toggle Json Input', () => {
     expect(wrapper.findComponent({ name: 'InputSwitch' }).exists()).toBe(true);
 
     expect(wrapper.findComponent({ name: 'CreateSchema' }).exists()).toBe(true);
-    wrapperVm.displayAsForm = true;
-    // wrapperVm.displayAsForm = false;
+
+    wrapperVm.showRawJson = false;
+
+    // Ensure that toggling to works
     await wrapperVm.toggleJson();
-
     await flushPromises();
-
-    wrapperVm.displayAsForm = false;
-
-    await flushPromises();
-
     expect(toJson).toHaveBeenCalled();
-    // expect(fromJson).toHaveBeenCalled();
+
+    // Ensure text Textarea is properly displayed
+    wrapperVm.showRawJson = true;
+    await flushPromises();
+
     expect(wrapper.findComponent({ name: 'Textarea' }).isVisible()).toBe(true);
 
+    // Ensure toggling from json works
     await wrapperVm.toggleJson();
-
     await flushPromises();
-
     expect(fromJson).toHaveBeenCalled();
   });
 });

--- a/services/tenant-ui/frontend/test/components/common/ToggleJson.test.ts
+++ b/services/tenant-ui/frontend/test/components/common/ToggleJson.test.ts
@@ -38,22 +38,28 @@ describe('Properly Toggle Json Input', () => {
     const fromJson = vi.spyOn(wrapperVm.props, 'fromJson');
 
     expect(wrapper.findComponent({ name: 'Textarea' }).isVisible()).toBe(false);
-    // showRawJson;
+    // displayAsForm;
     expect(wrapper.findComponent({ name: 'InputSwitch' }).exists()).toBe(true);
 
     expect(wrapper.findComponent({ name: 'CreateSchema' }).exists()).toBe(true);
-    wrapperVm.showRawJson = true;
+    wrapperVm.displayAsForm = true;
+    // wrapperVm.displayAsForm = false;
     await wrapperVm.toggleJson();
 
     await flushPromises();
 
-    wrapperVm.showRawJson = false;
-    await wrapperVm.toggleJson();
+    wrapperVm.displayAsForm = false;
 
     await flushPromises();
 
-    expect(wrapper.findComponent({ name: 'Textarea' }).isVisible()).toBe(true);
     expect(toJson).toHaveBeenCalled();
+    // expect(fromJson).toHaveBeenCalled();
+    expect(wrapper.findComponent({ name: 'Textarea' }).isVisible()).toBe(true);
+
+    await wrapperVm.toggleJson();
+
+    await flushPromises();
+
     expect(fromJson).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR resolves #1030

Uncertain as to why this is necessary but for whatever reason showRawJson defaulting to a false value seemed to never be properly applied and needed to be defaulted to true. For this reason it's usage has been inverted and the variable has been renamed to displayAsForm.