### PR TITLE
feat(connections): Add alias field to invitation response schema

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/connections/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/connections/routes.py
@@ -9,13 +9,22 @@ from acapy_agent.messaging.models.base import BaseModelError
 from acapy_agent.protocols.connections.v1_0.routes import (
     ConnectionsConnIdMatchInfoSchema, InvitationResultSchema)
 from acapy_agent.storage.error import StorageNotFoundError
+from marshmallow import fields 
 
 LOGGER = logging.getLogger(__name__)
 
+class InvitationResponseSchema(InvitationResultSchema):
+    """Response schema for a previous connection invitation."""
+
+    alias = fields.Str(
+        required=False,
+        allow_none=True,
+        metadata={"description": "Optional alias for the connection", "example": "Bob"},
+    )
 
 @docs(tags=["connection"], summary="Fetch connection invitation")
 @match_info_schema(ConnectionsConnIdMatchInfoSchema())
-@response_schema(InvitationResultSchema(), 200, description="")
+@response_schema(InvitationResponseSchema(), 200, description="")
 @tenant_authentication
 async def connections_invitation(request: web.BaseRequest):
     """Handle fetching invitation associated with a single connection record."""


### PR DESCRIPTION
This PR adds the `alias` field to the invitation response schema

### Changes:
- Extended `InvitationResultSchema` to include an optional `alias` field.
- Added descriptions and examples for the `alias` field in the OpenAPI documentation.

### Why:
- This change allows tools like openapi-generator to generate the correct interfaces / classes for the `/connections/{conn_id}/invitation` endpoint

### Testing:
- Verified that the `alias` field is included in the response when fetching an invitation.
- Confirmed that the OpenAPI documentation reflects the new field.