### PR TITLE
Support reading the Candy Prod ledger in PR and dev

### DIFF
--- a/deploy/traction/values-development.yaml
+++ b/deploy/traction/values-development.yaml
@@ -20,6 +20,10 @@ acapy:
       genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/dev/pool_transactions_genesis"
       endorser_did: "85DZerr49BLCuG5wWyDviy"
       endorser_alias: "candy-dev-endorser"
+    - id: candy-prod
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
     - id: sovrin-testnet
       is_production: true
       is_write: true

--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -19,6 +19,10 @@ acapy:
       genesis_url: "http://test.bcovrin.vonx.io/genesis"
       endorser_did: "DfQetNSm7gGEHuzfUvpfPn"
       endorser_alias: "bcovrin-test-endorser"
+    - id: candy-prod
+      is_production: true
+      is_write: false
+      genesis_url: "https://raw.githubusercontent.com/ICCS-ISAC/dtrust-reconu/main/CANdy/prod/pool_transactions_genesis"
     - id: sovrin-testnet
       is_production: true
       is_write: true


### PR DESCRIPTION
For Traction DEV we would like to have Candy PROD as a read-only ledger available.
This allows presentation request testing of things like the Person Credential in Traction envs.

The ledger does not appear to the user as a connectable ledger in the Tenant UI, as there's no Endorser details. (not that the user would be able to write in that case anyways)