### PR TITLE
Use "sandbox" Tools env bcovrin-test endorser for default helm file

### DIFF
--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -141,7 +141,7 @@ acapy:
       is_production: true
       is_write: true
       genesis_url: "http://test.bcovrin.vonx.io/genesis"
-      endorser_did: "Ket75eV5UQvVkW2XBjgDH7"
+      endorser_did: "DfQetNSm7gGEHuzfUvpfPn"
       endorser_alias: "bcovrin-test-endorser"
 
   ## @section Wallet Storage configuration


### PR DESCRIPTION
`values.yaml` had an old unused endorser DID in there