### PR TITLE
Remove unused endorser settings/parameters

### DIFF
--- a/scripts/.env-example
+++ b/scripts/.env-example
@@ -130,8 +130,6 @@ ACAPY_ENDORSER_1_ENDPOINT=http://host.docker.internal:9032
 ENDORSER_AGENT_NAME="Endorser Agent"
 ENDORSER_CONNECTION_ALIAS=endorser
 
-ENDORSER_ACAPY_READ_ONLY_MODE=
-
 # Protect all admin endpoints with the provided API key
 # Development setup (do not use in production!)
 #ENDORSER_ACAPY_ADMIN_CONFIG=--admin-insecure-mode

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -178,7 +178,6 @@ services:
         --auto-provision
         --arg-file endorser-acapy-args.yml \
         --inbound-transport http '0.0.0.0' ${ACAPY_ENDORSER_HTTP_PORT} \
-        --webhook-url '${ENDORSER_WEBHOOK_URL}' \
         --genesis-url '${ACAPY_GENESIS_URL}' \
         --endpoint ${ACAPY_ENDORSER_ENDPOINT} \
         --wallet-name '${ENDORSER_ACAPY_WALLET_DATABASE}' \
@@ -192,9 +191,6 @@ services:
         --admin '0.0.0.0' ${ACAPY_ENDORSER_ADMIN_PORT} \
         --label '${ENDORSER_AGENT_NAME}' \
         ${ENDORSER_ACAPY_ADMIN_CONFIG} \
-        ${ENDORSER_ACAPY_READ_ONLY_MODE} \
-        --endorser-protocol-role endorser \
-        --auto-endorse-transactions \
         ",
       ]
     environment:
@@ -220,7 +216,6 @@ services:
         --auto-provision
         --arg-file endorser-acapy-args.yml \
         --inbound-transport http '0.0.0.0' ${ACAPY_ENDORSER_1_HTTP_PORT} \
-        --webhook-url '${ENDORSER_1_WEBHOOK_URL}' \
         --genesis-url '${ACAPY_GENESIS_URL_1}' \
         --endpoint ${ACAPY_ENDORSER_1_ENDPOINT} \
         --wallet-name '${ENDORSER_1_ACAPY_WALLET_DATABASE}' \
@@ -234,9 +229,6 @@ services:
         --admin '0.0.0.0' ${ACAPY_ENDORSER_1_ADMIN_PORT} \
         --label '${ENDORSER_AGENT_NAME}' \
         ${ENDORSER_ACAPY_ADMIN_CONFIG} \
-        ${ENDORSER_ACAPY_READ_ONLY_MODE} \
-        --endorser-protocol-role endorser \
-        --auto-endorse-transactions \
         ",
       ]
     environment:

--- a/scripts/endorser-acapy-args.yml
+++ b/scripts/endorser-acapy-args.yml
@@ -5,7 +5,6 @@ auto-ping-connection: true
 auto-provision: true
 monitor-ping: true
 public-invites: true
-plugin: 'acapy_agent.messaging.jsonld'
 outbound-transport: http
 log-level: info
 endorser-protocol-role: endorser


### PR DESCRIPTION
Small cleanup removing duplicated settings for the endorser that were being set via environment variable AND configuration file.
Also removes a couple of settings (jsonld plugin and webhook endpoint) that are not required/used anymore.