### PR TITLE
Innkeeper unit tests for the remaining files

### DIFF
--- a/.github/workflows/test_innkeeper_plugin.yaml
+++ b/.github/workflows/test_innkeeper_plugin.yaml
@@ -49,4 +49,4 @@ jobs:
         id: unit-tests
         env:
           PYTHONPATH: .
-        run: poetry run pytest traction_innkeeper
+        run: poetry run pytest traction_innkeeper --cov --cov-fail-under 90

--- a/plugins/traction_innkeeper/poetry.lock
+++ b/plugins/traction_innkeeper/poetry.lock
@@ -634,6 +634,82 @@ test = ["PyYAML", "mock", "pytest"]
 yaml = ["PyYAML"]
 
 [[package]]
+name = "coverage"
+version = "7.8.0"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "coverage-7.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2931f66991175369859b5fd58529cd4b73582461877ecfd859b6549869287ffe"},
+    {file = "coverage-7.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52a523153c568d2c0ef8826f6cc23031dc86cffb8c6aeab92c4ff776e7951b28"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c8a5c139aae4c35cbd7cadca1df02ea8cf28a911534fc1b0456acb0b14234f3"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a26c0c795c3e0b63ec7da6efded5f0bc856d7c0b24b2ac84b4d1d7bc578d676"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:821f7bcbaa84318287115d54becb1915eece6918136c6f91045bb84e2f88739d"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a321c61477ff8ee705b8a5fed370b5710c56b3a52d17b983d9215861e37b642a"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:ed2144b8a78f9d94d9515963ed273d620e07846acd5d4b0a642d4849e8d91a0c"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:042e7841a26498fff7a37d6fda770d17519982f5b7d8bf5278d140b67b61095f"},
+    {file = "coverage-7.8.0-cp310-cp310-win32.whl", hash = "sha256:f9983d01d7705b2d1f7a95e10bbe4091fabc03a46881a256c2787637b087003f"},
+    {file = "coverage-7.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:5a570cd9bd20b85d1a0d7b009aaf6c110b52b5755c17be6962f8ccd65d1dbd23"},
+    {file = "coverage-7.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27"},
+    {file = "coverage-7.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9"},
+    {file = "coverage-7.8.0-cp311-cp311-win32.whl", hash = "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c"},
+    {file = "coverage-7.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78"},
+    {file = "coverage-7.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc"},
+    {file = "coverage-7.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe"},
+    {file = "coverage-7.8.0-cp312-cp312-win32.whl", hash = "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545"},
+    {file = "coverage-7.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b"},
+    {file = "coverage-7.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ac46d0c2dd5820ce93943a501ac5f6548ea81594777ca585bf002aa8854cacd"},
+    {file = "coverage-7.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:771eb7587a0563ca5bb6f622b9ed7f9d07bd08900f7589b4febff05f469bea00"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42421e04069fb2cbcbca5a696c4050b84a43b05392679d4068acbe65449b5c64"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:554fec1199d93ab30adaa751db68acec2b41c5602ac944bb19187cb9a41a8067"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aaeb00761f985007b38cf463b1d160a14a22c34eb3f6a39d9ad6fc27cb73008"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:581a40c7b94921fffd6457ffe532259813fc68eb2bdda60fa8cc343414ce3733"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f319bae0321bc838e205bf9e5bc28f0a3165f30c203b610f17ab5552cff90323"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04bfec25a8ef1c5f41f5e7e5c842f6b615599ca8ba8391ec33a9290d9d2db3a3"},
+    {file = "coverage-7.8.0-cp313-cp313-win32.whl", hash = "sha256:dd19608788b50eed889e13a5d71d832edc34fc9dfce606f66e8f9f917eef910d"},
+    {file = "coverage-7.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:a9abbccd778d98e9c7e85038e35e91e67f5b520776781d9a1e2ee9d400869487"},
+    {file = "coverage-7.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:18c5ae6d061ad5b3e7eef4363fb27a0576012a7447af48be6c75b88494c6cf25"},
+    {file = "coverage-7.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95aa6ae391a22bbbce1b77ddac846c98c5473de0372ba5c463480043a07bff42"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e013b07ba1c748dacc2a80e69a46286ff145935f260eb8c72df7185bf048f502"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d766a4f0e5aa1ba056ec3496243150698dc0481902e2b8559314368717be82b1"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad80e6b4a0c3cb6f10f29ae4c60e991f424e6b14219d46f1e7d442b938ee68a4"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b87eb6fc9e1bb8f98892a2458781348fa37e6925f35bb6ceb9d4afd54ba36c73"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:d1ba00ae33be84066cfbe7361d4e04dec78445b2b88bdb734d0d1cbab916025a"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883"},
+    {file = "coverage-7.8.0-cp313-cp313t-win32.whl", hash = "sha256:379fe315e206b14e21db5240f89dc0774bdd3e25c3c58c2c733c99eca96f1ada"},
+    {file = "coverage-7.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e4b6b87bb0c846a9315e3ab4be2d52fac905100565f4b92f02c445c8799e257"},
+    {file = "coverage-7.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa260de59dfb143af06dcf30c2be0b200bed2a73737a8a59248fcb9fa601ef0f"},
+    {file = "coverage-7.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:96121edfa4c2dfdda409877ea8608dd01de816a4dc4a0523356067b305e4e17a"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8af63b9afa1031c0ef05b217faa598f3069148eeee6bb24b79da9012423b82"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89b1f4af0d4afe495cd4787a68e00f30f1d15939f550e869de90a86efa7e0814"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94ec0be97723ae72d63d3aa41961a0b9a6f5a53ff599813c324548d18e3b9e8c"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8a1d96e780bdb2d0cbb297325711701f7c0b6f89199a57f2049e90064c29f6bd"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f1d8a2a57b47142b10374902777e798784abf400a004b14f1b0b9eaf1e528ba4"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cf60dd2696b457b710dd40bf17ad269d5f5457b96442f7f85722bdb16fa6c899"},
+    {file = "coverage-7.8.0-cp39-cp39-win32.whl", hash = "sha256:be945402e03de47ba1872cd5236395e0f4ad635526185a930735f66710e1bd3f"},
+    {file = "coverage-7.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:90e7fbc6216ecaffa5a880cdc9c77b7418c1dcb166166b78dbc630d07f278cc3"},
+    {file = "coverage-7.8.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd"},
+    {file = "coverage-7.8.0-py3-none-any.whl", hash = "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7"},
+    {file = "coverage-7.8.0.tar.gz", hash = "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501"},
+]
+
+[package.extras]
+toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
 name = "cryptography"
 version = "44.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -2228,6 +2304,43 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-cov"
+version = "6.1.1"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde"},
+    {file = "pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.5", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2707,4 +2820,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "a0d7f2e150763ad1ed85db8bb155059be8a4c6c52757aed4be9121098b0fe2f3"
+content-hash = "97327b1f7b96f4d69f99c91e5e0eb83cbb6e932ec2aadceb33965d75325eb5cf"

--- a/plugins/traction_innkeeper/pyproject.toml
+++ b/plugins/traction_innkeeper/pyproject.toml
@@ -20,7 +20,9 @@ multitenant-provider = {git = "https://github.com/openwallet-foundation/acapy-pl
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.11.4"
 pytest = "^8.3.5"
-pytest-asyncio="^0.26.0"
+pytest-cov = "^6.1.1"
+pytest-mock = "^3.14.0"
+pytest-asyncio= "^0.26.0"
 
 [tool.pytest.ini_options]
 # You might already have asyncio_mode set, 'auto' is common

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_connections_routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_connections_routes.py
@@ -1,0 +1,332 @@
+import json
+import logging
+from unittest.mock import MagicMock, AsyncMock, patch, ANY
+
+import pytest
+from aiohttp import web
+from acapy_agent.core.profile import Profile
+from acapy_agent.storage.error import StorageNotFoundError
+from acapy_agent.messaging.models.base import BaseModelError
+
+# Import the module containing the routes to be tested
+from traction_innkeeper.v1_0.connections import routes as test_module
+
+# Import Schemas and Models used for mocking return types or validation
+from acapy_agent.connections.models.conn_record import ConnRecord
+from acapy_agent.protocols.connections.v1_0.messages.connection_invitation import (
+    ConnectionInvitation,
+)
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+
+TEST_CONN_ID = "conn-id-abc-123"
+TEST_INVITATION_KEY = "invite-key-xyz-789"
+TEST_BASE_URL = "http://test-agent.com"
+TEST_DEFAULT_ENDPOINT = "http://default.endpoint.com"
+TEST_ALIAS = "Test Alias"
+
+# --- Reusable Fixtures (similar to test_innkeeper_routes.py) ---
+
+
+@pytest.fixture
+def mock_profile_inject():
+    """Provides a mock injector function and tracks injectable mocks."""
+    injectables = {}
+
+    def _injector(cls_to_inject, *args, **kwargs):
+        mock_instance = injectables.get(cls_to_inject)
+        if not mock_instance:
+            return MagicMock()
+        return mock_instance
+
+    return MagicMock(side_effect=_injector), injectables
+
+
+@pytest.fixture
+def mock_session():
+    """Provides a mocked async Session."""
+    session = AsyncMock(name="Session")
+
+    async def __aenter__(*args):
+        return session
+
+    async def __aexit__(*args):
+        pass
+
+    session.__aenter__ = __aenter__
+    session.__aexit__ = __aexit__
+    return session
+
+
+@pytest.fixture
+def mock_profile(mock_session: AsyncMock, mock_profile_inject: tuple):
+    """Provides a mocked Profile."""
+    profile = MagicMock(name="Profile")
+    profile.context = MagicMock(name="Context")
+    profile.settings = {
+        "multitenant.enabled": True,
+        # Base settings potentially needed
+        "admin.admin_api_key": "dummy-admin-key",
+        # Settings specific to connections_invitation
+        "invite_base_url": TEST_BASE_URL,
+        "default_endpoint": TEST_DEFAULT_ENDPOINT,
+    }
+    profile.context.settings = profile.settings
+    profile.session = MagicMock(return_value=mock_session)
+    profile.inject, profile._injectables = mock_profile_inject
+    return profile
+
+
+@pytest.fixture
+def mock_context(mock_profile: MagicMock):
+    """Provides a mocked AdminRequestContext containing the mock profile."""
+    context = MagicMock(name="AdminRequestContext")
+    context.profile = mock_profile
+    return context
+
+
+@pytest.fixture
+def mock_request(mock_context: MagicMock):
+    """Provides a mocked aiohttp.web.Request linked to the context."""
+    request = MagicMock(spec=web.Request)
+    request.match_info = {}
+    request.query = {}
+    test_api_key = "dummy-test-key"
+    request.headers = {
+        "Authorization": test_api_key,
+        "x-api-key": test_api_key,
+    }
+
+    def getitem_side_effect(key):
+        if key == "context":
+            return mock_context
+        return MagicMock()
+
+    request.__getitem__.side_effect = getitem_side_effect
+
+    request.json = AsyncMock()
+    request._set_match_info = lambda key, value: request.match_info.update({key: value})
+
+    return request
+
+
+# --- Test Cases for connections_invitation ---
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.ConnRecord", autospec=True)
+async def test_connections_invitation_direct(
+    MockConnRecordCls: MagicMock, mock_request: MagicMock, mock_profile: MagicMock
+):
+    """Test GET /connections/{conn_id}/invitation - direct invitation found."""
+    mock_request._set_match_info("conn_id", TEST_CONN_ID)
+    mock_profile.settings["invite_base_url"] = TEST_BASE_URL  # Ensure base url is set
+
+    # Mock ConnectionRecord and its invitation
+    mock_conn_rec = AsyncMock(spec=ConnRecord, alias=TEST_ALIAS)
+    mock_invitation = MagicMock(spec=ConnectionInvitation)
+    mock_invitation.serialize.return_value = {
+        "@type": "did:sov:...",
+        "recipientKeys": ["key1"],
+    }
+    mock_invitation.to_url.return_value = (
+        f"{TEST_BASE_URL}?c_i=ey..."  # Returns full URL
+    )
+
+    mock_conn_rec.retrieve_invitation = AsyncMock(return_value=mock_invitation)
+    MockConnRecordCls.retrieve_by_id = AsyncMock(return_value=mock_conn_rec)
+
+    response = await test_module.connections_invitation(mock_request)
+
+    MockConnRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_CONN_ID)
+    mock_conn_rec.retrieve_invitation.assert_awaited_once_with(ANY)
+    mock_invitation.to_url.assert_called_once_with(TEST_BASE_URL)
+    mock_invitation.serialize.assert_called_once()
+
+    assert response.status == 200
+    expected_body = {
+        "connection_id": TEST_CONN_ID,
+        "invitation": mock_invitation.serialize.return_value,
+        "invitation_url": mock_invitation.to_url.return_value,
+        "alias": TEST_ALIAS,
+    }
+    assert json.loads(response.body) == expected_body
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.ConnRecord", autospec=True)
+async def test_connections_invitation_multi_use(
+    MockConnRecordCls: MagicMock, mock_request: MagicMock, mock_profile: MagicMock
+):
+    """Test GET /connections/{conn_id}/invitation - multi-use invitation found."""
+    mock_request._set_match_info("conn_id", TEST_CONN_ID)
+    # Use default_endpoint as base url
+    del mock_profile.settings["invite_base_url"]
+    mock_profile.settings["default_endpoint"] = TEST_DEFAULT_ENDPOINT
+
+    # Mock primary ConnectionRecord (no alias, direct invite fails)
+    mock_conn_rec = AsyncMock(
+        spec=ConnRecord, alias=None, invitation_key=TEST_INVITATION_KEY
+    )
+    mock_conn_rec.retrieve_invitation = AsyncMock(
+        side_effect=StorageNotFoundError("Direct invite not found")
+    )
+    MockConnRecordCls.retrieve_by_id = AsyncMock(return_value=mock_conn_rec)
+
+    # Mock Multi-use ConnectionRecord and its invitation
+    mock_multi_use_conn = AsyncMock(spec=ConnRecord)
+    mock_multi_use_invitation = MagicMock(spec=ConnectionInvitation)
+    mock_multi_use_invitation.serialize.return_value = {
+        "@type": "...",
+        "label": "MultiUse",
+    }
+    # Simulate to_url returning only query params
+    mock_multi_use_invitation.to_url.return_value = "?c_i=ey..."
+
+    mock_multi_use_conn.retrieve_invitation = AsyncMock(
+        return_value=mock_multi_use_invitation
+    )
+    MockConnRecordCls.retrieve_by_invitation_key = AsyncMock(
+        return_value=mock_multi_use_conn
+    )
+
+    response = await test_module.connections_invitation(mock_request)
+
+    MockConnRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_CONN_ID)
+    mock_conn_rec.retrieve_invitation.assert_awaited_once_with(
+        ANY
+    )  # First attempt (failed)
+    MockConnRecordCls.retrieve_by_invitation_key.assert_awaited_once_with(
+        ANY, TEST_INVITATION_KEY
+    )
+    mock_multi_use_conn.retrieve_invitation.assert_awaited_once_with(
+        ANY
+    )  # Second attempt (success)
+    mock_multi_use_invitation.to_url.assert_called_once_with(TEST_DEFAULT_ENDPOINT)
+    mock_multi_use_invitation.serialize.assert_called_once()
+
+    assert response.status == 200
+    expected_invitation_url = (
+        f"{TEST_DEFAULT_ENDPOINT}{mock_multi_use_invitation.to_url.return_value}"
+    )
+    expected_body = {
+        "connection_id": TEST_CONN_ID,
+        "invitation": mock_multi_use_invitation.serialize.return_value,
+        "invitation_url": expected_invitation_url,
+        # No alias expected
+    }
+    assert json.loads(response.body) == expected_body
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.ConnRecord", autospec=True)
+async def test_connections_invitation_conn_not_found(
+    MockConnRecordCls: MagicMock, mock_request: MagicMock, mock_profile: MagicMock
+):
+    """Test GET /connections/{conn_id}/invitation - Connection not found."""
+    mock_request._set_match_info("conn_id", TEST_CONN_ID)
+    MockConnRecordCls.retrieve_by_id = AsyncMock(
+        side_effect=StorageNotFoundError("Conn not found")
+    )
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.connections_invitation(mock_request)
+    assert "Conn not found" in str(excinfo.value)
+
+    MockConnRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_CONN_ID)
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.ConnRecord", autospec=True)
+async def test_connections_invitation_direct_and_multi_use_not_found(
+    MockConnRecordCls: MagicMock, mock_request: MagicMock, mock_profile: MagicMock
+):
+    """Test GET /connections/{conn_id}/invitation - Both direct and multi-use invitations not found."""
+    mock_request._set_match_info("conn_id", TEST_CONN_ID)
+
+    # Mock primary ConnectionRecord (direct invite fails)
+    mock_conn_rec = AsyncMock(
+        spec=ConnRecord, alias=None, invitation_key=TEST_INVITATION_KEY
+    )
+    mock_conn_rec.retrieve_invitation = AsyncMock(
+        side_effect=StorageNotFoundError("Direct invite not found")
+    )
+    MockConnRecordCls.retrieve_by_id = AsyncMock(return_value=mock_conn_rec)
+
+    # Mock multi-use retrieval failure
+    MockConnRecordCls.retrieve_by_invitation_key = AsyncMock(
+        side_effect=StorageNotFoundError("Multi-use not found")
+    )
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.connections_invitation(mock_request)
+    assert "Multi-use not found" in str(excinfo.value)  # Error from the second lookup
+
+    MockConnRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_CONN_ID)
+    mock_conn_rec.retrieve_invitation.assert_awaited_once_with(ANY)
+    MockConnRecordCls.retrieve_by_invitation_key.assert_awaited_once_with(
+        ANY, TEST_INVITATION_KEY
+    )
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.ConnRecord", autospec=True)
+async def test_connections_invitation_base_model_error(
+    MockConnRecordCls: MagicMock, mock_request: MagicMock, mock_profile: MagicMock
+):
+    """Test GET /connections/{conn_id}/invitation - BaseModelError during retrieval."""
+    mock_request._set_match_info("conn_id", TEST_CONN_ID)
+    MockConnRecordCls.retrieve_by_id = AsyncMock(
+        side_effect=BaseModelError("Invalid record data")
+    )
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.connections_invitation(mock_request)
+    assert "Invalid record data" in str(excinfo.value)
+
+    MockConnRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_CONN_ID)
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.ConnRecord", autospec=True)
+async def test_connections_invitation_no_base_url_set(
+    MockConnRecordCls: MagicMock, mock_request: MagicMock, mock_profile: MagicMock
+):
+    """Test GET /connections/{conn_id}/invitation - Neither invite_base_url nor default_endpoint set."""
+    mock_request._set_match_info("conn_id", TEST_CONN_ID)
+    # Remove both base URL settings
+    del mock_profile.settings["invite_base_url"]
+    del mock_profile.settings["default_endpoint"]
+
+    # Mock ConnectionRecord and its invitation
+    mock_conn_rec = AsyncMock(spec=ConnRecord, alias=None)
+    mock_invitation = MagicMock(spec=ConnectionInvitation)
+    mock_invitation.serialize.return_value = {
+        "@type": "did:sov:...",
+        "recipientKeys": ["key1"],
+    }
+    # Assume to_url returns just the query part when base_url is empty
+    mock_invitation.to_url.return_value = "?c_i=ey..."
+
+    mock_conn_rec.retrieve_invitation = AsyncMock(return_value=mock_invitation)
+    MockConnRecordCls.retrieve_by_id = AsyncMock(return_value=mock_conn_rec)
+
+    response = await test_module.connections_invitation(mock_request)
+
+    MockConnRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_CONN_ID)
+    mock_conn_rec.retrieve_invitation.assert_awaited_once_with(ANY)
+    # Expect "" as the base_url passed to to_url
+    mock_invitation.to_url.assert_called_once_with("")
+
+    assert response.status == 200
+    # The URL should be constructed with an empty base, effectively starting with "?"
+    expected_invitation_url = "?c_i=ey..."
+    expected_body = {
+        "connection_id": TEST_CONN_ID,
+        "invitation": mock_invitation.serialize.return_value,
+        "invitation_url": expected_invitation_url,
+    }
+    assert json.loads(response.body) == expected_body

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_connections_routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_connections_routes.py
@@ -4,20 +4,16 @@ from unittest.mock import MagicMock, AsyncMock, patch, ANY
 
 import pytest
 from aiohttp import web
-from acapy_agent.core.profile import Profile
 from acapy_agent.storage.error import StorageNotFoundError
 from acapy_agent.messaging.models.base import BaseModelError
 
-# Import the module containing the routes to be tested
 from traction_innkeeper.v1_0.connections import routes as test_module
 
-# Import Schemas and Models used for mocking return types or validation
 from acapy_agent.connections.models.conn_record import ConnRecord
 from acapy_agent.protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )
 
-# Disable logging noise during tests
 logging.disable(logging.CRITICAL)
 
 # --- Constants ---

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_creddef_storage_routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_creddef_storage_routes.py
@@ -1,0 +1,431 @@
+import json
+import logging
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+from aiohttp import web
+from acapy_agent.core.profile import Profile
+from acapy_agent.storage.error import StorageNotFoundError, StorageError
+
+# Import the module containing the routes to be tested
+# Adjust path as necessary
+from traction_innkeeper.v1_0.creddef_storage import routes as test_module
+
+# Import Service and Models used for mocking
+from traction_innkeeper.v1_0.creddef_storage.creddef_storage_service import (
+    CredDefStorageService,
+)
+from traction_innkeeper.v1_0.creddef_storage.models import (
+    CredDefStorageRecord,  # Although schema not directly used, good practice
+)
+
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+TEST_CRED_DEF_ID = "55GkHamhTU1ZbTbV2ab9DE:3:CL:1234:default"
+TEST_ISSUER_DID = "55GkHamhTU1ZbTbV2ab9DE"
+TEST_API_KEY = "test-creddef-api-key"
+
+# --- Reusable Fixtures (similar to test_innkeeper_routes.py) ---
+
+
+@pytest.fixture
+def mock_profile_inject():
+    """Provides a mock injector function and tracks injectable mocks."""
+    injectables = {}
+
+    def _injector(cls_to_inject, *args, **kwargs):
+        # Handle inject_or by checking if cls_to_inject is a type
+        target_cls = (
+            cls_to_inject if isinstance(cls_to_inject, type) else type(cls_to_inject)
+        )
+
+        mock_instance = injectables.get(target_cls)
+        if not mock_instance:
+            # Return the default if provided (for inject_or)
+            if args:
+                return args[0]
+            return MagicMock()  # Fallback for regular inject
+        return mock_instance
+
+    return MagicMock(side_effect=_injector), injectables
+
+
+@pytest.fixture
+def mock_session():
+    """Provides a mocked async Session."""
+    session = AsyncMock(name="Session")
+
+    async def __aenter__(*args):
+        return session
+
+    async def __aexit__(*args):
+        pass
+
+    session.__aenter__ = __aenter__
+    session.__aexit__ = __aexit__
+    return session
+
+
+@pytest.fixture
+def mock_profile(mock_session: AsyncMock, mock_profile_inject: tuple):
+    """Provides a mocked Profile."""
+    profile = MagicMock(name="Profile", spec=Profile)
+    profile.context = MagicMock(name="Context")
+    profile.settings = {
+        "admin.admin_api_key": TEST_API_KEY,
+        # Add other base settings if needed
+    }
+    profile.context.settings = profile.settings
+    profile.session = MagicMock(return_value=mock_session)
+    profile.inject, profile._injectables = mock_profile_inject
+    # Add inject_or mock based on inject
+    profile.inject_or = profile.inject
+    return profile
+
+
+@pytest.fixture
+def mock_context(mock_profile: MagicMock):
+    """Provides a mocked AdminRequestContext containing the mock profile."""
+    context = MagicMock(name="AdminRequestContext")
+    context.profile = mock_profile
+    # Link inject/inject_or for convenience if context is used directly for injection
+    context.inject = mock_profile.inject
+    context.inject_or = mock_profile.inject_or
+    return context
+
+
+@pytest.fixture
+def mock_request(mock_context: MagicMock):
+    """Provides a mocked aiohttp.web.Request linked to the context."""
+    request = MagicMock(spec=web.Request)
+    request.match_info = {}
+    request.query = {}
+    # --- Crucial for tenant_authentication ---
+    request.headers = {"x-api-key": TEST_API_KEY}
+    # -----------------------------------------
+
+    def getitem_side_effect(key):
+        if key == "context":
+            return mock_context
+        # Allow accessing headers like a dict
+        if key == "headers":
+            return request.headers
+        return MagicMock()
+
+    request.__getitem__.side_effect = getitem_side_effect
+
+    request.json = AsyncMock()
+    request._set_match_info = lambda key, value: request.match_info.update({key: value})
+
+    return request
+
+
+@pytest.fixture
+def mock_creddef_storage_service(mock_profile: MagicMock):
+    """Provides a mocked CredDefStorageService AND configures it for injection."""
+    service = AsyncMock(spec=CredDefStorageService)
+    # Add mocked methods expected by routes
+    service.list_items = AsyncMock()
+    service.read_item = AsyncMock()
+    service.remove_item = AsyncMock()
+
+    # Configure injection
+    mock_profile._injectables[CredDefStorageService] = service
+    return service
+
+
+# --- Test Cases ---
+
+
+# Test List Cred Defs (GET /credential-definition-storage)
+@pytest.mark.asyncio
+async def test_creddef_storage_list(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test GET /credential-definition-storage endpoint."""
+    profile = mock_context.profile
+
+    # Mock service response
+    mock_rec_1 = MagicMock(spec=CredDefStorageRecord)
+    mock_rec_1.serialize.return_value = {"cred_def_id": "cred-def-1"}
+    mock_rec_2 = MagicMock(spec=CredDefStorageRecord)
+    mock_rec_2.serialize.return_value = {"cred_def_id": "cred-def-2"}
+    mock_creddef_storage_service.list_items.return_value = [mock_rec_1, mock_rec_2]
+
+    response = await test_module.creddef_storage_list(mock_request)
+
+    # Check service was injected and called
+    mock_context.inject_or.assert_called_once_with(CredDefStorageService)
+    mock_creddef_storage_service.list_items.assert_awaited_once_with(
+        profile, {}, {}  # Default filters
+    )
+
+    # Check response
+    assert response.status == 200
+    assert json.loads(response.body) == {
+        "results": [
+            {"cred_def_id": "cred-def-1"},
+            {"cred_def_id": "cred-def-2"},
+        ]
+    }
+    mock_rec_1.serialize.assert_called_once()
+    mock_rec_2.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_creddef_storage_list_empty(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test GET /credential-definition-storage endpoint with no results."""
+    profile = mock_context.profile
+    mock_creddef_storage_service.list_items.return_value = []  # Empty list
+
+    response = await test_module.creddef_storage_list(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(CredDefStorageService)
+    mock_creddef_storage_service.list_items.assert_awaited_once_with(profile, {}, {})
+    assert response.status == 200
+    assert json.loads(response.body) == {"results": []}
+
+
+@pytest.mark.asyncio
+async def test_creddef_storage_list_storage_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test GET /credential-definition-storage endpoint with StorageError."""
+    mock_creddef_storage_service.list_items.side_effect = StorageError(
+        "DB connection lost"
+    )
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.creddef_storage_list(mock_request)
+    assert "DB connection lost" in str(excinfo.value)
+
+
+# Test Get Cred Def (GET /credential-definition-storage/{cred_def_id})
+@pytest.mark.asyncio
+async def test_creddef_storage_get(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test GET /credential-definition-storage/{cred_def_id} endpoint."""
+    profile = mock_context.profile
+    mock_request._set_match_info("cred_def_id", TEST_CRED_DEF_ID)
+
+    # Mock service response
+    mock_rec = MagicMock(spec=CredDefStorageRecord)
+    mock_rec.serialize.return_value = {
+        "cred_def_id": TEST_CRED_DEF_ID,
+        "issuer_did": TEST_ISSUER_DID,
+    }
+    mock_creddef_storage_service.read_item.return_value = mock_rec
+
+    response = await test_module.creddef_storage_get(mock_request)
+
+    # Check service was injected and called
+    mock_context.inject_or.assert_called_once_with(CredDefStorageService)
+    mock_creddef_storage_service.read_item.assert_awaited_once_with(
+        profile, TEST_CRED_DEF_ID
+    )
+
+    # Check response
+    assert response.status == 200
+    assert json.loads(response.body) == {
+        "cred_def_id": TEST_CRED_DEF_ID,
+        "issuer_did": TEST_ISSUER_DID,
+    }
+    mock_rec.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_creddef_storage_get_not_found(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test GET /credential-definition-storage/{cred_def_id} not found."""
+    mock_request._set_match_info("cred_def_id", TEST_CRED_DEF_ID)
+    mock_creddef_storage_service.read_item.side_effect = StorageNotFoundError(
+        "Record not found"
+    )
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.creddef_storage_get(mock_request)
+    assert "Record not found" in str(excinfo.value)
+
+    mock_creddef_storage_service.read_item.assert_awaited_once_with(
+        mock_context.profile, TEST_CRED_DEF_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_creddef_storage_get_storage_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test GET /credential-definition-storage/{cred_def_id} with StorageError."""
+    mock_request._set_match_info("cred_def_id", TEST_CRED_DEF_ID)
+    mock_creddef_storage_service.read_item.side_effect = StorageError("Bad read")
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.creddef_storage_get(mock_request)
+    assert "Bad read" in str(excinfo.value)
+
+
+# Test Remove Cred Def (DELETE /credential-definition-storage/{cred_def_id})
+@pytest.mark.asyncio
+async def test_creddef_storage_remove_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test DELETE /credential-definition-storage/{cred_def_id} success."""
+    profile = mock_context.profile
+    mock_request._set_match_info("cred_def_id", TEST_CRED_DEF_ID)
+
+    # Mock service response
+    mock_creddef_storage_service.remove_item.return_value = True
+
+    response = await test_module.creddef_storage_remove(mock_request)
+
+    # Check service was injected and called
+    mock_context.inject_or.assert_called_once_with(CredDefStorageService)
+    mock_creddef_storage_service.remove_item.assert_awaited_once_with(
+        profile, TEST_CRED_DEF_ID
+    )
+
+    # Check response
+    assert response.status == 200
+    assert json.loads(response.body) == {"success": True}
+
+
+@pytest.mark.asyncio
+async def test_creddef_storage_remove_failure_from_service(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test DELETE /credential-definition-storage/{cred_def_id} where service returns false."""
+    profile = mock_context.profile
+    mock_request._set_match_info("cred_def_id", TEST_CRED_DEF_ID)
+    mock_creddef_storage_service.remove_item.return_value = False
+
+    response = await test_module.creddef_storage_remove(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(CredDefStorageService)
+    mock_creddef_storage_service.remove_item.assert_awaited_once_with(
+        profile, TEST_CRED_DEF_ID
+    )
+    assert response.status == 200
+    assert json.loads(response.body) == {"success": False}
+
+
+@pytest.mark.asyncio
+async def test_creddef_storage_remove_not_found(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test DELETE /credential-definition-storage/{cred_def_id} not found."""
+    mock_request._set_match_info("cred_def_id", TEST_CRED_DEF_ID)
+    mock_creddef_storage_service.remove_item.side_effect = StorageNotFoundError(
+        "Cannot find to remove"
+    )
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.creddef_storage_remove(mock_request)
+    assert "Cannot find to remove" in str(excinfo.value)
+
+    mock_creddef_storage_service.remove_item.assert_awaited_once_with(
+        mock_context.profile, TEST_CRED_DEF_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_creddef_storage_remove_storage_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_creddef_storage_service: AsyncMock,
+):
+    """Test DELETE /credential-definition-storage/{cred_def_id} with StorageError."""
+    mock_request._set_match_info("cred_def_id", TEST_CRED_DEF_ID)
+    mock_creddef_storage_service.remove_item.side_effect = StorageError("Cannot delete")
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.creddef_storage_remove(mock_request)
+    assert "Cannot delete" in str(excinfo.value)
+
+
+# --- Optional: Test register and post_process_routes ---
+# These are usually simple and less critical to unit test,
+# but can be added for completeness if desired.
+
+
+async def test_register():
+    """Test route registration."""
+    mock_app = MagicMock(spec=web.Application)
+    mock_app.add_routes = MagicMock()
+
+    await test_module.register(mock_app)  # Call the sync function
+
+    calls = mock_app.add_routes.call_args_list
+    # Check that add_routes was called once with a list containing the expected routes
+    assert len(calls) == 1
+    registered_routes = calls[0][0][0]  # Get the list of web.RouteDef objects
+    assert len(registered_routes) == 3
+    # Check paths and methods (can be more specific if needed)
+    assert any(
+        r.method == "GET" and r.path == "/credential-definition-storage"
+        for r in registered_routes
+    )
+    assert any(
+        r.method == "GET" and r.path == "/credential-definition-storage/{cred_def_id}"
+        for r in registered_routes
+    )
+    assert any(
+        r.method == "DELETE"
+        and r.path == "/credential-definition-storage/{cred_def_id}"
+        for r in registered_routes
+    )
+
+
+def test_post_process_routes():
+    """Test swagger documentation tagging."""
+    mock_app = MagicMock()
+    mock_app._state = {"swagger_dict": {}}  # Simulate swagger dict state
+
+    test_module.post_process_routes(mock_app)
+
+    assert "tags" in mock_app._state["swagger_dict"]
+    assert len(mock_app._state["swagger_dict"]["tags"]) == 1
+    assert (
+        mock_app._state["swagger_dict"]["tags"][0]["name"]
+        == test_module.SWAGGER_CATEGORY
+    )
+    assert "description" in mock_app._state["swagger_dict"]["tags"][0]
+
+
+def test_post_process_routes_existing_tags():
+    """Test swagger documentation tagging when tags list already exists."""
+    mock_app = MagicMock()
+    mock_app._state = {"swagger_dict": {"tags": [{"name": "existing_tag"}]}}
+
+    test_module.post_process_routes(mock_app)
+
+    assert len(mock_app._state["swagger_dict"]["tags"]) == 2
+    assert mock_app._state["swagger_dict"]["tags"][0]["name"] == "existing_tag"
+    assert (
+        mock_app._state["swagger_dict"]["tags"][1]["name"]
+        == test_module.SWAGGER_CATEGORY
+    )

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_creddef_storage_service.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_creddef_storage_service.py
@@ -1,0 +1,442 @@
+import logging
+from unittest.mock import MagicMock, AsyncMock, patch, call, ANY
+
+import pytest
+from acapy_agent.core.profile import Profile
+from acapy_agent.storage.error import StorageNotFoundError
+from acapy_agent.core.event_bus import Event
+
+# Assuming models and service are importable like this
+from traction_innkeeper.v1_0.creddef_storage.models import CredDefStorageRecord
+from traction_innkeeper.v1_0.creddef_storage.creddef_storage_service import (
+    CredDefStorageService,
+    creddef_event_handler,  # Import the handler function as well
+)
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+TEST_CRED_DEF_ID = "55GkHamhTU1ZbTbV2ab9DE:3:CL:1234:default"
+TEST_ISSUER_DID = "55GkHamhTU1ZbTbV2ab9DE"
+TEST_SCHEMA_ID = f"{TEST_ISSUER_DID}:2:schema_name:1.0"
+TEST_TAG = "default"
+TEST_SUPPORT_REVOCATION = False
+TEST_CONTEXT = {
+    "cred_def_id": TEST_CRED_DEF_ID,
+    "issuer_did": TEST_ISSUER_DID,
+    "schema_id": TEST_SCHEMA_ID,
+    "tag": TEST_TAG,
+    "support_revocation": TEST_SUPPORT_REVOCATION,
+    "cred_def": {"some": "details"},  # Example cred def structure
+}
+
+
+# --- Fixtures ---
+@pytest.fixture
+def mock_profile():
+    """Provides a mocked Profile with a working async session manager."""
+    profile = MagicMock(spec=Profile)
+    mock_session = AsyncMock(name="MockSession")
+    profile.session = MagicMock(return_value=mock_session)
+    # Make the session usable in an 'async with' block
+    mock_session.__aenter__.return_value = mock_session
+    mock_session.__aexit__.return_value = None
+    # Add inject mock
+    profile.inject = MagicMock()
+    return profile, mock_session
+
+
+@pytest.fixture
+def creddef_storage_service():
+    """Provides a CredDefStorageService instance."""
+    # The service itself doesn't require profile injection at init
+    return CredDefStorageService()
+
+
+@pytest.fixture
+def mock_creddef_storage_record():
+    """Provides a mocked CredDefStorageRecord instance."""
+    record = AsyncMock(spec=CredDefStorageRecord)
+    record.cred_def_id = TEST_CRED_DEF_ID
+    # Add other attributes if needed for specific tests
+    return record
+
+
+# --- Test Cases for CredDefStorageService ---
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_read_item_success(
+    mock_retrieve: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test successfully reading a CredDefStorageRecord."""
+    profile, session = mock_profile
+    mock_retrieve.return_value = mock_creddef_storage_record
+
+    result = await creddef_storage_service.read_item(profile, TEST_CRED_DEF_ID)
+
+    assert result == mock_creddef_storage_record
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_CRED_DEF_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_read_item_not_found(
+    mock_retrieve: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test reading a non-existent CredDefStorageRecord."""
+    profile, session = mock_profile
+    mock_retrieve.side_effect = StorageNotFoundError("Record not found")
+
+    result = await creddef_storage_service.read_item(profile, TEST_CRED_DEF_ID)
+
+    assert result is None
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_CRED_DEF_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_read_item_other_error(
+    mock_retrieve: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test handling unexpected errors during read."""
+    profile, session = mock_profile
+    mock_retrieve.side_effect = Exception("Database connection failed")
+
+    # Should still return None and log the error (logging disabled)
+    result = await creddef_storage_service.read_item(profile, TEST_CRED_DEF_ID)
+
+    assert result is None
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_CRED_DEF_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.query",
+    new_callable=AsyncMock,
+)
+async def test_list_items_success(
+    mock_query: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test successfully listing items with filters."""
+    profile, session = mock_profile
+    mock_query.return_value = [mock_creddef_storage_record]
+    tag_filter = {"issuer_did": TEST_ISSUER_DID}
+    post_filter = {"support_revocation": False}
+
+    result = await creddef_storage_service.list_items(profile, tag_filter, post_filter)
+
+    assert result == [mock_creddef_storage_record]
+    profile.session.assert_called_once()
+    mock_query.assert_awaited_once_with(
+        session=session,
+        tag_filter=tag_filter,
+        post_filter_positive=post_filter,
+        alt=True,
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.query",
+    new_callable=AsyncMock,
+)
+async def test_list_items_no_filters(
+    mock_query: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test listing items with default empty filters."""
+    profile, session = mock_profile
+    mock_query.return_value = []
+
+    result = await creddef_storage_service.list_items(profile)  # No filters passed
+
+    assert result == []
+    profile.session.assert_called_once()
+    # Verify default empty dicts are passed
+    mock_query.assert_awaited_once_with(
+        session=session,
+        tag_filter={},
+        post_filter_positive={},
+        alt=True,
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.creddef_storage_service.CredDefStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.deserialize"
+)
+async def test_add_item_new(
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test adding a new CredDefStorageRecord."""
+    profile, session = mock_profile
+    mock_read_item.return_value = None  # Simulate record doesn't exist
+    mock_deserialize.return_value = mock_creddef_storage_record
+    mock_creddef_storage_record.save = (
+        AsyncMock()
+    )  # Mock the save method on the instance
+
+    data = TEST_CONTEXT.copy()
+    result = await creddef_storage_service.add_item(profile, data)
+
+    assert result == mock_creddef_storage_record
+    mock_read_item.assert_awaited_once_with(profile, TEST_CRED_DEF_ID)
+    mock_deserialize.assert_called_once_with(data)
+    profile.session.assert_called_once()  # Called by save
+    mock_creddef_storage_record.save.assert_awaited_once_with(
+        session, reason="New cred def storage record"
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.creddef_storage_service.CredDefStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.deserialize"
+)
+async def test_add_item_existing(
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test adding an item that already exists (should be no-op)."""
+    profile, _ = mock_profile
+    mock_read_item.return_value = mock_creddef_storage_record  # Simulate record exists
+
+    data = TEST_CONTEXT.copy()
+    result = await creddef_storage_service.add_item(profile, data)
+
+    assert result == mock_creddef_storage_record  # Returns existing record
+    mock_read_item.assert_awaited_once_with(profile, TEST_CRED_DEF_ID)
+    mock_deserialize.assert_not_called()
+    profile.session.assert_not_called()  # Save should not be called
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.creddef_storage_service.CredDefStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.deserialize"
+)
+async def test_add_item_deserialize_error(
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test error during deserialization when adding."""
+    profile, _ = mock_profile
+    mock_read_item.return_value = None
+    mock_deserialize.side_effect = TypeError("Invalid data format")
+
+    data = TEST_CONTEXT.copy()
+    with pytest.raises(TypeError, match="Invalid data format"):
+        await creddef_storage_service.add_item(profile, data)
+
+    mock_read_item.assert_awaited_once_with(profile, TEST_CRED_DEF_ID)
+    mock_deserialize.assert_called_once_with(data)
+    profile.session.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.creddef_storage_service.CredDefStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.deserialize"
+)
+async def test_add_item_save_error(
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test error during save when adding."""
+    profile, session = mock_profile
+    mock_read_item.return_value = None
+    mock_deserialize.return_value = mock_creddef_storage_record
+    mock_creddef_storage_record.save = AsyncMock(
+        side_effect=Exception("DB write failed")
+    )
+
+    data = TEST_CONTEXT.copy()
+    with pytest.raises(Exception, match="DB write failed"):
+        await creddef_storage_service.add_item(profile, data)
+
+    mock_read_item.assert_awaited_once_with(profile, TEST_CRED_DEF_ID)
+    mock_deserialize.assert_called_once_with(data)
+    profile.session.assert_called_once()
+    mock_creddef_storage_record.save.assert_awaited_once_with(session, reason=ANY)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_remove_item_success(
+    mock_retrieve: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test successfully removing an item."""
+    profile, session = mock_profile
+    # Simulate retrieve succeeding first, then failing after delete
+    mock_retrieve.side_effect = [
+        mock_creddef_storage_record,
+        StorageNotFoundError("Not found after delete"),
+    ]
+    mock_creddef_storage_record.delete_record = AsyncMock()
+
+    result = await creddef_storage_service.remove_item(profile, TEST_CRED_DEF_ID)
+
+    assert result is True
+    assert profile.session.call_count == 1  # Only one session context used
+    # Check retrieve was called twice (once to get, once to confirm deletion)
+    assert mock_retrieve.await_count == 2
+    mock_retrieve.assert_has_awaits(
+        [
+            call(session, TEST_CRED_DEF_ID),
+            call(session, TEST_CRED_DEF_ID),
+        ]
+    )
+    mock_creddef_storage_record.delete_record.assert_awaited_once_with(session)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_remove_item_already_gone(
+    mock_retrieve: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test removing an item that is already not found."""
+    profile, session = mock_profile
+    mock_retrieve.side_effect = StorageNotFoundError("Record not found")
+
+    result = await creddef_storage_service.remove_item(profile, TEST_CRED_DEF_ID)
+
+    assert result is True  # Still returns True as the end state is 'not found'
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_CRED_DEF_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_remove_item_retrieve_error(
+    mock_retrieve: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test error during initial retrieve when removing."""
+    profile, session = mock_profile
+    mock_retrieve.side_effect = Exception("DB read failed")
+
+    result = await creddef_storage_service.remove_item(profile, TEST_CRED_DEF_ID)
+
+    assert result is False
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_CRED_DEF_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.creddef_storage.models.CredDefStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_remove_item_delete_error(
+    mock_retrieve: AsyncMock,
+    creddef_storage_service: CredDefStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test error during delete_record when removing."""
+    profile, session = mock_profile
+    mock_retrieve.return_value = mock_creddef_storage_record
+    mock_creddef_storage_record.delete_record = AsyncMock(
+        side_effect=Exception("DB write failed")
+    )
+
+    result = await creddef_storage_service.remove_item(profile, TEST_CRED_DEF_ID)
+
+    assert result is False
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_CRED_DEF_ID)
+    mock_creddef_storage_record.delete_record.assert_awaited_once_with(session)
+
+
+# --- Test Cases for Event Handler ---
+
+
+@pytest.mark.asyncio
+async def test_creddef_event_handler(
+    mock_profile: tuple[MagicMock, AsyncMock],
+    creddef_storage_service: CredDefStorageService,  # Use the fixture
+    mock_creddef_storage_record: AsyncMock,
+):
+    """Test the creddef_event_handler function."""
+    profile, _ = mock_profile
+    mock_event = MagicMock(spec=Event)
+    mock_event.payload = {"context": TEST_CONTEXT}
+
+    # Mock the service's add_item method specifically for this test
+    creddef_storage_service.add_item = AsyncMock(
+        return_value=mock_creddef_storage_record
+    )
+
+    # Mock profile.inject to return our service instance
+    profile.inject.return_value = creddef_storage_service
+
+    await creddef_event_handler(profile, mock_event)
+
+    profile.inject.assert_called_once_with(CredDefStorageService)
+    creddef_storage_service.add_item.assert_awaited_once_with(profile, TEST_CONTEXT)

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_endorser_connection_service.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_endorser_connection_service.py
@@ -1,0 +1,536 @@
+import logging
+from unittest.mock import MagicMock, AsyncMock, patch, call
+
+import pytest
+from acapy_agent.core.profile import Profile
+from acapy_agent.core.event_bus import Event, EventBus
+from acapy_agent.config.injector import Injector
+from acapy_agent.connections.models.conn_record import ConnRecord
+from acapy_agent.wallet.models.wallet_record import WalletRecord
+
+
+from traction_innkeeper.v1_0.innkeeper.models import TenantRecord
+
+
+# Import the module containing the service and handler to be tested
+from traction_innkeeper.v1_0.endorser import endorser_connection_service as test_module
+from traction_innkeeper.v1_0.endorser.endorser_connection_service import (
+    EndorserConnectionService,
+    connections_event_handler,
+    CONNECTIONS_EVENT_PATTERN,
+)
+
+# Import mocked dependencies
+
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+TEST_ENDORSER_ALIAS = "TestEndorser"
+TEST_ENDORSER_DID = "did:sov:EndorserDID123"
+TEST_TENANT_WALLET_ID = "tenant-wallet-abc"
+TEST_TENANT_NAME = "Tenant Name"
+TEST_WALLET_NAME = "Wallet Name"
+TEST_CONN_ID = "conn-id-xyz-789"
+
+
+# --- Fixtures ---
+@pytest.fixture
+def mock_profile():
+    """Provides a mocked Profile with settings, session, and inject."""
+    profile = MagicMock(spec=Profile)
+    mock_session = AsyncMock(name="MockSession")
+    profile.session = MagicMock(return_value=mock_session)
+    mock_session.__aenter__.return_value = mock_session
+    mock_session.__aexit__.return_value = None
+    profile.settings = MagicMock()
+    profile.settings.get = MagicMock()  # Mock the .get method directly
+    profile.inject = MagicMock()
+    return profile, mock_session
+
+
+@pytest.fixture
+def mock_context():
+    """Provides a mocked Injector context."""
+    context = MagicMock(spec=Injector)
+    context.inject = MagicMock()
+    return context
+
+
+@pytest.fixture
+def endorser_service():
+    """Provides an EndorserConnectionService instance."""
+    # Service has no constructor dependencies
+    return EndorserConnectionService()
+
+
+@pytest.fixture
+def mock_conn_record():
+    """Provides a mocked ConnRecord instance."""
+    record = AsyncMock(spec=ConnRecord)
+    record.connection_id = TEST_CONN_ID
+    record.alias = TEST_ENDORSER_ALIAS
+    record.state = ConnRecord.State.COMPLETED
+    record.metadata_get_all = AsyncMock()
+    record.metadata_get = AsyncMock()
+    record.metadata_set = AsyncMock()
+    return record
+
+
+@pytest.fixture
+def mock_event(mock_conn_record: AsyncMock):
+    """Provides a mocked Event instance with a serialized ConnRecord payload."""
+    event = MagicMock(spec=Event)
+    # Simulate serialized payload; deserialize will be mocked
+    event.payload = {
+        "connection_id": mock_conn_record.connection_id,
+        "alias": mock_conn_record.alias,
+        "state": mock_conn_record.state.rfc160,
+    }
+    return event
+
+
+# --- Test Cases for EndorserConnectionService Methods ---
+
+
+def test_endorser_alias(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test getting the endorser alias from settings."""
+    profile, _ = mock_profile
+    profile.settings.get.return_value = TEST_ENDORSER_ALIAS
+    assert endorser_service.endorser_alias(profile) == TEST_ENDORSER_ALIAS
+    profile.settings.get.assert_called_once_with("endorser.endorser_alias")
+
+
+def test_endorser_alias_missing(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test getting endorser alias when setting is missing."""
+    profile, _ = mock_profile
+    profile.settings.get.return_value = None
+    assert endorser_service.endorser_alias(profile) is None
+    profile.settings.get.assert_called_once_with("endorser.endorser_alias")
+
+
+def test_endorser_public_did(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test getting the endorser public DID from settings."""
+    profile, _ = mock_profile
+    profile.settings.get.return_value = TEST_ENDORSER_DID
+    assert endorser_service.endorser_public_did(profile) == TEST_ENDORSER_DID
+    profile.settings.get.assert_called_once_with("endorser.endorser_public_did")
+
+
+def test_endorser_public_did_missing(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test getting endorser public DID when setting is missing."""
+    profile, _ = mock_profile
+    profile.settings.get.return_value = None
+    assert endorser_service.endorser_public_did(profile) is None
+    profile.settings.get.assert_called_once_with("endorser.endorser_public_did")
+
+
+def test_endorser_info_success(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test getting endorser info when both settings are present."""
+    profile, _ = mock_profile
+
+    # Configure profile.settings.get side effect
+    def get_setting(key):
+        if key == "endorser.endorser_alias":
+            return TEST_ENDORSER_ALIAS
+        if key == "endorser.endorser_public_did":
+            return TEST_ENDORSER_DID
+        return None
+
+    profile.settings.get.side_effect = get_setting
+
+    expected_info = {
+        "endorser_did": TEST_ENDORSER_DID,
+        "endorser_name": TEST_ENDORSER_ALIAS,
+    }
+    assert endorser_service.endorser_info(profile) == expected_info
+    assert profile.settings.get.call_count == 2
+    profile.settings.get.assert_has_calls(
+        [
+            call("endorser.endorser_alias"),
+            call("endorser.endorser_public_did"),
+        ],
+        any_order=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "alias, did",
+    [
+        (None, TEST_ENDORSER_DID),
+        (TEST_ENDORSER_ALIAS, None),
+        (None, None),
+    ],
+)
+def test_endorser_info_missing_data(
+    alias,
+    did,
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test getting endorser info when one or both settings are missing."""
+    profile, _ = mock_profile
+
+    def get_setting(key):
+        if key == "endorser.endorser_alias":
+            return alias
+        if key == "endorser.endorser_public_did":
+            return did
+        return None
+
+    profile.settings.get.side_effect = get_setting
+
+    assert endorser_service.endorser_info(profile) is None
+    # Check that both were attempted
+    assert profile.settings.get.call_count >= 1
+
+
+@pytest.mark.asyncio
+@patch.object(test_module.ConnRecord, "retrieve_by_alias", new_callable=AsyncMock)
+async def test_endorser_connection_found(
+    mock_retrieve_by_alias: AsyncMock,
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_conn_record: AsyncMock,
+):
+    """Test finding an existing endorser connection."""
+    profile, session = mock_profile
+    # Mock endorser_info to return valid data
+    endorser_service.endorser_info = MagicMock(
+        return_value={
+            "endorser_did": TEST_ENDORSER_DID,
+            "endorser_name": TEST_ENDORSER_ALIAS,
+        }
+    )
+    mock_retrieve_by_alias.return_value = [mock_conn_record]  # Found one record
+
+    result = await endorser_service.endorser_connection(profile)
+
+    assert result == mock_conn_record
+    endorser_service.endorser_info.assert_called_once_with(profile)
+    profile.session.assert_called_once()
+    mock_retrieve_by_alias.assert_awaited_once_with(session, alias=TEST_ENDORSER_ALIAS)
+
+
+@pytest.mark.asyncio
+@patch.object(test_module.ConnRecord, "retrieve_by_alias", new_callable=AsyncMock)
+async def test_endorser_connection_not_found(
+    mock_retrieve_by_alias: AsyncMock,
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test when endorser connection doesn't exist."""
+    profile, session = mock_profile
+    endorser_service.endorser_info = MagicMock(
+        return_value={
+            "endorser_did": TEST_ENDORSER_DID,
+            "endorser_name": TEST_ENDORSER_ALIAS,
+        }
+    )
+    mock_retrieve_by_alias.return_value = []  # Found no records
+
+    result = await endorser_service.endorser_connection(profile)
+
+    assert result is None
+    endorser_service.endorser_info.assert_called_once_with(profile)
+    profile.session.assert_called_once()
+    mock_retrieve_by_alias.assert_awaited_once_with(session, alias=TEST_ENDORSER_ALIAS)
+
+
+@pytest.mark.asyncio
+async def test_endorser_connection_no_info(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test endorser_connection when endorser_info returns None."""
+    profile, _ = mock_profile
+    endorser_service.endorser_info = MagicMock(return_value=None)
+
+    result = await endorser_service.endorser_connection(profile)
+
+    assert result is None
+    endorser_service.endorser_info.assert_called_once_with(profile)
+    profile.session.assert_not_called()  # Should not try to get session
+
+
+@pytest.mark.asyncio
+async def test_connect_with_endorser_no_info(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_context: MagicMock,
+):
+    """Test connect_with_endorser when endorser_info returns None."""
+    profile, _ = mock_profile
+    endorser_service.endorser_info = MagicMock(return_value=None)
+
+    result = await endorser_service.connect_with_endorser(profile, mock_context)
+
+    assert result is None
+    endorser_service.endorser_info.assert_called_once_with(profile)
+    # Ensure no further calls were made
+    mock_context.inject.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_connect_with_endorser_already_connected(
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_context: MagicMock,
+    mock_conn_record: AsyncMock,
+):
+    """Test connect_with_endorser when connection already exists."""
+    profile, _ = mock_profile
+    endorser_service.endorser_info = MagicMock(
+        return_value={
+            "endorser_did": TEST_ENDORSER_DID,
+            "endorser_name": TEST_ENDORSER_ALIAS,
+        }
+    )
+    # Mock endorser_connection to return an existing connection
+    endorser_service.endorser_connection = AsyncMock(return_value=mock_conn_record)
+
+    result = await endorser_service.connect_with_endorser(profile, mock_context)
+
+    assert result == mock_conn_record
+    endorser_service.endorser_info.assert_called_once_with(profile)
+    endorser_service.endorser_connection.assert_awaited_once_with(profile)
+    # Ensure creation logic was not called
+    mock_context.inject.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.endorser.endorser_connection_service.TenantManager",
+    autospec=True,
+)
+@patch(
+    "traction_innkeeper.v1_0.endorser.endorser_connection_service.DIDXManager",
+    autospec=True,
+)
+async def test_connect_with_endorser_create_connection(
+    MockDIDXManager: MagicMock,
+    MockTenantManager: MagicMock,
+    endorser_service: EndorserConnectionService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_context: MagicMock,
+):
+    """Test connect_with_endorser initiating a new connection."""
+    profile, _ = mock_profile
+    endorser_info_dict = {
+        "endorser_did": TEST_ENDORSER_DID,
+        "endorser_name": TEST_ENDORSER_ALIAS,
+    }
+    endorser_service.endorser_info = MagicMock(return_value=endorser_info_dict)
+    # Mock endorser_connection to return None (not connected)
+    endorser_service.endorser_connection = AsyncMock(return_value=None)
+
+    # Mock profile settings for wallet ID
+    profile.settings.get.return_value = TEST_TENANT_WALLET_ID
+
+    # Mock TenantManager
+    mock_tenant_mgr_instance = MockTenantManager.return_value
+    mock_wallet_rec = MagicMock(spec=WalletRecord, wallet_name=TEST_WALLET_NAME)
+    mock_tenant_rec = MagicMock(spec=TenantRecord, tenant_name=TEST_TENANT_NAME)
+    mock_tenant_mgr_instance.get_wallet_and_tenant = AsyncMock(
+        return_value=(mock_wallet_rec, mock_tenant_rec)
+    )
+    mock_context.inject.return_value = mock_tenant_mgr_instance  # Configure injector
+
+    # Mock DIDXManager
+    mock_didx_mgr_instance = MockDIDXManager.return_value
+    mock_didx_result = {"connection_id": "new-conn-id"}
+    mock_didx_mgr_instance.create_request_implicit = AsyncMock(
+        return_value=mock_didx_result
+    )
+
+    result = await endorser_service.connect_with_endorser(profile, mock_context)
+
+    assert result == mock_didx_result
+    endorser_service.endorser_info.assert_called_once_with(profile)
+    endorser_service.endorser_connection.assert_awaited_once_with(profile)
+    profile.settings.get.assert_called_once_with("wallet.id")
+    mock_context.inject.assert_called_once_with(MockTenantManager)
+    mock_tenant_mgr_instance.get_wallet_and_tenant.assert_awaited_once_with(
+        TEST_TENANT_WALLET_ID
+    )
+    MockDIDXManager.assert_called_once_with(profile)
+    mock_didx_mgr_instance.create_request_implicit.assert_awaited_once_with(
+        their_public_did=TEST_ENDORSER_DID,
+        alias=TEST_ENDORSER_ALIAS,
+        my_label=TEST_TENANT_NAME,  # Tenant name should be preferred
+    )
+
+
+# --- Test Cases for Global Functions ---
+
+
+def test_subscribe(endorser_service: EndorserConnectionService):
+    """Test the subscribe function."""
+    mock_bus = MagicMock(spec=EventBus)
+    test_module.subscribe(mock_bus)
+    mock_bus.subscribe.assert_called_once_with(
+        CONNECTIONS_EVENT_PATTERN, connections_event_handler
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(test_module.ConnRecord, "deserialize")
+@patch.object(test_module.ConnRecord, "retrieve_by_id", new_callable=AsyncMock)
+@patch(
+    "traction_innkeeper.v1_0.endorser.endorser_connection_service.TransactionManager",
+    autospec=True,
+)
+async def test_connections_event_handler_metadata_needs_setting(
+    MockTransactionManager: MagicMock,
+    mock_retrieve_by_id: AsyncMock,
+    mock_deserialize: MagicMock,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_event: MagicMock,
+    mock_conn_record: AsyncMock,  # The record deserialized from event
+):
+    """Test event handler when connection is completed and needs metadata."""
+    profile, session = mock_profile
+
+    # Configure settings for alias and DID
+    def get_setting(key):
+        if key == "endorser.endorser_alias":
+            return TEST_ENDORSER_ALIAS
+        if key == "endorser.endorser_public_did":
+            return TEST_ENDORSER_DID
+        return None
+
+    profile.settings.get.side_effect = get_setting
+
+    # Configure deserialized record
+    mock_deserialize.return_value = mock_conn_record
+    mock_conn_record.alias = TEST_ENDORSER_ALIAS  # Ensure alias matches
+    mock_conn_record.state = ConnRecord.State.COMPLETED  # Ensure state is completed
+
+    # Simulate metadata missing transaction_my_job
+    mock_conn_record.metadata_get_all.return_value = {"some": "other_data"}
+
+    # Mock TransactionManager
+    mock_tx_mgr_instance = MockTransactionManager.return_value
+    mock_tx_mgr_instance.set_transaction_my_job = AsyncMock(return_value="tx_job_info")
+
+    # Mock ConnRecord.retrieve_by_id to return a record for metadata setting
+    # Important: This should be a *different* mock instance if we want to check
+    # methods called on *it* vs the one from deserialize.
+    mock_retrieved_conn_rec = AsyncMock(spec=ConnRecord)
+    mock_retrieve_by_id.return_value = mock_retrieved_conn_rec
+
+    await connections_event_handler(profile, mock_event)
+
+    # Assertions
+    profile.settings.get.assert_any_call("endorser.endorser_alias")
+    mock_deserialize.assert_called_once_with(mock_event.payload)
+    profile.session.assert_has_calls(
+        [call(), call()]
+    )  # Called twice: once for get_all, once for set
+    mock_conn_record.metadata_get_all.assert_awaited_once_with(session)
+
+    # Check transaction manager calls
+    MockTransactionManager.assert_called_once_with(profile)
+    mock_tx_mgr_instance.set_transaction_my_job.assert_awaited_once_with(
+        record=mock_conn_record, transaction_my_job="TRANSACTION_AUTHOR"
+    )
+
+    # Check metadata setting calls on the *retrieved* record
+    mock_retrieve_by_id.assert_awaited_once_with(
+        session, mock_conn_record.connection_id
+    )
+    mock_retrieved_conn_rec.metadata_get.assert_awaited_with(session, "endorser_info")
+    mock_retrieved_conn_rec.metadata_set.assert_awaited_once_with(
+        session,
+        key="endorser_info",
+        value={"endorser_did": TEST_ENDORSER_DID, "endorser_name": TEST_ENDORSER_ALIAS},
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(test_module.ConnRecord, "deserialize")
+async def test_connections_event_handler_alias_mismatch(
+    mock_deserialize: MagicMock,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_event: MagicMock,
+    mock_conn_record: AsyncMock,
+):
+    """Test event handler when the connection alias doesn't match."""
+    profile, _ = mock_profile
+    profile.settings.get.return_value = "DifferentAlias"  # Endorser alias setting
+    mock_deserialize.return_value = mock_conn_record
+    mock_conn_record.alias = TEST_ENDORSER_ALIAS  # Record has different alias
+
+    await connections_event_handler(profile, mock_event)
+
+    profile.settings.get.assert_called_once_with("endorser.endorser_alias")
+    mock_deserialize.assert_called_once_with(mock_event.payload)
+    profile.session.assert_not_called()  # Should exit early
+
+
+@pytest.mark.asyncio
+@patch.object(test_module.ConnRecord, "deserialize")
+async def test_connections_event_handler_state_not_completed(
+    mock_deserialize: MagicMock,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_event: MagicMock,
+    mock_conn_record: AsyncMock,
+):
+    """Test event handler when connection state is not completed."""
+    profile, _ = mock_profile
+    profile.settings.get.return_value = TEST_ENDORSER_ALIAS  # Alias matches
+    mock_deserialize.return_value = mock_conn_record
+    mock_conn_record.alias = TEST_ENDORSER_ALIAS
+    mock_conn_record.state = ConnRecord.State.REQUEST  # State is not completed
+
+    await connections_event_handler(profile, mock_event)
+
+    profile.settings.get.assert_called_once_with("endorser.endorser_alias")
+    mock_deserialize.assert_called_once_with(mock_event.payload)
+    profile.session.assert_not_called()  # Should exit before checking metadata
+
+
+@pytest.mark.asyncio
+@patch.object(test_module.ConnRecord, "deserialize")
+async def test_connections_event_handler_metadata_exists(
+    mock_deserialize: MagicMock,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_event: MagicMock,
+    mock_conn_record: AsyncMock,
+):
+    """Test event handler when metadata indicating author role already exists."""
+    profile, session = mock_profile
+    profile.settings.get.return_value = TEST_ENDORSER_ALIAS  # Alias matches
+    mock_deserialize.return_value = mock_conn_record
+    mock_conn_record.alias = TEST_ENDORSER_ALIAS
+    mock_conn_record.state = ConnRecord.State.COMPLETED  # State is completed
+
+    # Simulate metadata *already* having the job set
+    mock_conn_record.metadata_get_all.return_value = {
+        "transaction-jobs": {"transaction_my_job": "TRANSACTION_AUTHOR"}
+    }
+
+    await connections_event_handler(profile, mock_event)
+
+    profile.settings.get.assert_called_once_with("endorser.endorser_alias")
+    mock_deserialize.assert_called_once_with(mock_event.payload)
+    profile.session.assert_called_once()  # Only called once for metadata_get_all
+    mock_conn_record.metadata_get_all.assert_awaited_once_with(session)
+    # Ensure setting logic was not called
+    mock_conn_record.metadata_set.assert_not_called()

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_endorser_routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_endorser_routes.py
@@ -1,0 +1,438 @@
+import json
+import logging
+from unittest.mock import MagicMock, AsyncMock, patch, ANY
+
+import pytest
+from aiohttp import web
+from acapy_agent.core.profile import Profile
+from acapy_agent.storage.error import StorageError
+from acapy_agent.protocols.didexchange.v1_0.manager import DIDXManagerError
+
+# Import the module containing the routes to be tested
+# Adjust path as necessary
+from traction_innkeeper.v1_0.endorser import routes as test_module
+
+# Import Service and Models used for mocking
+from traction_innkeeper.v1_0.endorser.endorser_connection_service import (
+    EndorserConnectionService,
+)
+
+# Import models needed for the handlers' logic
+from traction_innkeeper.v1_0.innkeeper.models import TenantRecord
+from acapy_agent.connections.models.conn_record import ConnRecord
+
+# Needed for injection in endorser_connection_set
+from traction_innkeeper.v1_0.innkeeper.tenant_manager import TenantManager
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+TEST_TENANT_WALLET_ID = "tenant-wallet-id-xyz"
+TEST_CONN_ID = "conn-id-1234"
+TEST_ENDORSER_ALIAS = "TestEndorser"
+TEST_ENDORSER_DID = "did:sov:EndorserDID567"
+TEST_API_KEY = "test-endorser-api-key"
+
+# --- Reusable Fixtures (similar to test_innkeeper_routes.py) ---
+
+
+@pytest.fixture
+def mock_profile_inject():
+    """Provides a mock injector function and tracks injectable mocks."""
+    injectables = {}
+
+    def _injector(cls_to_inject, *args, **kwargs):
+        # Handle inject_or by checking if cls_to_inject is a type
+        target_cls = (
+            cls_to_inject if isinstance(cls_to_inject, type) else type(cls_to_inject)
+        )
+        mock_instance = injectables.get(target_cls)
+        if not mock_instance:
+            if args:
+                return args[0]  # inject_or default
+            # Create a default mock if not found for inject
+            return (
+                MagicMock(spec=target_cls)
+                if isinstance(cls_to_inject, type)
+                else MagicMock()
+            )
+        return mock_instance
+
+    return MagicMock(side_effect=_injector), injectables
+
+
+@pytest.fixture
+def mock_session():
+    """Provides a mocked async Session."""
+    session = AsyncMock(name="Session")
+
+    async def __aenter__(*args):
+        return session
+
+    async def __aexit__(*args):
+        pass
+
+    session.__aenter__ = __aenter__
+    session.__aexit__ = __aexit__
+    return session
+
+
+@pytest.fixture
+def mock_root_profile(mock_session: AsyncMock, mock_profile_inject: tuple):
+    """Provides a mocked Root Profile (needed for TenantManager)."""
+    # Simpler version, might need more details depending on TenantManager usage
+    profile = MagicMock(name="RootProfile", spec=Profile)
+    profile.context = MagicMock(name="RootContext")
+    profile.settings = {"admin.admin_api_key": "dummy-root-key"}
+    profile.context.settings = profile.settings
+    profile.session = MagicMock(return_value=mock_session)
+    profile.inject, profile._injectables = mock_profile_inject
+    profile.inject_or = profile.inject
+    return profile
+
+
+@pytest.fixture
+def mock_profile(mock_session: AsyncMock, mock_profile_inject: tuple):
+    """Provides a mocked Tenant Profile."""
+    profile = MagicMock(name="TenantProfile", spec=Profile)
+    profile.context = MagicMock(name="TenantContext")
+    profile.settings = {
+        "wallet.id": TEST_TENANT_WALLET_ID,
+        "admin.admin_api_key": TEST_API_KEY,
+        # Assuming endorser config might be here or root profile
+        "endorser.endorser_alias": TEST_ENDORSER_ALIAS,
+        "endorser.endorser_public_did": TEST_ENDORSER_DID,
+    }
+    profile.context.settings = profile.settings
+    profile.session = MagicMock(return_value=mock_session)
+    profile.inject, profile._injectables = mock_profile_inject
+    profile.inject_or = profile.inject
+    return profile
+
+
+@pytest.fixture
+def mock_context(mock_profile: MagicMock):
+    """Provides a mocked AdminRequestContext containing the tenant profile."""
+    context = MagicMock(name="AdminRequestContext")
+    context.profile = mock_profile
+    context.inject = mock_profile.inject
+    context.inject_or = mock_profile.inject_or
+    context.injector = context  # Make context act as injector for service call
+    return context
+
+
+@pytest.fixture
+def mock_request(mock_context: MagicMock):
+    """Provides a mocked aiohttp.web.Request linked to the context."""
+    request = MagicMock(spec=web.Request)
+    request.match_info = {}
+    request.query = {}
+    request.headers = {"x-api-key": TEST_API_KEY}  # Satisfy tenant_authentication
+
+    def getitem_side_effect(key):
+        if key == "context":
+            return mock_context
+        if key == "headers":
+            return request.headers
+        return MagicMock()
+
+    request.__getitem__.side_effect = getitem_side_effect
+    request.json = AsyncMock()
+    request._set_match_info = lambda key, value: request.match_info.update({key: value})
+    return request
+
+
+@pytest.fixture
+def mock_endorser_service(mock_profile: MagicMock):
+    """Provides a mocked EndorserConnectionService AND configures it for injection."""
+    service = MagicMock(spec=EndorserConnectionService)
+    service.endorser_connection = AsyncMock()
+    service.connect_with_endorser = AsyncMock()
+    service.endorser_info = MagicMock()
+    mock_profile._injectables[EndorserConnectionService] = service
+    return service
+
+
+@pytest.fixture
+def mock_tenant_mgr(mock_profile: MagicMock, mock_root_profile: MagicMock):
+    """Provides a mocked TenantManager AND configures it for injection."""
+    mgr = AsyncMock(spec=TenantManager)
+    mgr.profile = mock_root_profile  # TenantManager uses root profile
+    mock_profile._injectables[TenantManager] = mgr
+    return mgr
+
+
+# --- Test Cases ---
+
+
+# Test Endorser Connection Set (POST /tenant/endorser-connection)
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.TenantRecord", autospec=True)
+async def test_endorser_connection_set_success(
+    MockTenantRecordCls: MagicMock,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+    mock_tenant_mgr: AsyncMock,  # Needed for injection
+    mock_root_profile: MagicMock,  # Used by TenantManager
+):
+    """Test POST /tenant/endorser-connection success."""
+    profile = mock_context.profile  # This is the tenant profile
+
+    # Mock TenantRecord retrieval to show tenant is configured as issuer
+    mock_tenant_rec = AsyncMock(spec=TenantRecord)
+    mock_tenant_rec.connected_to_endorsers = ["some_endorser_config"]
+    mock_tenant_rec.created_public_did = ["some_did"]
+    MockTenantRecordCls.query_by_wallet_id = AsyncMock(return_value=mock_tenant_rec)
+
+    # Mock endorser service methods
+    mock_endorser_service.endorser_info.return_value = {
+        "endorser_did": TEST_ENDORSER_DID,
+        "endorser_name": TEST_ENDORSER_ALIAS,
+    }
+    mock_conn_rec = MagicMock(spec=ConnRecord)
+    mock_conn_rec.serialize.return_value = {
+        "connection_id": TEST_CONN_ID,
+        "state": "request_sent",
+    }
+    mock_endorser_service.connect_with_endorser.return_value = mock_conn_rec
+
+    response = await test_module.endorser_connection_set(mock_request)
+
+    # Check injections
+    mock_context.inject.assert_any_call(TenantManager)
+    mock_context.inject.assert_any_call(EndorserConnectionService)
+    # Check TenantRecord query
+    mock_root_profile.session.assert_called_once()  # Called within handler
+    MockTenantRecordCls.query_by_wallet_id.assert_awaited_once_with(
+        ANY, TEST_TENANT_WALLET_ID
+    )
+    # Check service calls
+    mock_endorser_service.endorser_info.assert_called_once_with(profile)
+    mock_endorser_service.connect_with_endorser.assert_awaited_once_with(
+        profile, mock_context.injector
+    )
+    # Check response
+    assert response.status == 200
+    assert json.loads(response.body) == {
+        "connection_id": TEST_CONN_ID,
+        "state": "request_sent",
+    }
+    mock_conn_rec.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.TenantRecord", autospec=True)
+@pytest.mark.parametrize(
+    "endorsers, did",
+    [
+        ([], ["some_did"]),  # No endorser config
+        (["some_config"], []),  # No public DID
+        ([], []),  # Neither
+    ],
+)
+async def test_endorser_connection_set_tenant_not_issuer(
+    MockTenantRecordCls: MagicMock,
+    endorsers,
+    did,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_tenant_mgr: AsyncMock,
+    mock_root_profile: MagicMock,
+):
+    """Test POST /tenant/endorser-connection when tenant not configured as issuer."""
+    mock_tenant_rec = AsyncMock(spec=TenantRecord)
+    mock_tenant_rec.connected_to_endorsers = endorsers
+    mock_tenant_rec.created_public_did = did
+    MockTenantRecordCls.query_by_wallet_id = AsyncMock(return_value=mock_tenant_rec)
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.endorser_connection_set(mock_request)
+
+    assert "Tenant is not configured as an issuer" in str(excinfo.value)
+    mock_context.inject.assert_called_once_with(TenantManager)
+    MockTenantRecordCls.query_by_wallet_id.assert_awaited_once_with(
+        ANY, TEST_TENANT_WALLET_ID
+    )
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.TenantRecord", autospec=True)
+async def test_endorser_connection_set_no_endorser_info(
+    MockTenantRecordCls: MagicMock,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+    mock_tenant_mgr: AsyncMock,
+    mock_root_profile: MagicMock,
+):
+    """Test POST /tenant/endorser-connection when endorser service has no info."""
+    mock_tenant_rec = AsyncMock(spec=TenantRecord)
+    mock_tenant_rec.connected_to_endorsers = ["some_config"]
+    mock_tenant_rec.created_public_did = ["some_did"]
+    MockTenantRecordCls.query_by_wallet_id = AsyncMock(return_value=mock_tenant_rec)
+    mock_endorser_service.endorser_info.return_value = None  # No info configured
+    mock_request["context"] = MagicMock()
+    mock_request["context"].inject.return_value = mock_endorser_service
+
+    endsrv = mock_request["context"].inject(EndorserConnectionService)
+    assert endsrv.endorser_info(2) is None
+    with pytest.raises(web.HTTPConflict) as excinfo:
+        await test_module.endorser_connection_set(mock_request)
+
+    assert "Endorser is not configured" in str(excinfo.value)
+    mock_endorser_service.endorser_info.assert_called_with(mock_context.profile)
+    mock_endorser_service.connect_with_endorser.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(f"{test_module.__name__}.TenantRecord", autospec=True)
+async def test_endorser_connection_set_connect_error(
+    MockTenantRecordCls: MagicMock,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+    mock_tenant_mgr: AsyncMock,
+    mock_root_profile: MagicMock,
+):
+    """Test POST /tenant/endorser-connection with error during connection."""
+    mock_tenant_rec = AsyncMock(spec=TenantRecord)
+    mock_tenant_rec.connected_to_endorsers = ["some_config"]
+    mock_tenant_rec.created_public_did = ["some_did"]
+    MockTenantRecordCls.query_by_wallet_id = AsyncMock(return_value=mock_tenant_rec)
+    mock_endorser_service.endorser_info.return_value = {"did": "...", "name": "..."}
+    mock_endorser_service.connect_with_endorser.side_effect = DIDXManagerError(
+        "Failed to connect"
+    )
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:  # Check error_handler mapping
+        await test_module.endorser_connection_set(mock_request)
+
+    assert "Failed to connect" in str(excinfo.value)
+    mock_endorser_service.connect_with_endorser.assert_awaited_once()
+
+
+# Test Endorser Connection Get (GET /tenant/endorser-connection)
+@pytest.mark.asyncio
+async def test_endorser_connection_get_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+):
+    """Test GET /tenant/endorser-connection success."""
+    profile = mock_context.profile
+    mock_conn_rec = MagicMock(spec=ConnRecord)
+    mock_conn_rec.serialize.return_value = {
+        "connection_id": TEST_CONN_ID,
+        "state": "completed",
+    }
+    mock_endorser_service.endorser_connection.return_value = mock_conn_rec
+
+    response = await test_module.endorser_connection_get(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(EndorserConnectionService)
+    mock_endorser_service.endorser_connection.assert_awaited_once_with(profile)
+    assert response.status == 200
+    assert json.loads(response.body) == {
+        "connection_id": TEST_CONN_ID,
+        "state": "completed",
+    }
+    mock_conn_rec.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_endorser_connection_get_not_found(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+):
+    """Test GET /tenant/endorser-connection not found."""
+    profile = mock_context.profile
+    mock_endorser_service.endorser_connection.return_value = (
+        None  # Service returns None
+    )
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.endorser_connection_get(mock_request)
+
+    assert "Connection with endorser not found" in str(excinfo.value)
+    mock_endorser_service.endorser_connection.assert_awaited_once_with(profile)
+
+
+@pytest.mark.asyncio
+async def test_endorser_connection_get_storage_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+):
+    """Test GET /tenant/endorser-connection with storage error."""
+    profile = mock_context.profile
+    mock_endorser_service.endorser_connection.side_effect = StorageError(
+        "DB read failed"
+    )
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.endorser_connection_get(mock_request)
+
+    assert "DB read failed" in str(excinfo.value)
+    mock_endorser_service.endorser_connection.assert_awaited_once_with(profile)
+
+
+# Test Endorser Info Get (GET /tenant/endorser-info)
+@pytest.mark.asyncio
+async def test_endorser_info_get_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+):
+    """Test GET /tenant/endorser-info success."""
+    profile = mock_context.profile
+    endorser_info_dict = {
+        "endorser_did": TEST_ENDORSER_DID,
+        "endorser_name": TEST_ENDORSER_ALIAS,
+    }
+    mock_endorser_service.endorser_info.return_value = endorser_info_dict
+
+    response = await test_module.endorser_info_get(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(EndorserConnectionService)
+    mock_endorser_service.endorser_info.assert_called_once_with(profile)
+    assert response.status == 200
+    assert json.loads(response.body) == endorser_info_dict
+
+
+@pytest.mark.asyncio
+async def test_endorser_info_get_not_found(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_endorser_service: AsyncMock,
+):
+    """Test GET /tenant/endorser-info when info not configured."""
+    profile = mock_context.profile
+    mock_endorser_service.endorser_info.return_value = None
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.endorser_info_get(mock_request)
+
+    assert "Configured Endorser Information not found" in str(excinfo.value)
+    mock_endorser_service.endorser_info.assert_called_once_with(profile)
+
+
+# Test register function
+@pytest.mark.asyncio  # Needs to be async because register itself is async
+async def test_register():
+    """Test route registration."""
+    mock_app = MagicMock(spec=web.Application)
+    mock_app.add_routes = MagicMock()
+
+    await test_module.register(mock_app)  # Await the async function
+
+    calls = mock_app.add_routes.call_args_list
+    assert len(calls) == 1
+    registered_routes = calls[0][0][0]
+    assert len(registered_routes) == 3
+    paths_methods = {(r.path, r.method) for r in registered_routes}
+    assert ("/tenant/endorser-connection", "POST") in paths_methods
+    assert ("/tenant/endorser-connection", "GET") in paths_methods
+    assert ("/tenant/endorser-info", "GET") in paths_methods

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_holder_revocation_service.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_holder_revocation_service.py
@@ -1,0 +1,358 @@
+import logging
+from unittest.mock import MagicMock, AsyncMock, patch, ANY
+
+import pytest
+from acapy_agent.core.profile import Profile
+from acapy_agent.core.event_bus import Event, EventBus
+from acapy_agent.storage.error import StorageError, StorageNotFoundError
+from acapy_agent.messaging.models.base import BaseModelError
+
+# Assuming models and service are importable like this
+from acapy_agent.protocols.issue_credential.v1_0 import V10CredentialExchange
+
+# Import the module containing the service and handler to be tested
+from traction_innkeeper.v1_0.tenant.holder_revocation_service import (
+    HolderRevocationService,
+    subscribe,
+    revocation_notification_handler,
+    REVOCATION_NOTIFICATION_EVENT_PATTERN,
+)
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+TEST_REV_REG_ID = "RvgFV1_CL_1_tag:4:RvgFV1_CL_1_tag:3:CL:1:tag:CL_ACCUM:default"
+TEST_REVOCATION_ID = "12345"
+TEST_THREAD_ID = f"indy::{TEST_REV_REG_ID}::{TEST_REVOCATION_ID}"
+TEST_CRED_EX_ID = "cred-ex-id-abc-987"
+TEST_COMMENT = "Credential revoked by issuer"
+
+
+# --- Fixtures ---
+@pytest.fixture
+def mock_profile():
+    """Provides a mocked Profile with session, transaction, and inject."""
+    profile = MagicMock(spec=Profile)
+    # Mock session context manager
+    mock_session = AsyncMock(name="MockSession")
+    profile.session = MagicMock(return_value=mock_session)
+    mock_session.__aenter__.return_value = mock_session
+    mock_session.__aexit__.return_value = None
+    # Mock transaction context manager
+    mock_txn = AsyncMock(name="MockTransaction")
+    profile.transaction = MagicMock(return_value=mock_txn)
+    mock_txn.__aenter__.return_value = mock_txn
+    mock_txn.__aexit__.return_value = None
+    mock_txn.commit = AsyncMock()
+    mock_txn.rollback = AsyncMock()
+    # Mock injection directly on profile (for event handler)
+    profile.inject = MagicMock()
+    return profile, mock_session, mock_txn
+
+
+@pytest.fixture
+def holder_revocation_service():
+    """Provides a HolderRevocationService instance."""
+    return HolderRevocationService()
+
+
+@pytest.fixture
+def mock_v10_cred_ex_record():
+    """Provides a mocked V10CredentialExchange instance."""
+    record = AsyncMock(spec=V10CredentialExchange)
+    record.credential_exchange_id = TEST_CRED_EX_ID
+    record.state = V10CredentialExchange.STATE_ISSUED  # Initial state
+    record.error_msg = None
+    record.revoc_reg_id = TEST_REV_REG_ID
+    record.revocation_id = TEST_REVOCATION_ID
+    record.save = AsyncMock()
+    return record
+
+
+@pytest.fixture
+def mock_event():
+    """Provides a mocked Event for revocation notification."""
+    event = MagicMock(spec=Event)
+    event.payload = {"thread_id": TEST_THREAD_ID, "comment": TEST_COMMENT}
+    return event
+
+
+@pytest.fixture
+def mock_event_bus():
+    """Provides a mocked EventBus."""
+    bus = MagicMock(spec=EventBus)
+    bus.subscribe = MagicMock()
+    return bus
+
+
+# --- Test Cases for HolderRevocationService Methods ---
+
+
+# Test parse_thread_id
+def test_parse_thread_id(holder_revocation_service: HolderRevocationService):
+    """Test parsing a valid thread_id."""
+    revoc_reg_id, revocation_id = holder_revocation_service.parse_thread_id(
+        TEST_THREAD_ID
+    )
+    assert revoc_reg_id == TEST_REV_REG_ID
+    assert revocation_id == TEST_REVOCATION_ID
+
+
+def test_parse_thread_id_invalid_format(
+    holder_revocation_service: HolderRevocationService,
+):
+    """Test parsing an invalid thread_id format."""
+    with pytest.raises(IndexError):
+        holder_revocation_service.parse_thread_id("invalid-thread-id")
+
+
+# Test find_credential_exchange_v10
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.tenant.holder_revocation_service.V10CredentialExchange.query",
+    new_callable=AsyncMock,
+)
+async def test_find_credential_exchange_v10_success(
+    mock_query: AsyncMock,
+    holder_revocation_service: HolderRevocationService,
+    mock_profile: tuple,
+    mock_v10_cred_ex_record: AsyncMock,
+):
+    """Test finding a V10 credential exchange successfully."""
+    profile, session, _ = mock_profile
+    mock_query.return_value = [mock_v10_cred_ex_record]
+
+    result = await holder_revocation_service.find_credential_exchange_v10(
+        profile, TEST_REV_REG_ID, TEST_REVOCATION_ID
+    )
+
+    assert result == mock_v10_cred_ex_record
+    profile.session.assert_called_once()
+    expected_post_filter = {
+        "revoc_reg_id": TEST_REV_REG_ID,
+        "revocation_id": TEST_REVOCATION_ID,
+    }
+    mock_query.assert_awaited_once_with(
+        session=session, tag_filter={}, post_filter_positive=expected_post_filter
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.tenant.holder_revocation_service.V10CredentialExchange.query",
+    new_callable=AsyncMock,
+)
+async def test_find_credential_exchange_v10_not_found(
+    mock_query: AsyncMock,
+    holder_revocation_service: HolderRevocationService,
+    mock_profile: tuple,
+):
+    """Test finding V10 credential exchange when none exists."""
+    profile, session, _ = mock_profile
+    mock_query.return_value = []  # No records found
+
+    # Expect IndexError because code accesses records[0]
+    with pytest.raises(IndexError):
+        await holder_revocation_service.find_credential_exchange_v10(
+            profile, TEST_REV_REG_ID, TEST_REVOCATION_ID
+        )
+
+    profile.session.assert_called_once()
+    mock_query.assert_awaited_once_with(
+        session=session, tag_filter=ANY, post_filter_positive=ANY
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.tenant.holder_revocation_service.V10CredentialExchange.query",
+    new_callable=AsyncMock,
+)
+@pytest.mark.parametrize("error_cls", [StorageError, BaseModelError])
+async def test_find_credential_exchange_v10_query_error(
+    mock_query: AsyncMock,
+    error_cls: type,
+    holder_revocation_service: HolderRevocationService,
+    mock_profile: tuple,
+):
+    """Test finding V10 credential exchange with storage/model errors."""
+    profile, session, _ = mock_profile
+    mock_query.side_effect = error_cls("Query failed")
+
+    result = await holder_revocation_service.find_credential_exchange_v10(
+        profile, TEST_REV_REG_ID, TEST_REVOCATION_ID
+    )
+
+    # Service catches the error and returns None
+    assert result is None
+    profile.session.assert_called_once()
+    mock_query.assert_awaited_once_with(
+        session=session, tag_filter=ANY, post_filter_positive=ANY
+    )
+
+
+# Test set_credential_exchange_revoked_v10
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.tenant.holder_revocation_service.V10CredentialExchange.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_set_credential_exchange_revoked_v10_success(
+    mock_retrieve: AsyncMock,
+    holder_revocation_service: HolderRevocationService,
+    mock_profile: tuple,
+    mock_v10_cred_ex_record: AsyncMock,
+):
+    """Test successfully setting a credential exchange to revoked state."""
+    profile, _, txn = mock_profile
+    mock_retrieve.return_value = mock_v10_cred_ex_record
+
+    result = await holder_revocation_service.set_credential_exchange_revoked_v10(
+        profile, TEST_CRED_EX_ID, TEST_COMMENT
+    )
+
+    assert result == mock_v10_cred_ex_record
+    assert result.state == V10CredentialExchange.STATE_CREDENTIAL_REVOKED
+    assert result.error_msg == TEST_COMMENT
+    profile.transaction.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(txn, TEST_CRED_EX_ID, for_update=True)
+    mock_v10_cred_ex_record.save.assert_awaited_once_with(
+        txn, reason="revoke credential"
+    )
+    txn.commit.assert_awaited_once()
+    txn.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.tenant.holder_revocation_service.V10CredentialExchange.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_set_credential_exchange_revoked_v10_not_found(
+    mock_retrieve: AsyncMock,
+    holder_revocation_service: HolderRevocationService,
+    mock_profile: tuple,
+):
+    """Test setting revoked state when the record is not found."""
+    profile, _, txn = mock_profile
+    mock_retrieve.side_effect = StorageNotFoundError("Record not found")
+
+    result = await holder_revocation_service.set_credential_exchange_revoked_v10(
+        profile, TEST_CRED_EX_ID, TEST_COMMENT
+    )
+
+    # Service catches and returns None
+    assert result is None
+    profile.transaction.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(txn, TEST_CRED_EX_ID, for_update=True)
+    txn.commit.assert_not_called()  # Commit shouldn't happen
+    # Rollback might be called implicitly by context manager exit on error
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.tenant.holder_revocation_service.V10CredentialExchange.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_set_credential_exchange_revoked_v10_save_error(
+    mock_retrieve: AsyncMock,
+    holder_revocation_service: HolderRevocationService,
+    mock_profile: tuple,
+    mock_v10_cred_ex_record: AsyncMock,
+):
+    """Test setting revoked state when save fails."""
+    profile, _, txn = mock_profile
+    mock_retrieve.return_value = mock_v10_cred_ex_record
+    mock_v10_cred_ex_record.save.side_effect = StorageError("Save failed")
+
+    # The service doesn't explicitly catch this, expect StorageError propagation
+    with pytest.raises(StorageError, match="Save failed"):
+        await holder_revocation_service.set_credential_exchange_revoked_v10(
+            profile, TEST_CRED_EX_ID, TEST_COMMENT
+        )
+
+    profile.transaction.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(txn, TEST_CRED_EX_ID, for_update=True)
+    mock_v10_cred_ex_record.save.assert_awaited_once_with(
+        txn, reason="revoke credential"
+    )
+    txn.commit.assert_not_called()  # Commit shouldn't happen
+
+
+# --- Test Cases for Global Functions ---
+
+
+# Test subscribe
+def test_subscribe(mock_event_bus: MagicMock):
+    """Test the subscribe function registers the handler."""
+    subscribe(mock_event_bus)
+    mock_event_bus.subscribe.assert_called_once_with(
+        REVOCATION_NOTIFICATION_EVENT_PATTERN, revocation_notification_handler
+    )
+
+
+# Test revocation_notification_handler
+@pytest.mark.asyncio
+async def test_revocation_notification_handler_success(
+    mock_profile: tuple,
+    holder_revocation_service: HolderRevocationService,  # Use fixture
+    mock_event: MagicMock,
+    mock_v10_cred_ex_record: AsyncMock,
+):
+    """Test the revocation_notification_handler successfully finds and updates."""
+    profile, _, _ = mock_profile
+
+    # Mock profile.inject to return our service instance
+    profile.inject.return_value = holder_revocation_service
+
+    # Mock the service methods specifically for this test
+    holder_revocation_service.parse_thread_id = MagicMock(
+        return_value=(TEST_REV_REG_ID, TEST_REVOCATION_ID)
+    )
+    holder_revocation_service.find_credential_exchange_v10 = AsyncMock(
+        return_value=mock_v10_cred_ex_record
+    )
+    holder_revocation_service.set_credential_exchange_revoked_v10 = AsyncMock(
+        return_value=mock_v10_cred_ex_record  # Simulate successful update
+    )
+
+    await revocation_notification_handler(profile, mock_event)
+
+    profile.inject.assert_called_once_with(HolderRevocationService)
+    holder_revocation_service.parse_thread_id.assert_called_once_with(TEST_THREAD_ID)
+    holder_revocation_service.find_credential_exchange_v10.assert_awaited_once_with(
+        profile, TEST_REV_REG_ID, TEST_REVOCATION_ID
+    )
+    holder_revocation_service.set_credential_exchange_revoked_v10.assert_awaited_once_with(
+        profile, TEST_CRED_EX_ID, TEST_COMMENT
+    )
+
+
+@pytest.mark.asyncio
+async def test_revocation_notification_handler_record_not_found(
+    mock_profile: tuple,
+    holder_revocation_service: HolderRevocationService,
+    mock_event: MagicMock,
+):
+    """Test the handler when the credential exchange record is not found."""
+    profile, _, _ = mock_profile
+    profile.inject.return_value = holder_revocation_service
+    holder_revocation_service.parse_thread_id = MagicMock(
+        return_value=(TEST_REV_REG_ID, TEST_REVOCATION_ID)
+    )
+    # Simulate find returning None (or raising IndexError which is caught)
+    holder_revocation_service.find_credential_exchange_v10 = AsyncMock(
+        return_value=None
+    )
+    holder_revocation_service.set_credential_exchange_revoked_v10 = AsyncMock()
+
+    await revocation_notification_handler(profile, mock_event)
+
+    profile.inject.assert_called_once_with(HolderRevocationService)
+    holder_revocation_service.parse_thread_id.assert_called_once_with(TEST_THREAD_ID)
+    holder_revocation_service.find_credential_exchange_v10.assert_awaited_once_with(
+        profile, TEST_REV_REG_ID, TEST_REVOCATION_ID
+    )
+    # Ensure set_credential_exchange_revoked_v10 was NOT called
+    holder_revocation_service.set_credential_exchange_revoked_v10.assert_not_awaited()

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_oca_routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_oca_routes.py
@@ -1,0 +1,555 @@
+import json
+import logging
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+from aiohttp import web
+from acapy_agent.core.profile import Profile
+from acapy_agent.storage.error import StorageNotFoundError, StorageError
+from acapy_agent.messaging.models.base import BaseModelError
+from marshmallow import ValidationError
+
+# Import the module containing the routes to be tested
+# Adjust path as necessary
+from traction_innkeeper.v1_0.oca import routes as test_module
+
+# Import Service and Models used for mocking
+from traction_innkeeper.v1_0.oca.oca_service import (
+    OcaService,
+    PublicDIDRequiredError,
+    PublicDIDMismatchError,
+)
+
+# Assuming OcaRecord exists and has serialize method
+from traction_innkeeper.v1_0.oca.models import OcaRecord
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+TEST_OCA_ID = "test-oca-id-123"
+TEST_SCHEMA_ID = "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+TEST_CRED_DEF_ID = "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag"
+TEST_OCA_URL = "http://example.com/oca.json"
+TEST_OCA_BUNDLE = {"format": "aries/oca-bundle", "version": ["1.0"]}
+TEST_API_KEY = "test-oca-api-key"
+
+# --- Reusable Fixtures (similar to test_innkeeper_routes.py) ---
+
+
+@pytest.fixture
+def mock_profile_inject():
+    """Provides a mock injector function and tracks injectable mocks."""
+    injectables = {}
+
+    def _injector(cls_to_inject, *args, **kwargs):
+        target_cls = (
+            cls_to_inject if isinstance(cls_to_inject, type) else type(cls_to_inject)
+        )
+        mock_instance = injectables.get(target_cls)
+        if not mock_instance:
+            if args:
+                return args[0]  # inject_or default
+            return MagicMock()  # Fallback for regular inject
+        return mock_instance
+
+    return MagicMock(side_effect=_injector), injectables
+
+
+@pytest.fixture
+def mock_session():
+    """Provides a mocked async Session."""
+    session = AsyncMock(name="Session")
+
+    async def __aenter__(*args):
+        return session
+
+    async def __aexit__(*args):
+        pass
+
+    session.__aenter__ = __aenter__
+    session.__aexit__ = __aexit__
+    return session
+
+
+@pytest.fixture
+def mock_profile(mock_session: AsyncMock, mock_profile_inject: tuple):
+    """Provides a mocked Profile."""
+    profile = MagicMock(name="Profile", spec=Profile)
+    profile.context = MagicMock(name="Context")
+    profile.settings = {
+        "admin.admin_api_key": TEST_API_KEY,
+    }
+    profile.context.settings = profile.settings
+    profile.session = MagicMock(return_value=mock_session)
+    profile.inject, profile._injectables = mock_profile_inject
+    profile.inject_or = (
+        profile.inject
+    )  # Assume inject_or behaves like inject for simplicity
+    return profile
+
+
+@pytest.fixture
+def mock_context(mock_profile: MagicMock):
+    """Provides a mocked AdminRequestContext containing the mock profile."""
+    context = MagicMock(name="AdminRequestContext")
+    context.profile = mock_profile
+    context.inject = mock_profile.inject
+    context.inject_or = mock_profile.inject_or
+    return context
+
+
+@pytest.fixture
+def mock_request(mock_context: MagicMock):
+    """Provides a mocked aiohttp.web.Request linked to the context."""
+    request = MagicMock(spec=web.Request)
+    request.match_info = {}
+    request.query = {}
+    request.headers = {"x-api-key": TEST_API_KEY}  # Satisfy tenant_authentication
+
+    def getitem_side_effect(key):
+        if key == "context":
+            return mock_context
+        if key == "headers":
+            return request.headers
+        return MagicMock()
+
+    request.__getitem__.side_effect = getitem_side_effect
+    request.json = AsyncMock()
+    request._set_match_info = lambda key, value: request.match_info.update({key: value})
+    request._set_json_body = lambda data: setattr(request.json, "return_value", data)
+    return request
+
+
+@pytest.fixture
+def mock_oca_service(mock_profile: MagicMock):
+    """Provides a mocked OcaService AND configures it for injection."""
+    service = AsyncMock(spec=OcaService)
+    # Add mocked methods expected by routes
+    service.create_or_update_oca_record = AsyncMock()
+    service.read_oca_record = AsyncMock()
+    service.update_oca_record = AsyncMock()
+    service.delete_oca_record = AsyncMock()
+    service.list_oca_records = AsyncMock()
+    # Configure injection
+    mock_profile._injectables[OcaService] = service
+    return service
+
+
+@pytest.fixture
+def mock_oca_record():
+    """Provides a mocked OcaRecord instance."""
+    record = MagicMock(spec=OcaRecord)
+    record.oca_record_id = TEST_OCA_ID
+    record.cred_def_id = TEST_CRED_DEF_ID
+    # Add other fields if needed by specific tests
+    record.serialize = MagicMock(
+        return_value={
+            "oca_record_id": TEST_OCA_ID,
+            "cred_def_id": TEST_CRED_DEF_ID,
+            "url": TEST_OCA_URL,
+            "oca_bundle": TEST_OCA_BUNDLE,
+        }
+    )
+    return record
+
+
+# --- Test Cases ---
+
+
+# Test Create OCA Record (POST /oca)
+@pytest.mark.asyncio
+async def test_oca_record_create_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+    mock_oca_record: MagicMock,
+):
+    """Test POST /oca endpoint success."""
+    profile = mock_context.profile
+    create_body = {"cred_def_id": TEST_CRED_DEF_ID, "url": TEST_OCA_URL}
+    mock_request._set_json_body(create_body)
+    mock_oca_service.create_or_update_oca_record.return_value = mock_oca_record
+
+    response = await test_module.oca_record_create(mock_request)
+
+    mock_context.inject.assert_called_once_with(OcaService)
+    mock_request.json.assert_awaited_once()
+    mock_oca_service.create_or_update_oca_record.assert_awaited_once_with(
+        profile, create_body
+    )
+    assert response.status == 200
+    assert json.loads(response.body) == mock_oca_record.serialize.return_value
+    mock_oca_record.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_cls, expected_exception",
+    [
+        (ValidationError, web.HTTPUnprocessableEntity),
+        (PublicDIDRequiredError, web.HTTPBadRequest),
+        (StorageError, web.HTTPBadRequest),
+        (BaseModelError, web.HTTPBadRequest),
+        (Exception, Exception),  # Test generic exception re-raising
+    ],
+)
+async def test_oca_record_create_errors(
+    error_cls,
+    expected_exception,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+):
+    """Test POST /oca endpoint error handling."""
+    profile = mock_context.profile
+    create_body = {"cred_def_id": TEST_CRED_DEF_ID}
+    mock_request._set_json_body(create_body)
+    error_message = "Test Error"
+    # Use .messages for ValidationError
+    error_instance = error_cls(
+        error_message if error_cls != ValidationError else {"field": [error_message]}
+    )
+    mock_oca_service.create_or_update_oca_record.side_effect = error_instance
+
+    with pytest.raises(expected_exception) as excinfo:
+        await test_module.oca_record_create(mock_request)
+
+    # For handled exceptions, check the reason
+    if expected_exception is not Exception:
+        assert error_message in str(excinfo.value)
+
+    mock_oca_service.create_or_update_oca_record.assert_awaited_once_with(
+        profile, create_body
+    )
+
+
+# Test Read OCA Record (GET /oca/{oca_id})
+@pytest.mark.asyncio
+async def test_oca_record_read_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+    mock_oca_record: MagicMock,
+):
+    """Test GET /oca/{oca_id} endpoint success."""
+    profile = mock_context.profile
+    mock_request._set_match_info("oca_id", TEST_OCA_ID)
+    mock_oca_service.read_oca_record.return_value = mock_oca_record
+
+    response = await test_module.oca_record_read(mock_request)
+
+    mock_context.inject.assert_called_once_with(OcaService)
+    mock_oca_service.read_oca_record.assert_awaited_once_with(profile, TEST_OCA_ID)
+    assert response.status == 200
+    assert json.loads(response.body) == mock_oca_record.serialize.return_value
+    mock_oca_record.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_cls, expected_exception",
+    [
+        (StorageNotFoundError, web.HTTPNotFound),
+        (PublicDIDMismatchError, web.HTTPUnauthorized),
+        (StorageError, web.HTTPBadRequest),
+        (BaseModelError, web.HTTPBadRequest),
+    ],
+)
+async def test_oca_record_read_errors(
+    error_cls,
+    expected_exception,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+):
+    """Test GET /oca/{oca_id} endpoint error handling."""
+    profile = mock_context.profile
+    mock_request._set_match_info("oca_id", TEST_OCA_ID)
+    error_message = "Test Read Error"
+    mock_oca_service.read_oca_record.side_effect = error_cls(error_message)
+
+    with pytest.raises(expected_exception) as excinfo:
+        await test_module.oca_record_read(mock_request)
+
+    assert error_message in str(excinfo.value)
+    mock_oca_service.read_oca_record.assert_awaited_once_with(profile, TEST_OCA_ID)
+
+
+# Test Update OCA Record (PUT /oca/{oca_id})
+@pytest.mark.asyncio
+async def test_oca_record_update_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+    mock_oca_record: MagicMock,
+):
+    """Test PUT /oca/{oca_id} endpoint success."""
+    profile = mock_context.profile
+    mock_request._set_match_info("oca_id", TEST_OCA_ID)
+    update_body = {"url": "http://new.url/bundle.json"}
+    mock_request._set_json_body(update_body)
+    mock_oca_service.update_oca_record.return_value = mock_oca_record
+
+    response = await test_module.oca_record_update(mock_request)
+
+    mock_context.inject.assert_called_once_with(OcaService)
+    mock_request.json.assert_awaited_once()
+    mock_oca_service.update_oca_record.assert_awaited_once_with(
+        profile, TEST_OCA_ID, update_body
+    )
+    assert response.status == 200
+    assert json.loads(response.body) == mock_oca_record.serialize.return_value
+    mock_oca_record.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_cls, expected_exception",
+    [
+        (
+            ValidationError,
+            web.HTTPUnprocessableEntity,
+        ),  # From potential request body validation
+        (StorageNotFoundError, web.HTTPNotFound),
+        (PublicDIDMismatchError, web.HTTPUnauthorized),
+        (StorageError, web.HTTPBadRequest),
+        (BaseModelError, web.HTTPBadRequest),
+    ],
+)
+async def test_oca_record_update_errors(
+    error_cls,
+    expected_exception,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+):
+    """Test PUT /oca/{oca_id} endpoint error handling."""
+    profile = mock_context.profile
+    mock_request._set_match_info("oca_id", TEST_OCA_ID)
+    update_body = {"url": "http://new.url/bundle.json"}
+    mock_request._set_json_body(update_body)
+    error_message = "Test Update Error"
+    error_instance = error_cls(
+        error_message if error_cls != ValidationError else {"field": [error_message]}
+    )
+    mock_oca_service.update_oca_record.side_effect = error_instance
+
+    with pytest.raises(expected_exception) as excinfo:
+        await test_module.oca_record_update(mock_request)
+
+    assert error_message in str(excinfo.value)
+    mock_oca_service.update_oca_record.assert_awaited_once_with(
+        profile, TEST_OCA_ID, update_body
+    )
+
+
+# Test Delete OCA Record (DELETE /oca/{oca_id})
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_return, expected_success",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+async def test_oca_record_delete_success(
+    service_return,
+    expected_success,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+):
+    """Test DELETE /oca/{oca_id} endpoint success cases."""
+    profile = mock_context.profile
+    mock_request._set_match_info("oca_id", TEST_OCA_ID)
+    mock_oca_service.delete_oca_record.return_value = service_return
+
+    response = await test_module.oca_record_delete(mock_request)
+
+    mock_context.inject.assert_called_once_with(OcaService)
+    mock_oca_service.delete_oca_record.assert_awaited_once_with(profile, TEST_OCA_ID)
+    assert response.status == 200
+    assert json.loads(response.body) == {"success": expected_success}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_cls, expected_exception",
+    [
+        (StorageNotFoundError, web.HTTPNotFound),
+        (PublicDIDMismatchError, web.HTTPUnauthorized),
+        (StorageError, web.HTTPBadRequest),
+        (BaseModelError, web.HTTPBadRequest),
+    ],
+)
+async def test_oca_record_delete_errors(
+    error_cls,
+    expected_exception,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+):
+    """Test DELETE /oca/{oca_id} endpoint error handling."""
+    profile = mock_context.profile
+    mock_request._set_match_info("oca_id", TEST_OCA_ID)
+    error_message = "Test Delete Error"
+    mock_oca_service.delete_oca_record.side_effect = error_cls(error_message)
+
+    with pytest.raises(expected_exception) as excinfo:
+        await test_module.oca_record_delete(mock_request)
+
+    assert error_message in str(excinfo.value)
+    mock_oca_service.delete_oca_record.assert_awaited_once_with(profile, TEST_OCA_ID)
+
+
+# Test List OCA Records (GET /oca)
+@pytest.mark.asyncio
+async def test_oca_record_list_success_no_filter(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+    mock_oca_record: MagicMock,
+):
+    """Test GET /oca endpoint success without filters."""
+    profile = mock_context.profile
+    # Need a second mock record for list
+    mock_rec2 = MagicMock(spec=OcaRecord)
+    mock_rec2.serialize.return_value = {"oca_record_id": "oca-id-456"}
+    mock_oca_service.list_oca_records.return_value = [mock_oca_record, mock_rec2]
+
+    response = await test_module.oca_record_list(mock_request)
+
+    mock_context.inject.assert_called_once_with(OcaService)
+    mock_oca_service.list_oca_records.assert_awaited_once_with(
+        profile, None, None
+    )  # No filters
+    assert response.status == 200
+    assert json.loads(response.body) == {
+        "results": [mock_oca_record.serialize(), mock_rec2.serialize()]
+    }
+    mock_oca_record.serialize.assert_called()
+    mock_rec2.serialize.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_oca_record_list_success_with_filter(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+    mock_oca_record: MagicMock,
+):
+    """Test GET /oca endpoint success with cred_def_id filter."""
+    profile = mock_context.profile
+    mock_request.query["cred_def_id"] = TEST_CRED_DEF_ID  # Set query param
+    mock_oca_service.list_oca_records.return_value = [
+        mock_oca_record
+    ]  # Assume filter returns one
+
+    response = await test_module.oca_record_list(mock_request)
+
+    mock_context.inject.assert_called_once_with(OcaService)
+    mock_oca_service.list_oca_records.assert_awaited_once_with(
+        profile, None, TEST_CRED_DEF_ID
+    )
+    assert response.status == 200
+    assert json.loads(response.body) == {"results": [mock_oca_record.serialize()]}
+    mock_oca_record.serialize.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_oca_record_list_empty(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+):
+    """Test GET /oca endpoint success with empty results."""
+    profile = mock_context.profile
+    mock_oca_service.list_oca_records.return_value = []  # Empty list
+
+    response = await test_module.oca_record_list(mock_request)
+
+    mock_context.inject.assert_called_once_with(OcaService)
+    mock_oca_service.list_oca_records.assert_awaited_once_with(profile, None, None)
+    assert response.status == 200
+    assert json.loads(response.body) == {"results": []}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_cls, expected_exception",
+    [
+        (StorageError, web.HTTPBadRequest),
+        (BaseModelError, web.HTTPBadRequest),
+    ],
+)
+async def test_oca_record_list_errors(
+    error_cls,
+    expected_exception,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_oca_service: AsyncMock,
+):
+    """Test GET /oca endpoint error handling."""
+    profile = mock_context.profile
+    error_message = "Test List Error"
+    mock_oca_service.list_oca_records.side_effect = error_cls(error_message)
+
+    with pytest.raises(expected_exception) as excinfo:
+        await test_module.oca_record_list(mock_request)
+
+    assert error_message in str(excinfo.value)
+    mock_oca_service.list_oca_records.assert_awaited_once_with(profile, None, None)
+
+
+# Test register function
+@pytest.mark.asyncio
+async def test_register():
+    """Test route registration."""
+    mock_app = MagicMock(spec=web.Application)
+    mock_app.add_routes = MagicMock()
+
+    await test_module.register(mock_app)  # Await the async function
+
+    calls = mock_app.add_routes.call_args_list
+    assert len(calls) == 1
+    registered_routes = calls[0][0][0]  # Get the list of web.RouteDef objects
+    assert len(registered_routes) == 5  # Check number of routes
+    paths_methods = {(r.path, r.method) for r in registered_routes}
+    assert ("/oca", "GET") in paths_methods
+    assert ("/oca", "POST") in paths_methods
+    assert ("/oca/{oca_id}", "GET") in paths_methods
+    assert ("/oca/{oca_id}", "PUT") in paths_methods
+    assert ("/oca/{oca_id}", "DELETE") in paths_methods
+
+
+# Test post_process_routes function
+def test_post_process_routes():
+    """Test swagger documentation tagging."""
+    mock_app = MagicMock()
+    mock_app._state = {"swagger_dict": {}}  # Simulate swagger dict state
+
+    test_module.post_process_routes(mock_app)
+
+    assert "tags" in mock_app._state["swagger_dict"]
+    assert len(mock_app._state["swagger_dict"]["tags"]) == 1
+    assert (
+        mock_app._state["swagger_dict"]["tags"][0]["name"]
+        == test_module.SWAGGER_CATEGORY
+    )
+    assert "description" in mock_app._state["swagger_dict"]["tags"][0]
+
+
+def test_post_process_routes_existing_tags():
+    """Test swagger documentation tagging when tags list already exists."""
+    mock_app = MagicMock()
+    mock_app._state = {"swagger_dict": {"tags": [{"name": "existing_tag"}]}}
+
+    test_module.post_process_routes(mock_app)
+
+    assert len(mock_app._state["swagger_dict"]["tags"]) == 2
+    assert mock_app._state["swagger_dict"]["tags"][0]["name"] == "existing_tag"
+    assert (
+        mock_app._state["swagger_dict"]["tags"][1]["name"]
+        == test_module.SWAGGER_CATEGORY
+    )

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_schema_storage_routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_schema_storage_routes.py
@@ -1,0 +1,658 @@
+import json
+import logging
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+from aiohttp import web
+from acapy_agent.core.profile import Profile
+from acapy_agent.storage.error import StorageNotFoundError, StorageError
+from acapy_agent.messaging.models.base import BaseModelError
+
+# Import the module containing the routes to be tested
+# Adjust path as necessary
+from traction_innkeeper.v1_0.schema_storage import routes as test_module
+
+# Import Service and Models used for mocking
+from traction_innkeeper.v1_0.schema_storage.schema_storage_service import (
+    SchemaStorageService,
+)
+from traction_innkeeper.v1_0.schema_storage.models import (
+    SchemaStorageRecord,  # Although schema not directly used, good practice
+)
+
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+
+# --- Constants ---
+TEST_SCHEMA_ID = "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+TEST_ISSUER_DID = "WgWxqztrNooG92RXvxSTWv"
+TEST_API_KEY = "test-schema-storage-api-key"
+TEST_SCHEMA_DATA = {
+    "ver": "1.0",
+    "id": TEST_SCHEMA_ID,
+    "name": "schema_name",
+    "version": "1.0",
+    "attrNames": ["attr1", "attr2"],
+    "seqNo": 1234,
+}
+
+# --- Reusable Fixtures (similar to test_innkeeper_routes.py) ---
+
+
+@pytest.fixture
+def mock_profile_inject():
+    """Provides a mock injector function and tracks injectable mocks."""
+    injectables = {}
+
+    def _injector(cls_to_inject, *args, **kwargs):
+        # Handle inject_or by checking if cls_to_inject is a type
+        target_cls = (
+            cls_to_inject if isinstance(cls_to_inject, type) else type(cls_to_inject)
+        )
+        mock_instance = injectables.get(target_cls)
+        if not mock_instance:
+            if args:
+                return args[0]  # inject_or default
+            return MagicMock()  # Fallback for regular inject
+        return mock_instance
+
+    return MagicMock(side_effect=_injector), injectables
+
+
+@pytest.fixture
+def mock_session():
+    """Provides a mocked async Session."""
+    session = AsyncMock(name="Session")
+
+    async def __aenter__(*args):
+        return session
+
+    async def __aexit__(*args):
+        pass
+
+    session.__aenter__ = __aenter__
+    session.__aexit__ = __aexit__
+    return session
+
+
+@pytest.fixture
+def mock_profile(mock_session: AsyncMock, mock_profile_inject: tuple):
+    """Provides a mocked Profile."""
+    profile = MagicMock(name="Profile", spec=Profile)
+    profile.context = MagicMock(name="Context")
+    profile.settings = {
+        "admin.admin_api_key": TEST_API_KEY,
+    }
+    profile.context.settings = profile.settings
+    profile.session = MagicMock(return_value=mock_session)
+    profile.inject, profile._injectables = mock_profile_inject
+    profile.inject_or = (
+        profile.inject
+    )  # Assume inject_or behaves like inject for simplicity
+    return profile
+
+
+@pytest.fixture
+def mock_context(mock_profile: MagicMock):
+    """Provides a mocked AdminRequestContext containing the mock profile."""
+    context = MagicMock(name="AdminRequestContext")
+    context.profile = mock_profile
+    context.inject = mock_profile.inject
+    context.inject_or = mock_profile.inject_or
+    return context
+
+
+@pytest.fixture
+def mock_request(mock_context: MagicMock):
+    """Provides a mocked aiohttp.web.Request linked to the context."""
+    request = MagicMock(spec=web.Request)
+    request.match_info = {}
+    request.query = {}
+    request.headers = {"x-api-key": TEST_API_KEY}  # Satisfy tenant_authentication
+
+    def getitem_side_effect(key):
+        if key == "context":
+            return mock_context
+        if key == "headers":
+            return request.headers
+        return MagicMock()
+
+    request.__getitem__.side_effect = getitem_side_effect
+    request.json = AsyncMock()
+    request._set_match_info = lambda key, value: request.match_info.update({key: value})
+    request._set_json_body = lambda data: setattr(request.json, "return_value", data)
+    return request
+
+
+@pytest.fixture
+def mock_schema_storage_service(mock_profile: MagicMock):
+    """Provides a mocked SchemaStorageService AND configures it for injection."""
+    service = AsyncMock(spec=SchemaStorageService)
+    # Add mocked methods expected by routes
+    service.list_items = AsyncMock()
+    service.add_item = AsyncMock()
+    service.read_item = AsyncMock()
+    service.remove_item = AsyncMock()
+    service.sync_created = AsyncMock()
+    # Configure injection
+    mock_profile._injectables[SchemaStorageService] = service
+    return service
+
+
+@pytest.fixture
+def mock_schema_storage_record():
+    """Provides a mocked SchemaStorageRecord instance."""
+    record = MagicMock(spec=SchemaStorageRecord)
+    record.schema_id = TEST_SCHEMA_ID
+    record.serialize = MagicMock(
+        return_value={
+            "schema_id": TEST_SCHEMA_ID,
+            "schema": TEST_SCHEMA_DATA,
+            "ledger_id": "test-ledger",
+        }
+    )
+    return record
+
+
+# --- Test Cases ---
+
+
+# Test List Schemas (GET /schema-storage)
+@pytest.mark.asyncio
+async def test_schema_storage_list(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test GET /schema-storage endpoint."""
+    profile = mock_context.profile
+
+    # Mock service response
+    mock_rec_1 = MagicMock(spec=SchemaStorageRecord)
+    mock_rec_1.serialize.return_value = {"schema_id": "schema-1"}
+    mock_rec_2 = MagicMock(spec=SchemaStorageRecord)
+    mock_rec_2.serialize.return_value = {"schema_id": "schema-2"}
+    mock_schema_storage_service.list_items.return_value = [mock_rec_1, mock_rec_2]
+
+    response = await test_module.schema_storage_list(mock_request)
+
+    # Check service was injected and called
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.list_items.assert_awaited_once_with(
+        profile, {}, {}  # Default filters
+    )
+
+    # Check response
+    assert response.status == 200
+    assert json.loads(response.body) == {
+        "results": [
+            {"schema_id": "schema-1"},
+            {"schema_id": "schema-2"},
+        ]
+    }
+    mock_rec_1.serialize.assert_called_once()
+    mock_rec_2.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_list_empty(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test GET /schema-storage endpoint with no results."""
+    profile = mock_context.profile
+    mock_schema_storage_service.list_items.return_value = []  # Empty list
+
+    response = await test_module.schema_storage_list(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.list_items.assert_awaited_once_with(profile, {}, {})
+    assert response.status == 200
+    assert json.loads(response.body) == {"results": []}
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_list_storage_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test GET /schema-storage endpoint with StorageError."""
+    mock_schema_storage_service.list_items.side_effect = StorageError(
+        "DB connection lost"
+    )
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.schema_storage_list(mock_request)
+    assert "DB connection lost" in str(excinfo.value)
+
+
+# Test Add Schema (POST /schema-storage)
+@pytest.mark.asyncio
+async def test_schema_storage_add_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+    mock_schema_storage_record: MagicMock,
+):
+    """Test POST /schema-storage endpoint success."""
+    profile = mock_context.profile
+    add_body = {"schema_id": TEST_SCHEMA_ID}
+    mock_request._set_json_body(add_body)
+    mock_schema_storage_service.add_item.return_value = mock_schema_storage_record
+
+    response = await test_module.schema_storage_add(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_request.json.assert_awaited_once()
+    mock_schema_storage_service.add_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+    assert response.status == 200
+    assert (
+        json.loads(response.body) == mock_schema_storage_record.serialize.return_value
+    )
+    mock_schema_storage_record.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_cls, expected_exception",
+    [
+        (StorageNotFoundError, web.HTTPNotFound),  # If add_item uses ledger and fails
+        (StorageError, web.HTTPBadRequest),
+        (BaseModelError, web.HTTPBadRequest),
+        (Exception, Exception),  # Check re-raise
+    ],
+)
+async def test_schema_storage_add_errors(
+    error_cls,
+    expected_exception,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test POST /schema-storage endpoint error handling."""
+    profile = mock_context.profile
+    add_body = {"schema_id": TEST_SCHEMA_ID}
+    mock_request._set_json_body(add_body)
+    error_message = "Test Add Error"
+    mock_schema_storage_service.add_item.side_effect = error_cls(error_message)
+
+    with pytest.raises(expected_exception) as excinfo:
+        await test_module.schema_storage_add(mock_request)
+
+    if expected_exception is not Exception:
+        assert error_message in str(excinfo.value)
+
+    mock_schema_storage_service.add_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+
+
+# Test Get Schema (GET /schema-storage/{schema_id})
+@pytest.mark.asyncio
+async def test_schema_storage_get_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+    mock_schema_storage_record: MagicMock,
+):
+    """Test GET /schema-storage/{schema_id} endpoint success."""
+    profile = mock_context.profile
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    mock_schema_storage_service.read_item.return_value = mock_schema_storage_record
+
+    response = await test_module.schema_storage_get(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.read_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+    assert response.status == 200
+    assert (
+        json.loads(response.body) == mock_schema_storage_record.serialize.return_value
+    )
+    mock_schema_storage_record.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_get_not_found(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test GET /schema-storage/{schema_id} not found."""
+    profile = mock_context.profile
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    mock_schema_storage_service.read_item.side_effect = StorageNotFoundError(
+        "Record not found"
+    )
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.schema_storage_get(mock_request)
+    assert "Record not found" in str(excinfo.value)
+
+    mock_schema_storage_service.read_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_get_storage_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test GET /schema-storage/{schema_id} with StorageError."""
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    mock_schema_storage_service.read_item.side_effect = StorageError("Bad read")
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.schema_storage_get(mock_request)
+    assert "Bad read" in str(excinfo.value)
+
+
+# Test Remove Schema (DELETE /schema-storage/{schema_id})
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_return, expected_success",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+async def test_schema_storage_remove_success(
+    service_return,
+    expected_success,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test DELETE /schema-storage/{schema_id} success cases."""
+    profile = mock_context.profile
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    mock_schema_storage_service.remove_item.return_value = service_return
+
+    response = await test_module.schema_storage_remove(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.remove_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+    assert response.status == 200
+    assert json.loads(response.body) == {"success": expected_success}
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_remove_not_found(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test DELETE /schema-storage/{schema_id} not found."""
+    profile = mock_context.profile
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    mock_schema_storage_service.remove_item.side_effect = StorageNotFoundError(
+        "Cannot find to remove"
+    )
+
+    with pytest.raises(web.HTTPNotFound) as excinfo:
+        await test_module.schema_storage_remove(mock_request)
+    assert "Cannot find to remove" in str(excinfo.value)
+
+    mock_schema_storage_service.remove_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_remove_storage_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test DELETE /schema-storage/{schema_id} with StorageError."""
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    mock_schema_storage_service.remove_item.side_effect = StorageError("Cannot delete")
+
+    with pytest.raises(web.HTTPBadRequest) as excinfo:
+        await test_module.schema_storage_remove(mock_request)
+    assert "Cannot delete" in str(excinfo.value)
+
+
+# Test Sync Created Schemas (POST /schema-storage/sync-created)
+@pytest.mark.asyncio
+async def test_schema_storage_sync_created_success(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+    mock_schema_storage_record: MagicMock,
+):
+    """Test POST /schema-storage/sync-created endpoint success."""
+    profile = mock_context.profile
+
+    # Mock service response
+    mock_rec_synced = MagicMock(spec=SchemaStorageRecord)
+    mock_rec_synced.serialize.return_value = {"schema_id": "synced-schema-1"}
+    mock_schema_storage_service.sync_created.return_value = [mock_rec_synced]
+
+    response = await test_module.schema_storage_sync_created(mock_request)
+
+    # Check service was injected and called
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.sync_created.assert_awaited_once_with(profile)
+
+    # Check response
+    assert response.status == 200
+    assert json.loads(response.body) == {"results": [{"schema_id": "synced-schema-1"}]}
+    mock_rec_synced.serialize.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_sync_created_empty(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test POST /schema-storage/sync-created endpoint with no results."""
+    profile = mock_context.profile
+    mock_schema_storage_service.sync_created.return_value = []  # Empty list
+
+    response = await test_module.schema_storage_sync_created(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.sync_created.assert_awaited_once_with(profile)
+    assert response.status == 200
+    assert json.loads(response.body) == {"results": []}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_cls, expected_exception",
+    [
+        (StorageError, web.HTTPBadRequest),
+        (BaseModelError, web.HTTPBadRequest),
+        (Exception, Exception),  # Check re-raise
+    ],
+)
+async def test_schema_storage_sync_created_errors(
+    error_cls,
+    expected_exception,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test POST /schema-storage/sync-created endpoint error handling."""
+    profile = mock_context.profile
+    error_message = "Test Sync Error"
+    mock_schema_storage_service.sync_created.side_effect = error_cls(error_message)
+
+    with pytest.raises(expected_exception) as excinfo:
+        await test_module.schema_storage_sync_created(mock_request)
+
+    if expected_exception is not Exception:
+        assert error_message in str(excinfo.value)
+
+    mock_schema_storage_service.sync_created.assert_awaited_once_with(profile)
+
+
+# Test register function
+@pytest.mark.asyncio
+async def test_register():
+    """Test route registration."""
+    mock_app = MagicMock(spec=web.Application)
+    mock_app.add_routes = MagicMock()
+
+    await test_module.register(mock_app)  # Await the async function
+
+    calls = mock_app.add_routes.call_args_list
+    assert len(calls) == 1
+    registered_routes = calls[0][0][0]  # Get the list of web.RouteDef objects
+    assert len(registered_routes) == 5  # Check number of routes
+    paths_methods = {(r.path, r.method) for r in registered_routes}
+    assert ("/schema-storage", "GET") in paths_methods
+    assert ("/schema-storage", "POST") in paths_methods
+    assert ("/schema-storage/{schema_id}", "GET") in paths_methods
+    assert ("/schema-storage/{schema_id}", "DELETE") in paths_methods
+    assert ("/schema-storage/sync-created", "POST") in paths_methods
+
+
+# Test post_process_routes function
+def test_post_process_routes():
+    """Test swagger documentation tagging."""
+    mock_app = MagicMock()
+    mock_app._state = {"swagger_dict": {}}  # Simulate swagger dict state
+
+    test_module.post_process_routes(mock_app)
+
+    assert "tags" in mock_app._state["swagger_dict"]
+    assert len(mock_app._state["swagger_dict"]["tags"]) == 1
+    assert (
+        mock_app._state["swagger_dict"]["tags"][0]["name"]
+        == test_module.SWAGGER_CATEGORY
+    )
+    assert "description" in mock_app._state["swagger_dict"]["tags"][0]
+
+
+def test_post_process_routes_existing_tags():
+    """Test swagger documentation tagging when tags list already exists."""
+    mock_app = MagicMock()
+    mock_app._state = {"swagger_dict": {"tags": [{"name": "existing_tag"}]}}
+
+    test_module.post_process_routes(mock_app)
+
+    assert len(mock_app._state["swagger_dict"]["tags"]) == 2
+    assert mock_app._state["swagger_dict"]["tags"][0]["name"] == "existing_tag"
+    assert (
+        mock_app._state["swagger_dict"]["tags"][1]["name"]
+        == test_module.SWAGGER_CATEGORY
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_list_generic_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test GET /schema-storage endpoint with generic Exception."""
+    profile = mock_context.profile
+    error_message = "Generic unexpected list error"
+    mock_schema_storage_service.list_items.side_effect = Exception(error_message)
+
+    # The error_handler should catch Exception and re-raise it
+    with pytest.raises(Exception, match=error_message):
+        await test_module.schema_storage_list(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.list_items.assert_awaited_once_with(profile, {}, {})
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_add_generic_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test POST /schema-storage endpoint with generic Exception."""
+    profile = mock_context.profile
+    add_body = {"schema_id": TEST_SCHEMA_ID}
+    mock_request._set_json_body(add_body)
+    error_message = "Generic unexpected add error"
+    mock_schema_storage_service.add_item.side_effect = Exception(error_message)
+
+    # The error_handler should catch Exception and re-raise it
+    with pytest.raises(Exception, match=error_message):
+        await test_module.schema_storage_add(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_request.json.assert_awaited_once()
+    mock_schema_storage_service.add_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_get_generic_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test GET /schema-storage/{schema_id} endpoint with generic Exception."""
+    profile = mock_context.profile
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    error_message = "Generic unexpected get error"
+    mock_schema_storage_service.read_item.side_effect = Exception(error_message)
+
+    # The error_handler should catch Exception and re-raise it
+    with pytest.raises(Exception, match=error_message):
+        await test_module.schema_storage_get(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.read_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_remove_generic_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test DELETE /schema-storage/{schema_id} endpoint with generic Exception."""
+    profile = mock_context.profile
+    mock_request._set_match_info("schema_id", TEST_SCHEMA_ID)
+    error_message = "Generic unexpected remove error"
+    mock_schema_storage_service.remove_item.side_effect = Exception(error_message)
+
+    # The error_handler should catch Exception and re-raise it
+    with pytest.raises(Exception, match=error_message):
+        await test_module.schema_storage_remove(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.remove_item.assert_awaited_once_with(
+        profile, TEST_SCHEMA_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_storage_sync_created_generic_error(
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_schema_storage_service: AsyncMock,
+):
+    """Test POST /schema-storage/sync-created endpoint with generic Exception."""
+    profile = mock_context.profile
+    error_message = "Generic unexpected sync error"
+    mock_schema_storage_service.sync_created.side_effect = Exception(error_message)
+
+    # The error_handler should catch Exception and re-raise it
+    with pytest.raises(Exception, match=error_message):
+        await test_module.schema_storage_sync_created(mock_request)
+
+    mock_context.inject_or.assert_called_once_with(SchemaStorageService)
+    mock_schema_storage_service.sync_created.assert_awaited_once_with(profile)

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_schema_storage_service.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_schema_storage_service.py
@@ -1,0 +1,716 @@
+import logging
+from unittest.mock import MagicMock, AsyncMock, patch, call, ANY
+
+from acapy_agent.wallet.models.wallet_record import BaseRecord
+import pytest
+from acapy_agent.core.profile import Profile
+from acapy_agent.storage.error import StorageNotFoundError, StorageError
+from acapy_agent.core.event_bus import Event, EventBus
+from acapy_agent.storage.base import BaseStorage
+
+# Assuming models and service are importable like this
+from traction_innkeeper.v1_0.schema_storage.models import SchemaStorageRecord
+from traction_innkeeper.v1_0.schema_storage.schema_storage_service import (
+    SchemaStorageService,
+    schemas_event_handler,
+    subscribe,
+    SCHEMAS_EVENT_LISTENER_PATTERN,  # Import logger to potentially disable it if needed
+)
+
+# Import mocked dependencies
+from acapy_agent.ledger.multiple_ledger.ledger_requests_executor import (
+    IndyLedgerRequestsExecutor,
+    GET_SCHEMA,
+)
+from acapy_agent.multitenant.base import BaseMultitenantManager
+from acapy_agent.ledger.base import BaseLedger
+
+# Disable logging noise during tests
+logging.disable(logging.CRITICAL)
+# Optionally disable the service's specific logger if it's noisy
+# SERVICE_LOGGER.disabled = True
+
+# --- Constants ---
+TEST_SCHEMA_ID = "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+TEST_ISSUER_DID = "WgWxqztrNooG92RXvxSTWv"
+TEST_LEDGER_ID = "test-ledger-id"
+TEST_SCHEMA_DATA = {
+    "ver": "1.0",
+    "id": TEST_SCHEMA_ID,
+    "name": "schema_name",
+    "version": "1.0",
+    "attrNames": ["attr1", "attr2"],
+    "seqNo": 1234,
+}
+
+
+# --- Fixtures ---
+@pytest.fixture
+def mock_profile():
+    """Provides a mocked Profile with settings, session, and inject."""
+    profile = MagicMock(spec=Profile)
+    mock_session = AsyncMock(name="MockSession")
+    profile.session = MagicMock(return_value=mock_session)
+    mock_session.__aenter__.return_value = mock_session
+    mock_session.__aexit__.return_value = None
+    profile.settings = mock_session
+    profile.settings.get = MagicMock()  # Mock the .get method directly
+    profile.inject = MagicMock()
+    return profile, mock_session
+
+
+@pytest.fixture
+def schema_storage_service():
+    """Provides a SchemaStorageService instance."""
+    return SchemaStorageService()
+
+
+@pytest.fixture
+def mock_schema_storage_record():
+    """Provides a mocked SchemaStorageRecord instance."""
+    record = AsyncMock(spec=SchemaStorageRecord)
+    record.schema_id = TEST_SCHEMA_ID
+    record.schema_ = TEST_SCHEMA_DATA  # Note the underscore for the attribute name
+    record.ledger_id = TEST_LEDGER_ID
+    record.record_value = {"schema": TEST_SCHEMA_DATA}  # Simulate internal storage
+    record.save = AsyncMock()
+    record.delete_record = AsyncMock()
+    # Add serialize if needed by any consuming code (not directly used by service)
+    record.serialize = MagicMock(
+        return_value={
+            "schema_id": TEST_SCHEMA_ID,
+            "schema": TEST_SCHEMA_DATA,
+            "ledger_id": TEST_LEDGER_ID,
+        }
+    )
+    return record
+
+
+@pytest.fixture
+def mock_ledger_executor(mock_profile: tuple):
+    """Provides a mocked IndyLedgerRequestsExecutor."""
+    executor = AsyncMock(spec=IndyLedgerRequestsExecutor)
+    executor.get_ledger_for_identifier = AsyncMock()
+    # Configure injection for the executor
+    profile, session = mock_profile
+    session.inject.return_value = executor  # Default injection
+    return executor
+
+
+@pytest.fixture
+def mock_ledger():
+    """Provides a mocked BaseLedger."""
+    ledger = AsyncMock(spec=BaseLedger)
+    ledger.get_schema = AsyncMock()
+    # Make ledger usable in 'async with' block
+    ledger.__aenter__ = AsyncMock(return_value=ledger)
+    ledger.__aexit__ = AsyncMock(return_value=None)
+    return ledger
+
+
+@pytest.fixture
+def mock_storage(mock_profile: tuple):
+    """Provides a mocked BaseStorage."""
+    storage = AsyncMock(spec=BaseStorage)
+    storage.find_all_records = AsyncMock()
+    # Configure injection
+    profile, session = mock_profile
+    session.inject.return_value = storage
+    return storage
+
+
+@pytest.fixture
+def mock_event():
+    """Provides a mocked Event."""
+    event = MagicMock(spec=Event)
+    event.payload = {"context": {"schema_id": TEST_SCHEMA_ID}}
+    return event
+
+
+@pytest.fixture
+def mock_event_bus():
+    """Provides a mocked EventBus."""
+    bus = MagicMock(spec=EventBus)
+    bus.subscribe = MagicMock()
+    return bus
+
+
+# --- Test Cases for SchemaStorageService ---
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_read_item_success(
+    mock_retrieve: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test successfully reading a SchemaStorageRecord."""
+    profile, session = mock_profile
+    mock_retrieve.return_value = mock_schema_storage_record
+
+    result = await schema_storage_service.read_item(profile, TEST_SCHEMA_ID)
+
+    assert result == mock_schema_storage_record
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_SCHEMA_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_read_item_not_found(
+    mock_retrieve: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+):
+    """Test reading a non-existent SchemaStorageRecord."""
+    profile, session = mock_profile
+    mock_retrieve.side_effect = StorageNotFoundError("Record not found")
+
+    result = await schema_storage_service.read_item(profile, TEST_SCHEMA_ID)
+
+    assert result is None
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_SCHEMA_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_read_item_other_error(
+    mock_retrieve: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+):
+    """Test handling unexpected errors during read."""
+    profile, session = mock_profile
+    mock_retrieve.side_effect = Exception("Database connection failed")
+
+    result = await schema_storage_service.read_item(profile, TEST_SCHEMA_ID)
+
+    assert result is None  # Should still return None and log the error
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_SCHEMA_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.query",
+    new_callable=AsyncMock,
+)
+async def test_list_items_success(
+    mock_query: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test successfully listing items with filters."""
+    profile, session = mock_profile
+    mock_query.return_value = [mock_schema_storage_record]
+    tag_filter = {"issuer_did": TEST_ISSUER_DID}
+    post_filter = {"ledger_id": TEST_LEDGER_ID}
+
+    result = await schema_storage_service.list_items(profile, tag_filter, post_filter)
+
+    assert result == [mock_schema_storage_record]
+    profile.session.assert_called_once()
+    mock_query.assert_awaited_once_with(
+        session=session,
+        tag_filter=tag_filter,
+        post_filter_positive=post_filter,
+        alt=True,
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.query",
+    new_callable=AsyncMock,
+)
+async def test_list_items_no_filters(
+    mock_query: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+):
+    """Test listing items with default empty filters."""
+    profile, session = mock_profile
+    mock_query.return_value = []
+
+    result = await schema_storage_service.list_items(profile)  # No filters passed
+
+    assert result == []
+    profile.session.assert_called_once()
+    mock_query.assert_awaited_once_with(
+        session=session,
+        tag_filter={},
+        post_filter_positive={},
+        alt=True,
+    )
+
+
+# --- add_item tests ---
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch("traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.deserialize")
+async def test_add_item_existing(
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test add_item when the record already exists."""
+    profile, _ = mock_profile
+    mock_read_item.return_value = mock_schema_storage_record  # Simulate exists
+
+    result = await schema_storage_service.add_item(profile, TEST_SCHEMA_ID)
+
+    assert result == mock_schema_storage_record
+    mock_read_item.assert_awaited_once_with(profile, TEST_SCHEMA_ID)
+    # Ensure ledger/save path is not taken
+    profile.session.assert_not_called()
+    mock_deserialize.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch("traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.deserialize")
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.IndyLedgerRequestsExecutor",
+    autospec=True,
+)
+async def test_add_item_new_success_no_multitenant(
+    MockExecutorCls: MagicMock,
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_ledger: AsyncMock,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test add_item success for a new record without multitenancy."""
+    profile, session = mock_profile
+    mock_read_item.return_value = None  # Does not exist
+    session.inject_or = MagicMock(return_value=None)  # No multitenant manager
+    mock_executor_instance = MagicMock()
+    mock_executor_instance.get_ledger_for_identifier = AsyncMock(
+        return_value=(TEST_LEDGER_ID, mock_ledger)
+    )
+
+    session.inject = MagicMock(return_value=mock_executor_instance)
+    MockExecutorCls.return_value = mock_executor_instance  # Instance from class mock
+    mock_ledger.get_schema.return_value = TEST_SCHEMA_DATA
+    mock_deserialize.return_value = mock_schema_storage_record
+
+    result = await schema_storage_service.add_item(profile, TEST_SCHEMA_ID)
+
+    assert result == mock_schema_storage_record
+    mock_read_item.assert_awaited_once_with(profile, TEST_SCHEMA_ID)
+    profile.session.assert_has_calls(
+        [call(), call()]
+    )  # For inject_or/inject, then for save
+    session.inject_or.assert_called_once_with(BaseMultitenantManager)
+    # Executor injected directly from session context when no multitenancy
+    session.inject.assert_called_once_with(MockExecutorCls)
+    mock_executor_instance.get_ledger_for_identifier.assert_awaited_once_with(
+        TEST_SCHEMA_ID, txn_record_type=GET_SCHEMA
+    )
+    mock_ledger.get_schema.assert_awaited_once_with(TEST_SCHEMA_ID)
+    expected_data = {
+        "schema_id": TEST_SCHEMA_ID,
+        "schema": TEST_SCHEMA_DATA,
+        "ledger_id": TEST_LEDGER_ID,
+    }
+    mock_deserialize.assert_called_once_with(expected_data)
+    mock_schema_storage_record.save.assert_awaited_once_with(
+        session, reason="New schema storage record"
+    )
+    # Ensure constructor wasn't called, instance came from session.inject
+    MockExecutorCls.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch("traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.deserialize")
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.IndyLedgerRequestsExecutor",
+    autospec=True,
+)
+async def test_add_item_new_success_with_multitenant(
+    MockExecutorCls: MagicMock,
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_ledger: AsyncMock,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test add_item success for a new record with multitenancy."""
+    profile, session = mock_profile
+    mock_read_item.return_value = None  # Does not exist
+    mock_multitenant_mgr = MagicMock(spec=BaseMultitenantManager)
+    session.inject_or.return_value = mock_multitenant_mgr  # Multitenant manager exists
+    mock_executor_instance = MockExecutorCls.return_value  # Instance from class mock
+    mock_executor_instance.get_ledger_for_identifier = AsyncMock(
+        return_value=(TEST_LEDGER_ID, mock_ledger)
+    )
+    mock_ledger.get_schema.return_value = TEST_SCHEMA_DATA
+    mock_deserialize.return_value = mock_schema_storage_record
+
+    result = await schema_storage_service.add_item(profile, TEST_SCHEMA_ID)
+
+    assert result == mock_schema_storage_record
+    mock_read_item.assert_awaited_once_with(profile, TEST_SCHEMA_ID)
+    profile.session.assert_has_calls([call(), call()])  # For inject_or, then for save
+    session.inject_or.assert_called_once_with(BaseMultitenantManager)
+    # Executor constructed directly when multitenancy is enabled
+    MockExecutorCls.assert_called_once_with(profile)
+    session.inject.assert_not_called()  # Should not inject executor
+    mock_executor_instance.get_ledger_for_identifier.assert_awaited_once_with(
+        TEST_SCHEMA_ID, txn_record_type=GET_SCHEMA
+    )
+    mock_ledger.get_schema.assert_awaited_once_with(TEST_SCHEMA_ID)
+    mock_deserialize.assert_called_once()
+    mock_schema_storage_record.save.assert_awaited_once_with(session, reason=ANY)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.IndyLedgerRequestsExecutor",
+    autospec=True,
+)
+async def test_add_item_ledger_schema_not_found(
+    MockExecutorCls: MagicMock,
+    mock_read_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_ledger: AsyncMock,
+):
+    """Test add_item when the schema is not found on the ledger."""
+    profile, session = mock_profile
+    mock_read_item.return_value = None
+    session.inject_or.return_value = None  # No multitenant
+    mock_executor_instance = AsyncMock()
+    mock_executor_instance.get_ledger_for_identifier = AsyncMock(
+        return_value=(TEST_LEDGER_ID, mock_ledger)
+    )
+    session.inject.return_value = mock_executor_instance
+    MockExecutorCls.return_value = mock_executor_instance  # Instance from class mock
+    # Simulate ledger error or returning None
+    mock_ledger.get_schema.return_value = None
+    # Or mock_ledger.get_schema.side_effect = LedgerError("Not found")
+
+    with pytest.raises(StorageNotFoundError, match="Schema not found on ledger"):
+        await schema_storage_service.add_item(profile, TEST_SCHEMA_ID)
+
+    mock_read_item.assert_awaited_once_with(profile, TEST_SCHEMA_ID)
+    mock_ledger.get_schema.assert_awaited_once_with(TEST_SCHEMA_ID)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch("traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.deserialize")
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.IndyLedgerRequestsExecutor",
+    autospec=True,
+)
+async def test_add_item_deserialize_error(
+    MockExecutorCls: MagicMock,
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_ledger: AsyncMock,
+):
+    """Test add_item with a deserialization error."""
+    profile, session = mock_profile
+    mock_read_item.return_value = None
+    session.inject_or.return_value = None
+    mock_executor_instance = AsyncMock()
+    session.inject.return_value = mock_executor_instance
+    MockExecutorCls.return_value = mock_executor_instance  # Instance from class mock
+    mock_executor_instance.get_ledger_for_identifier = AsyncMock(
+        return_value=(TEST_LEDGER_ID, mock_ledger)
+    )
+    mock_ledger.get_schema.return_value = TEST_SCHEMA_DATA
+    mock_deserialize.side_effect = TypeError("Bad data")  # Simulate deserialize failure
+
+    with pytest.raises(TypeError, match="Bad data"):
+        await schema_storage_service.add_item(profile, TEST_SCHEMA_ID)
+
+    mock_deserialize.assert_called_once()
+    # Ensure save wasn't called
+    profile.session.assert_called_once()  # Only called for inject
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.read_item",
+    new_callable=AsyncMock,
+)
+@patch("traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.deserialize")
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.IndyLedgerRequestsExecutor",
+    autospec=True,
+)
+async def test_add_item_save_error(
+    MockExecutorCls: MagicMock,
+    mock_deserialize: MagicMock,
+    mock_read_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_ledger: AsyncMock,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test add_item with a storage save error."""
+    profile, session = mock_profile
+    mock_read_item.return_value = None
+    session.inject_or.return_value = None
+    mock_executor_instance = AsyncMock()
+    mock_executor_instance.get_ledger_for_identifier = AsyncMock(
+        return_value=(TEST_LEDGER_ID, mock_ledger)
+    )
+
+    session.inject.return_value = mock_executor_instance
+    MockExecutorCls.return_value = mock_executor_instance  # Instance from class mock
+    mock_ledger.get_schema.return_value = TEST_SCHEMA_DATA
+    mock_deserialize.return_value = mock_schema_storage_record
+
+    mock_schema_storage_record.save.side_effect = StorageError("DB write failed")
+
+    with pytest.raises(StorageError, match="DB write failed"):
+        await schema_storage_service.add_item(profile, TEST_SCHEMA_ID)
+
+    mock_deserialize.assert_called_once()
+    mock_schema_storage_record.save.assert_awaited_once()
+
+
+# --- remove_item tests ---
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_remove_item_success(
+    mock_retrieve: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test successfully removing an item."""
+    profile, session = mock_profile
+    # Simulate retrieve succeeding first, then failing after delete
+    mock_retrieve.side_effect = [
+        mock_schema_storage_record,
+        StorageNotFoundError("Not found after delete"),
+    ]
+
+    result = await schema_storage_service.remove_item(profile, TEST_SCHEMA_ID)
+
+    assert result is True
+    profile.session.assert_called_once()  # Only one session context used
+    # Check retrieve was called twice
+    assert mock_retrieve.await_count == 2
+    mock_retrieve.assert_has_awaits(
+        [call(session, TEST_SCHEMA_ID), call(session, TEST_SCHEMA_ID)]
+    )
+    mock_schema_storage_record.delete_record.assert_awaited_once_with(session)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_remove_item_already_gone(
+    mock_retrieve: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+):
+    """Test removing an item that is already not found."""
+    profile, session = mock_profile
+    mock_retrieve.side_effect = StorageNotFoundError("Record not found")
+
+    result = await schema_storage_service.remove_item(profile, TEST_SCHEMA_ID)
+
+    assert result is True  # Still returns True
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_SCHEMA_ID)
+
+
+@pytest.mark.skip("TODO: for some reason remove_by_id is never awaited")
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.models.SchemaStorageRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+async def test_remove_item_delete_error(
+    mock_retrieve: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test error during delete_record when removing."""
+    profile, session = mock_profile
+    mock_retrieve.return_value = mock_schema_storage_record
+    mock_schema_storage_record.delete_record.side_effect = StorageError(
+        "DB write failed"
+    )
+
+    # Service catches the error and returns False
+    result = await schema_storage_service.remove_item(profile, TEST_SCHEMA_ID)
+
+    assert result is False
+    profile.session.assert_called_once()
+    mock_retrieve.assert_awaited_once_with(session, TEST_SCHEMA_ID)
+    mock_schema_storage_record.delete_record.assert_awaited_once_with(session)
+
+
+# --- sync_created tests ---
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.add_item",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.list_items",
+    new_callable=AsyncMock,
+)
+@pytest.mark.skip(
+    "TODO: AttributeError: 'coroutine' object has no attribute 'find_all_records'"
+)
+async def test_sync_created_success(
+    mock_list_items: AsyncMock,
+    mock_add_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test sync_created successfully adds found schemas."""
+    mock_storage = MagicMock(spec=BaseStorage)
+    profile, session = mock_profile
+    profile.session = AsyncMock(return_value=session)
+
+    schema_id_1 = "schema-id-1"
+    schema_id_2 = "schema-id-2"
+    mock_record_1 = MagicMock(spec=BaseRecord, value=schema_id_1)
+    mock_record_2 = MagicMock(spec=BaseRecord, value=schema_id_2)
+    mock_storage.find_all_records.return_value = [mock_record_1, mock_record_2]
+    mock_list_items.return_value = [mock_schema_storage_record]  # Final list result
+
+    session.inject.return_value = mock_storage
+    result = await schema_storage_service.sync_created(profile)
+
+    assert result == [mock_schema_storage_record]
+    # Check session usage
+    assert profile.session.await_count == 1  # Used for find_all_records
+    session.inject.assert_called_once_with(BaseStorage)
+    mock_storage.find_all_records.assert_awaited_once_with(
+        type_filter=ANY,  # Check for SCHEMA_SENT_RECORD_TYPE
+        tag_query={},
+    )
+    # Check add_item calls
+    assert mock_add_item.await_count == 2
+    mock_add_item.assert_has_awaits(
+        [
+            call(profile, schema_id_1),
+            call(profile, schema_id_2),
+        ]
+    )
+    # Check final list call
+    mock_list_items.assert_awaited_once_with(profile)
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.add_item",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.schema_storage.schema_storage_service.SchemaStorageService.list_items",
+    new_callable=AsyncMock,
+)
+@pytest.mark.skip("TODO: 'coroutine' object has no attribute 'find_all_records'")
+async def test_sync_created_no_schemas_found(
+    mock_list_items: AsyncMock,
+    mock_add_item: AsyncMock,
+    schema_storage_service: SchemaStorageService,
+    mock_profile: tuple[MagicMock, AsyncMock],
+):
+    """Test sync_created when no schema_sent records are found."""
+    mock_storage = MagicMock(spec=BaseStorage)
+    profile, session = mock_profile
+    profile.session = AsyncMock(return_value=session)
+    mock_storage.find_all_records.return_value = []  # No records found
+    mock_list_items.return_value = []  # Final list is empty
+    session.inject.return_value = mock_storage
+
+    result = await schema_storage_service.sync_created(profile)
+
+    assert result == []
+    session.inject.assert_called_once_with(BaseStorage)
+    mock_storage.find_all_records.assert_awaited_once()
+    mock_add_item.assert_not_awaited()  # add_item should not be called
+    mock_list_items.assert_awaited_once_with(profile)
+
+
+# --- Global Function Tests ---
+
+
+def test_subscribe(mock_event_bus: MagicMock):
+    """Test the subscribe function registers the handler."""
+    subscribe(mock_event_bus)
+    mock_event_bus.subscribe.assert_called_once_with(
+        SCHEMAS_EVENT_LISTENER_PATTERN, schemas_event_handler
+    )
+
+
+@pytest.mark.asyncio
+async def test_schemas_event_handler(
+    mock_profile: tuple,
+    schema_storage_service: SchemaStorageService,  # Use fixture
+    mock_event: MagicMock,
+    mock_schema_storage_record: AsyncMock,
+):
+    """Test the schemas_event_handler function."""
+    profile, _ = mock_profile
+    # Mock profile.inject to return our service instance
+    profile.inject.return_value = schema_storage_service
+    # Mock the service's add_item method specifically for this test
+    schema_storage_service.add_item = AsyncMock(return_value=mock_schema_storage_record)
+
+    await schemas_event_handler(profile, mock_event)
+
+    profile.inject.assert_called_once_with(SchemaStorageService)
+    schema_storage_service.add_item.assert_awaited_once_with(profile, TEST_SCHEMA_ID)

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_tenant_manager.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_tenant_manager.py
@@ -1,5 +1,5 @@
 import logging
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock, AsyncMock, patch, call
 import pytest
 
 # Assuming tenant_manager.py is in ../innkeeper relative to this test file
@@ -8,6 +8,8 @@ from traction_innkeeper.v1_0.innkeeper.tenant_manager import TenantManager
 # Import classes that need mocking or inspection
 from traction_innkeeper.v1_0.innkeeper.models import (
     TenantRecord,
+    ReservationRecord,
+    TenantAuthenticationApiRecord,
 )  # noqa F401 mocked
 from traction_innkeeper.v1_0.innkeeper.config import (
     TractionInnkeeperConfig,
@@ -57,6 +59,33 @@ def mock_traction_config(mock_innkeeper_wallet_config, mock_reservation_config):
     config.innkeeper_wallet = mock_innkeeper_wallet_config
     config.reservation = mock_reservation_config
     return config
+
+
+@pytest.fixture
+def mock_bcrypt(mocker):
+    """Mocks bcrypt functions."""
+    # Use mocker fixture provided by pytest-mock
+    mocked_bcrypt = mocker.patch(
+        "traction_innkeeper.v1_0.innkeeper.tenant_manager.bcrypt", autospec=True
+    )
+    return mocked_bcrypt
+
+
+@pytest.fixture
+def mock_tenant_rec():
+    """Mocks bcrypt functions."""
+    # Use mocker fixture provided by pytest-mock
+    mock_tenant_rec = MagicMock(spec=TenantRecord)
+    mock_tenant_rec.wallet_id = "existing_wallet_id"
+    mock_tenant_rec.tenant_name = "test_tenant"
+    mock_tenant_rec.connected_to_endorsers = True
+    mock_tenant_rec.tenant_id = None
+    mock_tenant_rec.wallet_name = None
+    mock_tenant_rec.connected_to_endorsers = None
+    mock_tenant_rec.created_public_did = None
+    mock_tenant_rec.auto_issuer = None
+    mock_tenant_rec.enable_ledger_switch = None
+    return mock_tenant_rec
 
 
 # --- Base Fixtures ---
@@ -352,3 +381,596 @@ async def test_get_wallet_and_tenant_tenant_not_found(
     mock_query_by_wallet_id.assert_awaited_once_with(session, wallet_id)
     assert result_wallet == mock_wallet_rec
     assert result_tenant is None  # Expect None when tenant query returns nothing
+
+
+@pytest.mark.asyncio
+async def test_get_token_success(
+    tenant_manager: TenantManager,
+    mock_multitenant_mgr: AsyncMock,
+):
+    """Test get_token successfully retrieves a token."""
+    mock_wallet_record = MagicMock(spec=WalletRecord, wallet_name="test-wallet")
+    wallet_key = "test_key"
+    expected_token = "mock_auth_token_123"
+    mock_multitenant_mgr.create_auth_token = AsyncMock(return_value=expected_token)
+
+    token = await tenant_manager.get_token(mock_wallet_record, wallet_key)
+
+    assert token == expected_token
+    mock_multitenant_mgr.create_auth_token.assert_awaited_once_with(
+        mock_wallet_record, wallet_key
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_token_failure(
+    tenant_manager: TenantManager,
+    mock_multitenant_mgr: AsyncMock,
+):
+    """Test get_token handles BaseError during token creation."""
+    from acapy_agent.core.error import BaseError  # Import locally if needed
+
+    mock_wallet_record = MagicMock(spec=WalletRecord, wallet_name="test-wallet")
+    wallet_key = "test_key"
+    mock_multitenant_mgr.create_auth_token = AsyncMock(
+        side_effect=BaseError("Token generation failed")
+    )
+
+    with pytest.raises(BaseError, match="Token generation failed"):
+        await tenant_manager.get_token(mock_wallet_record, wallet_key)
+
+    mock_multitenant_mgr.create_auth_token.assert_awaited_once_with(
+        mock_wallet_record, wallet_key
+    )
+
+
+# --- Tests for check_tables_for_wallet_name ---
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.innkeeper.tenant_manager.WalletRecord.query",
+    new_callable=AsyncMock,
+)
+async def test_check_tables_for_wallet_name_exists(
+    mock_wallet_query: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_profile,
+):
+    """Test check_tables_for_wallet_name when wallet exists."""
+    profile, session = mock_profile
+    wallet_name = "existing-wallet"
+    mock_wallet_query.return_value = [MagicMock()]  # Return a list with one item
+
+    exists = await tenant_manager.check_tables_for_wallet_name(session, wallet_name)
+
+    assert exists is True
+    mock_wallet_query.assert_awaited_once_with(session, {"wallet_name": wallet_name})
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.innkeeper.tenant_manager.WalletRecord.query",
+    new_callable=AsyncMock,
+)
+async def test_check_tables_for_wallet_name_not_exists(
+    mock_wallet_query: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_profile,
+):
+    """Test check_tables_for_wallet_name when wallet does not exist."""
+    profile, session = mock_profile
+    wallet_name = "new-wallet"
+    mock_wallet_query.return_value = []  # Return an empty list
+
+    exists = await tenant_manager.check_tables_for_wallet_name(session, wallet_name)
+
+    assert exists is False
+    mock_wallet_query.assert_awaited_once_with(session, {"wallet_name": wallet_name})
+
+
+# --- Tests for get_unique_wallet_name ---
+
+
+@pytest.mark.asyncio
+@patch.object(TenantManager, "check_tables_for_wallet_name", new_callable=AsyncMock)
+async def test_get_unique_wallet_name_already_unique(
+    mock_check_tables: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_profile,
+):
+    """Test get_unique_wallet_name when the name is already unique."""
+    profile, session = mock_profile
+    wallet_name = "unique-wallet"
+    mock_check_tables.return_value = False  # Name is unique
+
+    unique_name = await tenant_manager.get_unique_wallet_name(wallet_name)
+
+    assert unique_name == wallet_name
+    mock_check_tables.assert_awaited_once_with(session, wallet_name)
+
+
+@pytest.mark.asyncio
+@patch.object(TenantManager, "check_tables_for_wallet_name", new_callable=AsyncMock)
+async def test_get_unique_wallet_name_needs_one_suffix(
+    mock_check_tables: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_profile,
+):
+    """Test get_unique_wallet_name when one suffix is needed."""
+    profile, session = mock_profile
+    wallet_name = "taken-wallet"
+    # Simulate: 'taken-wallet' exists, 'taken-wallet-1' does not
+    mock_check_tables.side_effect = [True, False]
+
+    unique_name = await tenant_manager.get_unique_wallet_name(wallet_name)
+
+    assert unique_name == f"{wallet_name}-1"
+    assert mock_check_tables.await_count == 2
+    mock_check_tables.assert_has_awaits(
+        [
+            call(session, wallet_name),
+            call(session, f"{wallet_name}-1"),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(TenantManager, "check_tables_for_wallet_name", new_callable=AsyncMock)
+async def test_get_unique_wallet_name_needs_multiple_suffixes(
+    mock_check_tables: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_profile,
+):
+    """Test get_unique_wallet_name when multiple suffixes are needed."""
+    profile, session = mock_profile
+    wallet_name = "very-taken-wallet"
+    # Simulate: 'very-taken-wallet' exists, 'very-taken-wallet-1' exists, 'very-taken-wallet-1-2' does not
+    mock_check_tables.side_effect = [True, True, False]
+
+    unique_name = await tenant_manager.get_unique_wallet_name(wallet_name)
+
+    # Note: The loop logic adds '-1', then '-1-2', etc.
+    assert unique_name == f"{wallet_name}-1-2"
+    assert mock_check_tables.await_count == 3
+    mock_check_tables.assert_has_awaits(
+        [
+            call(session, wallet_name),
+            call(session, f"{wallet_name}-1"),
+            call(session, f"{wallet_name}-1-2"),
+        ]
+    )
+
+
+# --- Tests for check_reservation_password ---
+
+
+def test_check_reservation_password_null_input(
+    tenant_manager: TenantManager, mock_bcrypt
+):
+    """Test check_reservation_password with null inputs."""
+    mock_reservation = MagicMock(spec=ReservationRecord)
+    assert tenant_manager.check_reservation_password(None, mock_reservation) is None
+    assert tenant_manager.check_reservation_password("pwd", None) is None
+    mock_bcrypt.hashpw.assert_not_called()
+    mock_bcrypt.checkpw.assert_not_called()
+
+
+def test_check_reservation_password_correct(tenant_manager: TenantManager, mock_bcrypt):
+    """Test check_reservation_password with correct password."""
+    pwd = "correct_password"
+    salt = b"salt_value"
+    hash_val = b"hashed_password_value"
+    mock_reservation = MagicMock(
+        spec=ReservationRecord,
+        reservation_token_salt=salt.decode(),
+        reservation_token_hash=hash_val.decode(),
+    )
+    # Make hashpw return something deterministic based on input pwd and salt
+    mock_bcrypt.hashpw.return_value = hash_val
+    # Make checkpw return True (indicating match)
+    mock_bcrypt.checkpw.return_value = True
+
+    # Expected token is the *re-hashed* password using the salt
+    expected_token = hash_val.decode()
+    result_token = tenant_manager.check_reservation_password(pwd, mock_reservation)
+
+    assert result_token == expected_token
+    mock_bcrypt.hashpw.assert_called_once_with(pwd.encode("utf-8"), salt)
+    # checkpw is called twice in the function
+    assert mock_bcrypt.checkpw.call_count == 2
+    mock_bcrypt.checkpw.assert_has_calls(
+        [
+            call(pwd.encode("utf-8"), hash_val),  # Check against re-hashed
+            call(pwd.encode("utf-8"), hash_val),  # Check against stored hash
+        ]
+    )
+
+
+def test_check_reservation_password_incorrect(
+    tenant_manager: TenantManager, mock_bcrypt
+):
+    """Test check_reservation_password with incorrect password."""
+    pwd = "wrong_password"
+    salt = b"salt_value"
+    correct_hash = b"correct_hashed_password"
+    wrong_hash = b"wrong_hashed_password"  # What hashpw returns for wrong pwd
+    mock_reservation = MagicMock(
+        spec=ReservationRecord,
+        reservation_token_salt=salt.decode(),
+        reservation_token_hash=correct_hash.decode(),
+    )
+    mock_bcrypt.hashpw.return_value = wrong_hash
+    # Simulate checkpw failing on one or both checks
+    mock_bcrypt.checkpw.side_effect = [False, False]  # Fails both checks
+
+    result_token = tenant_manager.check_reservation_password(pwd, mock_reservation)
+
+    assert result_token is None
+    mock_bcrypt.hashpw.assert_called_once_with(pwd.encode("utf-8"), salt)
+    assert mock_bcrypt.checkpw.call_count == 2
+    mock_bcrypt.checkpw.assert_has_calls(
+        [
+            call(pwd.encode("utf-8"), wrong_hash),  # Check against re-hashed (fails)
+            call(
+                pwd.encode("utf-8"), correct_hash
+            ),  # Check against stored hash (fails)
+        ]
+    )
+
+
+# --- Tests for check_api_key --- (Similar structure to password check)
+
+
+def test_check_api_key_null_input(tenant_manager: TenantManager, mock_bcrypt):
+    """Test check_api_key with null inputs."""
+    mock_api_rec = MagicMock(spec=TenantAuthenticationApiRecord)
+    assert tenant_manager.check_api_key(None, mock_api_rec) is None
+    assert tenant_manager.check_api_key("key", None) is None
+    mock_bcrypt.hashpw.assert_not_called()
+    mock_bcrypt.checkpw.assert_not_called()
+
+
+def test_check_api_key_correct(tenant_manager: TenantManager, mock_bcrypt):
+    """Test check_api_key with correct API key."""
+    api_key = "correct_api_key"
+    salt = b"api_salt_value"
+    hash_val = b"hashed_api_key_value"
+    mock_api_rec = MagicMock(
+        spec=TenantAuthenticationApiRecord,
+        api_key_token_salt=salt.decode(),
+        api_key_token_hash=hash_val.decode(),
+    )
+    mock_bcrypt.hashpw.return_value = hash_val
+    mock_bcrypt.checkpw.return_value = True
+
+    expected_token = hash_val.decode()
+    result_token = tenant_manager.check_api_key(api_key, mock_api_rec)
+
+    assert result_token == expected_token
+    mock_bcrypt.hashpw.assert_called_once_with(api_key.encode("utf-8"), salt)
+    assert mock_bcrypt.checkpw.call_count == 2
+
+
+def test_check_api_key_incorrect(tenant_manager: TenantManager, mock_bcrypt):
+    """Test check_api_key with incorrect API key."""
+    api_key = "wrong_api_key"
+    salt = b"api_salt_value"
+    correct_hash = b"correct_hashed_api_key"
+    wrong_hash = b"wrong_hashed_api_key"
+    mock_api_rec = MagicMock(
+        spec=TenantAuthenticationApiRecord,
+        api_key_token_salt=salt.decode(),
+        api_key_token_hash=correct_hash.decode(),
+    )
+    mock_bcrypt.hashpw.return_value = wrong_hash
+    mock_bcrypt.checkpw.side_effect = [False, False]
+
+    result_token = tenant_manager.check_api_key(api_key, mock_api_rec)
+
+    assert result_token is None
+    mock_bcrypt.hashpw.assert_called_once_with(api_key.encode("utf-8"), salt)
+    assert mock_bcrypt.checkpw.call_count == 2
+
+
+# --- Tests for create_wallet Error Paths and Options ---
+
+
+@pytest.mark.asyncio
+@patch.object(TenantManager, "get_unique_wallet_name", new_callable=AsyncMock)
+async def test_create_wallet_multitenant_error(
+    mock_get_unique_wallet_name: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_multitenant_mgr: AsyncMock,
+    mock_profile,
+):
+    """Test create_wallet failure during multitenant.create_wallet."""
+    from acapy_agent.core.error import BaseError  # Import locally if needed
+
+    profile, _ = mock_profile
+    unique_wallet_name = "UniqueName"
+    mock_get_unique_wallet_name.return_value = unique_wallet_name
+    mock_multitenant_mgr.create_wallet = AsyncMock(
+        side_effect=BaseError("Wallet creation failed")
+    )
+
+    with pytest.raises(BaseError, match="Wallet creation failed"):
+        await tenant_manager.create_wallet(
+            wallet_name="Test Wallet",
+            wallet_key="key",
+            tenant_email="email@test.com",
+        )
+
+    mock_get_unique_wallet_name.assert_awaited_once_with("Test Wallet")
+    mock_multitenant_mgr.create_wallet.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch.object(TenantManager, "get_unique_wallet_name", new_callable=AsyncMock)
+@patch.object(TenantManager, "get_token", new_callable=AsyncMock)
+@patch.object(TenantManager, "create_tenant", new_callable=AsyncMock)
+async def test_create_wallet_get_token_error(
+    mock_create_tenant: AsyncMock,
+    mock_get_token: AsyncMock,
+    mock_get_unique_wallet_name: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_multitenant_mgr: AsyncMock,
+    mock_profile,
+):
+    """Test create_wallet failure during get_token."""
+    from acapy_agent.core.error import BaseError  # Import locally if needed
+
+    profile, _ = mock_profile
+    unique_wallet_name = "UniqueName"
+    mock_get_unique_wallet_name.return_value = unique_wallet_name
+    mock_wallet_record = MagicMock(spec=WalletRecord)
+    mock_multitenant_mgr.create_wallet = AsyncMock(return_value=mock_wallet_record)
+    mock_get_token.side_effect = BaseError("Get token failed")
+
+    with pytest.raises(BaseError, match="Get token failed"):
+        await tenant_manager.create_wallet(
+            wallet_name="Test Wallet",
+            wallet_key="key",
+            tenant_email="email@test.com",
+        )
+
+    mock_get_unique_wallet_name.assert_awaited_once()
+    mock_multitenant_mgr.create_wallet.assert_awaited_once()
+    mock_get_token.assert_awaited_once()
+    mock_create_tenant.assert_not_awaited()  # Should fail before creating tenant
+
+
+@pytest.mark.asyncio
+@patch.object(TenantManager, "get_unique_wallet_name", new_callable=AsyncMock)
+@patch.object(TenantManager, "get_token", new_callable=AsyncMock)
+@patch.object(TenantManager, "create_tenant", new_callable=AsyncMock)
+async def test_create_wallet_with_extra_settings(
+    mock_create_tenant: AsyncMock,
+    mock_get_token: AsyncMock,
+    mock_get_unique_wallet_name: AsyncMock,
+    tenant_manager: TenantManager,
+    mock_multitenant_mgr: AsyncMock,
+    mock_profile,
+):
+    """Test create_wallet successfully handles extra_settings override."""
+    profile, _ = mock_profile
+    wallet_name = "Test Wallet"
+    wallet_key = "test_key"
+    tenant_email = "tenant@test.com"
+    unique_wallet_name = "Test-Wallet-Unique"
+    mock_token = "mock_auth_token"
+    tenant_id = "extra-settings-tenant-id"
+
+    # Custom settings to override config
+    extra_connect_endorser = [{"endpoint": "http://extra.endorser"}]
+    extra_public_did = [{"did": "did:sov:extra123"}]
+    extra_auto_issuer = True  # Override config default (False)
+    extra_ledger_switch = True  # Override config default (False)
+    extra_wallet_setting = {"custom_key": "custom_value"}
+
+    extra_settings = {
+        "tenant.endorser_config": extra_connect_endorser,
+        "tenant.public_did_config": extra_public_did,
+        "tenant.auto_issuer": extra_auto_issuer,
+        "tenant.enable_ledger_switch": extra_ledger_switch,
+        **extra_wallet_setting,
+    }
+
+    # Setup mocks
+    mock_get_unique_wallet_name.return_value = unique_wallet_name
+    mock_wallet_record = MagicMock(spec=WalletRecord, wallet_id="new-wallet-id")
+    mock_multitenant_mgr.create_wallet = AsyncMock(return_value=mock_wallet_record)
+    mock_get_token.return_value = mock_token
+    mock_tenant_record = MagicMock(spec=TenantRecord, tenant_id=tenant_id)
+    mock_create_tenant.return_value = mock_tenant_record
+
+    await tenant_manager.create_wallet(
+        wallet_name=wallet_name,
+        wallet_key=wallet_key,
+        tenant_email=tenant_email,
+        extra_settings=extra_settings,
+        tenant_id=tenant_id,
+    )
+
+    # Assert multitenant_mgr.create_wallet received extra wallet settings
+    mock_multitenant_mgr.create_wallet.assert_awaited_once()
+    call_args, _ = mock_multitenant_mgr.create_wallet.call_args
+    passed_settings = call_args[0]
+    assert passed_settings["custom_key"] == "custom_value"
+
+    # Assert create_tenant received overridden values
+    mock_create_tenant.assert_awaited_once_with(
+        wallet_id=mock_wallet_record.wallet_id,
+        email=tenant_email,
+        tenant_id=tenant_id,
+        connected_to_endorsers=extra_connect_endorser,  # Overridden
+        created_public_did=extra_public_did,  # Overridden
+        auto_issuer=extra_auto_issuer,  # Overridden
+        enable_ledger_switch=extra_ledger_switch,  # Overridden
+    )
+
+
+# --- Tests for create_tenant Edge Cases ---
+
+
+@pytest.mark.asyncio
+@patch("traction_innkeeper.v1_0.innkeeper.tenant_manager.WalletRecord", autospec=True)
+@patch("traction_innkeeper.v1_0.innkeeper.tenant_manager.TenantRecord", autospec=True)
+async def test_create_tenant_label_fallback(
+    MockTenantRecord: MagicMock,
+    MockWalletRecord: MagicMock,
+    tenant_manager: TenantManager,
+    mock_profile,
+):
+    """Test create_tenant uses wallet_name if default_label is missing."""
+    profile, session = mock_profile
+    wallet_id = "test-wallet-id"
+    tenant_email = "test@example.com"
+    wallet_name = "ActualWalletName"  # The underlying name
+
+    # Setup mock WalletRecord without default_label in settings
+    mock_wallet_rec_instance = MagicMock(spec=WalletRecord)
+    mock_wallet_rec_instance.wallet_id = wallet_id
+    mock_wallet_rec_instance.wallet_name = wallet_name
+    mock_wallet_rec_instance.settings = {}  # Empty settings, no default_label
+    MockWalletRecord.retrieve_by_id = AsyncMock(return_value=mock_wallet_rec_instance)
+
+    mock_tenant_rec_instance = AsyncMock(spec=TenantRecord)
+    MockTenantRecord.return_value = mock_tenant_rec_instance
+
+    await tenant_manager.create_tenant(
+        wallet_id=wallet_id,
+        email=tenant_email,
+    )
+
+    # Assert TenantRecord called with wallet_name as tenant_name
+    MockTenantRecord.assert_called_once_with(
+        tenant_id=None,  # Default
+        tenant_name=wallet_name,  # <<< Should fallback to wallet_name
+        contact_email=tenant_email,
+        wallet_id=wallet_id,
+        new_with_id=False,
+        connected_to_endorsers=[],
+        created_public_did=[],
+        enable_ledger_switch=False,
+        auto_issuer=False,
+    )
+    mock_tenant_rec_instance.save.assert_awaited_once()
+
+
+# --- Tests for create_innkeeper ---
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.innkeeper.tenant_manager.TenantRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.innkeeper.tenant_manager.WalletRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+@patch.object(TenantManager, "get_token", new_callable=AsyncMock)
+@patch.object(TenantManager, "create_wallet", new_callable=AsyncMock)
+@patch("builtins.print")  # Mock print to avoid polluting test output
+async def test_create_innkeeper_exists(
+    mock_print: MagicMock,
+    mock_create_wallet: AsyncMock,
+    mock_get_token: AsyncMock,
+    mock_wallet_retrieve: AsyncMock,
+    mock_tenant_retrieve: AsyncMock,
+    mock_tenant_rec: MagicMock,
+    tenant_manager: TenantManager,  # Uses the fixture with mocked config
+    mock_traction_config: MagicMock,
+    mock_profile,
+):
+    """Test create_innkeeper when the innkeeper tenant/wallet already exist."""
+    profile, session = mock_profile
+    config = mock_traction_config.innkeeper_wallet
+    tenant_id = config.tenant_id
+    wallet_key = config.wallet_key
+    expected_token = "existing_token"
+
+    mock_wallet_rec = MagicMock(
+        spec=WalletRecord,
+        wallet_id="existing_wallet_id",
+        wallet_name=config.wallet_name,
+    )
+    mock_tenant_retrieve.return_value = mock_tenant_rec
+    mock_wallet_retrieve.return_value = mock_wallet_rec
+    mock_get_token.return_value = expected_token
+
+    await tenant_manager.create_innkeeper()
+
+    mock_tenant_retrieve.assert_awaited_once_with(session, tenant_id)
+    mock_wallet_retrieve.assert_awaited_once_with(session, "existing_wallet_id")
+    mock_get_token.assert_awaited_once_with(mock_wallet_rec, wallet_key)
+    mock_create_wallet.assert_not_awaited()  # Should not create wallet
+    assert mock_print.call_count > 5  # Check that info was printed
+
+
+@pytest.mark.asyncio
+@patch(
+    "traction_innkeeper.v1_0.innkeeper.tenant_manager.TenantRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+@patch(
+    "traction_innkeeper.v1_0.innkeeper.tenant_manager.WalletRecord.retrieve_by_id",
+    new_callable=AsyncMock,
+)
+@patch.object(TenantManager, "get_token", new_callable=AsyncMock)
+@patch.object(TenantManager, "create_wallet", new_callable=AsyncMock)
+@patch("builtins.print")  # Mock print
+async def test_create_innkeeper_does_not_exist(
+    mock_print: MagicMock,
+    mock_create_wallet: AsyncMock,
+    mock_get_token: AsyncMock,  # This mock won't be called directly
+    mock_wallet_retrieve: AsyncMock,
+    mock_tenant_retrieve: AsyncMock,
+    mock_tenant_rec: MagicMock,
+    tenant_manager: TenantManager,
+    mock_traction_config: MagicMock,
+    mock_profile,
+):
+    """Test create_innkeeper when the innkeeper needs to be created."""
+    from acapy_agent.storage.error import StorageNotFoundError  # Import locally
+
+    profile, session = mock_profile
+    config = mock_traction_config.innkeeper_wallet
+    res_config = mock_traction_config.reservation
+    tenant_id = config.tenant_id
+    wallet_name = config.wallet_name
+    wallet_key = config.wallet_key
+    expected_token = "newly_created_token"
+
+    # Simulate retrieval failure
+    mock_tenant_retrieve.side_effect = StorageNotFoundError("Tenant not found")
+    # Wallet retrieve won't be called if tenant retrieve fails
+
+    # Mock create_wallet return values
+    mock_tenant_rec.tenant_id = tenant_id
+    mock_tenant_rec.wallet_id = "new_wallet_id"
+    mock_wallet_rec = MagicMock(
+        spec=WalletRecord, wallet_id="new_wallet_id", wallet_name=wallet_name
+    )
+    mock_create_wallet.return_value = (mock_tenant_rec, mock_wallet_rec, expected_token)
+
+    await tenant_manager.create_innkeeper()
+
+    mock_tenant_retrieve.assert_awaited_once_with(session, tenant_id)
+    mock_wallet_retrieve.assert_not_awaited()  # Not called because tenant failed
+    mock_get_token.assert_not_awaited()  # Not called directly, part of create_wallet mock
+    # Check create_wallet was called with correct args from config
+    mock_create_wallet.assert_awaited_once_with(
+        wallet_name,
+        wallet_key,
+        None,  # Innkeeper has no email in this flow
+        {  # Extra settings expected for innkeeper
+            "wallet.innkeeper": True,
+            "tenant.endorser_config": config.connect_to_endorser,
+            "tenant.public_did_config": config.create_public_did,
+            "tenant.auto_issuer": res_config.auto_issuer,
+        },
+        tenant_id,
+    )
+    assert mock_print.call_count > 5  # Check that info was printed


### PR DESCRIPTION
This PR resolves #1568

Currently 3 tests are skipped and should be implemented at a later time. As the coverage report below shows we have surpassed 90% coverage which I would consider enough to look into merging this.

In addition to the new tests I have also added coverage to the test output. With this new coverage feature I have added an option to fail the tests when test coverage falls below 90%. We may want to make this more flexible if changes to the plugin becomes more common. For now a strict 90% seems feasible to maintain.

```
____________________________________________________________ coverage: platform linux, python 3.13.3-final-0 _____________________________________________________________

Name                                                                 Stmts   Miss  Cover
----------------------------------------------------------------------------------------
traction_innkeeper/__init__.py                                           0      0   100%
traction_innkeeper/v1_0/__init__.py                                     25     16    36%
traction_innkeeper/v1_0/connections/__init__.py                         18     11    39%
traction_innkeeper/v1_0/connections/routes.py                           61      6    90%
traction_innkeeper/v1_0/creddef_storage/__init__.py                     22     14    36%
traction_innkeeper/v1_0/creddef_storage/creddef_storage_service.py      78      1    99%
traction_innkeeper/v1_0/creddef_storage/models.py                       31      7    77%
traction_innkeeper/v1_0/creddef_storage/routes.py                       79      3    96%
traction_innkeeper/v1_0/endorser/__init__.py                            22     14    36%
traction_innkeeper/v1_0/endorser/endorser_connection_service.py         98      0   100%
traction_innkeeper/v1_0/endorser/routes.py                              84      1    99%
traction_innkeeper/v1_0/innkeeper/__init__.py                           35     20    43%
traction_innkeeper/v1_0/innkeeper/config.py                             75     31    59%
traction_innkeeper/v1_0/innkeeper/models.py                            184     74    60%
traction_innkeeper/v1_0/innkeeper/routes.py                            551    127    77%
traction_innkeeper/v1_0/innkeeper/tenant_manager.py                    165      2    99%
traction_innkeeper/v1_0/innkeeper/utils.py                              89      0   100%
traction_innkeeper/v1_0/oca/__init__.py                                 40     27    32%
traction_innkeeper/v1_0/oca/models.py                                   33      8    76%
traction_innkeeper/v1_0/oca/oca_service.py                             173      5    97%
traction_innkeeper/v1_0/oca/routes.py                                  116      0   100%
traction_innkeeper/v1_0/schema_storage/__init__.py                      22     14    36%
traction_innkeeper/v1_0/schema_storage/models.py                        29      6    79%
traction_innkeeper/v1_0/schema_storage/routes.py                       104      0   100%
traction_innkeeper/v1_0/schema_storage/schema_storage_service.py       113     14    88%
traction_innkeeper/v1_0/tenant/__init__.py                              46     31    33%
traction_innkeeper/v1_0/tenant/holder_revocation_service.py             60      0   100%
traction_innkeeper/v1_0/tenant/routes.py                               308     50    84%
traction_innkeeper/v1_0/tests/test_connections_routes.py               161      5    97%
traction_innkeeper/v1_0/tests/test_creddef_storage_routes.py           196      8    96%
traction_innkeeper/v1_0/tests/test_creddef_storage_service.py          185      0   100%
traction_innkeeper/v1_0/tests/test_endorser_connection_service.py      244      3    99%
traction_innkeeper/v1_0/tests/test_endorser_routes.py                  223      6    97%
traction_innkeeper/v1_0/tests/test_holder_revocation_service.py        152      0   100%
traction_innkeeper/v1_0/tests/test_innkeeper_routes.py                 474      4    99%
traction_innkeeper/v1_0/tests/test_innkeeper_util.py                   224      0   100%
traction_innkeeper/v1_0/tests/test_oca_routes.py                       264      8    97%
traction_innkeeper/v1_0/tests/test_oca_service.py                      385      0   100%
traction_innkeeper/v1_0/tests/test_schema_storage_routes.py            310      8    97%
traction_innkeeper/v1_0/tests/test_schema_storage_service.py           318     48    85%
traction_innkeeper/v1_0/tests/test_tenant_manager.py                   427      0   100%
traction_innkeeper/v1_0/tests/test_tenant_routes.py                    280      4    99%
----------------------------------------------------------------------------------------
TOTAL                                                                 6504    576    91%
```