### PR TITLE
Fix incorrect ref when building images

### DIFF
--- a/.github/actions/build_acapy/action.yaml
+++ b/.github/actions/build_acapy/action.yaml
@@ -43,7 +43,7 @@ runs:
   steps:
     - uses: actions/checkout@v4   
       with:
-        ref: ${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}${{ inputs.ref }}
+        ref: ${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/actions/build_ui/action.yaml
+++ b/.github/actions/build_ui/action.yaml
@@ -38,7 +38,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}${{ inputs.ref }}
+        ref: ${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}
 
     - name: Set up Node
       uses: actions/setup-node@master


### PR DESCRIPTION
It looks like we had the chck on build ref defined incorrectly - or rather it had an unnecessary extra value appended to the one evaluated first