### PR TITLE
Disable clean-ghcr job in Uninstall PR Instance workflow

### DIFF
--- a/.github/workflows/on_pr_closed.yaml
+++ b/.github/workflows/on_pr_closed.yaml
@@ -46,7 +46,7 @@ jobs:
 
   clean-ghcr:
     runs-on: ubuntu-22.04
-    if: github.repository_owner == 'bcgov'
+    if: ${{ false }}
     name: Delete closed PR images
     steps:
       - name: Delete Images


### PR DESCRIPTION
Disable clean-ghcr job in the workflow to troubleshoot image corruption issue in GHCR.