### PR TITLE
Update argfiles for PRs for DB name and tails

### DIFF
--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -11,7 +11,8 @@ acapy:
       walletkey: "change-me"
       tenantid: "innkeeper"
   argfile.yml:
-    wallet-name: default
+    tails-server-base-url: https://tails-dev.vonx.io
+    tails-server-upload-url: https://tails-dev.vonx.io
   ledgers.yml:
     - id: bcovrin-test
       is_production: true


### PR DESCRIPTION
Was getting very confused about our dev/test/prod deployments having an 'askar-wallet' db and PRs having 'default' so lets make those match for OCP deployments. Can normalize the DB name now that the fix here is in: https://github.com/bcgov/traction/pull/1428 (thanks to Ivan for finding that out)

Also update to have PRs use dev tails server