### PR TITLE
[Deployment] Increase CPU limit for Acapy container

### DIFF
--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -64,6 +64,9 @@ acapy:
       enabled: true
       namespaceSelector:
         network.openshift.io/policy-group: ingress
+  resources:
+    limits:
+      cpu: 500m
 tenant_proxy:
   image:
     pullPolicy: Always


### PR DESCRIPTION
Increase `dev` Acapy container CPU limit from `300m` to `500m`
Address throttling condition in `dev` deployment as per https://github.com/bcgov/DITP-DevOps/issues/181