### PR TITLE
Fix unique wallet name function

### DIFF
--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/tenant_manager.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/tenant_manager.py
@@ -268,13 +268,13 @@ class TenantManager:
 
     async def get_unique_wallet_name(self, wallet_name: str):
         self._logger.info(f"> get_unique_wallet_name('{wallet_name}')")
-        unique_wallet_name = wallet_name
+        unique_wallet_name = wallet_name.copy()
         async with self._profile.session() as session:
             w = await self.check_tables_for_wallet_name(session, unique_wallet_name)
             idx = 1
             while w:
                 self._logger.info(f"'{unique_wallet_name}': wallet_exists = {w}")
-                unique_wallet_name = f"{unique_wallet_name}-{idx}"
+                unique_wallet_name = f"{wallet_name}-{idx}"
                 w = await self.check_tables_for_wallet_name(session, unique_wallet_name)
                 idx += 1
         # return a unique wallet/tenant name, either the input or calculated...


### PR DESCRIPTION
There was a recursive index appended to the wallet name resulting in names such as:
`alice`
`alice-1`
`alice-1-2`
`alice-1-2-3`

This fix will ensure only the current loop index is affixed to the wallet name so we get:
`alice`
`alice-1`
`alice-2`
`alice-3`