### PR TITLE
feat(chart): update acapy chart, refactor helper and deployment to use exstisting secrets

### DIFF
--- a/charts/traction/Chart.yaml
+++ b/charts/traction/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traction
 description: The Traction service allows organizations to verify, hold, and issue verifiable credentials. The Traction Tenant UI allows tenants to manage their agent.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 1.2.0
 home: "https://github.com/bcgov/traction"
 sources: ["https://github.com/bcgov/traction"]
@@ -19,7 +19,7 @@ maintainers:
     url: https://github.com/loneil
 dependencies:
   - name: acapy
-    version: 0.2.0
+    version: 0.2.1
     repository: https://openwallet-foundation.github.io/helm-charts/
   - name: common
     repository: "https://charts.bitnami.com/bitnami"

--- a/charts/traction/README.md
+++ b/charts/traction/README.md
@@ -1,6 +1,6 @@
 # Traction
 
-![version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 The Traction service allows organizations to verify, hold, and issue verifiable credentials.
 
@@ -140,13 +140,22 @@ kubectl delete secret,pvc --selector "app.kubernetes.io/instance"=my-release
 
 ### ACA-Py common configurations
 
-| Name                              | Description                                    | Value   |
-| --------------------------------- | ---------------------------------------------- | ------- |
-| `acapy.resources.requests.memory` | The requested memory for the ACA-Py containers | `200Mi` |
-| `acapy.resources.requests.cpu`    | The requested cpu for the ACA-Py containers    | `120m`  |
-| `acapy.service.ports.http`        | Port to expose for http service                | `8021`  |
-| `acapy.service.ports.admin`       | Port to expose for admin service               | `8022`  |
-| `acapy.service.ports.ws`          | Port to expose for websocket service           | `8023`  |
+| Name                                         | Description                                                                                              | Value         |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------- |
+| `acapy.resources.requests.memory`            | The requested memory for the ACA-Py containers                                                           | `200Mi`       |
+| `acapy.resources.requests.cpu`               | The requested cpu for the ACA-Py containers                                                              | `120m`        |
+| `acapy.service.ports.http`                   | Port to expose for http service                                                                          | `8021`        |
+| `acapy.service.ports.admin`                  | Port to expose for admin service                                                                         | `8022`        |
+| `acapy.service.ports.ws`                     | Port to expose for websocket service                                                                     | `8023`        |
+| `acapy.secrets.api.retainOnUninstall`        | When true, adds helm.sh/resource-policy: keep to generated api secret                                    | `true`        |
+| `acapy.secrets.api.existingSecret`           | Name of an existing Secret providing API related keys. If set, the chart will NOT create the api secret. | `""`          |
+| `acapy.secrets.api.secretKeys.adminApiKey`   | Key in the API secret holding the admin API key.                                                         | `adminApiKey` |
+| `acapy.secrets.api.secretKeys.jwtKey`        | Key in the API secret holding the multitenant JWT signing secret.                                        | `jwt`         |
+| `acapy.secrets.api.secretKeys.walletKey`     | Key in the API secret holding the wallet key.                                                            | `walletKey`   |
+| `acapy.secrets.api.secretKeys.webhookapiKey` | Key in the API secret holding the webhook API key (used when embedding in webhook-url).                  | `webhookapi`  |
+| `acapy.secrets.seed.retainOnUninstall`       | When true, adds helm.sh/resource-policy: keep to generated seed secret                                   | `true`        |
+| `acapy.secrets.seed.existingSecret`          | Name of an existing Secret providing the wallet seed. If set, the chart will NOT create the seed secret. | `""`          |
+| `acapy.secrets.seed.secretKeys.seed`         | Key in the seed secret holding the wallet seed value.                                                    | `seed`        |
 
 ### ACA-Py NetworkPolicy parameters
 

--- a/charts/traction/templates/_helpers.tpl
+++ b/charts/traction/templates/_helpers.tpl
@@ -238,7 +238,11 @@ http://{{- template "traction.acapy.fullname" . }}:{{ .Values.acapy.service.port
 ACA-Py API secret name (for tenant proxy)
 */}}
 {{- define "traction.acapy.api.secretName" -}}
-{{- template "traction.acapy.fullname" . }}-api
+{{- if .Values.acapy.secrets.api.existingSecret -}}
+    {{- .Values.acapy.secrets.api.existingSecret -}}
+{{- else -}}
+    {{- printf "%s-api" (include "traction.acapy.fullname" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/traction/templates/proxy/deployment.yaml
+++ b/charts/traction/templates/proxy/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "traction.acapy.api.secretName" . }}
-                  key: adminApiKey
+                  key: {{ .Values.acapy.secrets.api.secretKeys.adminApiKey | default "adminApiKey" }}
             - name: ACAPY_ADMIN_URL
               value: {{ include "traction.acapy.internal.admin.url" . }}
           resources:

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -332,6 +332,30 @@ acapy:
       admin: 8022
       ws: 8023
 
+  ## @param acapy.secrets.api.retainOnUninstall When true, adds helm.sh/resource-policy: keep to generated api secret
+  ## @param acapy.secrets.api.existingSecret Name of an existing Secret providing API related keys. If set, the chart will NOT create the api secret.
+  ## @param acapy.secrets.api.secretKeys.adminApiKey Key in the API secret holding the admin API key.
+  ## @param acapy.secrets.api.secretKeys.jwtKey Key in the API secret holding the multitenant JWT signing secret.
+  ## @param acapy.secrets.api.secretKeys.walletKey Key in the API secret holding the wallet key.
+  ## @param acapy.secrets.api.secretKeys.webhookapiKey Key in the API secret holding the webhook API key (used when embedding in webhook-url).
+  ## @param acapy.secrets.seed.retainOnUninstall When true, adds helm.sh/resource-policy: keep to generated seed secret
+  ## @param acapy.secrets.seed.existingSecret Name of an existing Secret providing the wallet seed. If set, the chart will NOT create the seed secret.
+  ## @param acapy.secrets.seed.secretKeys.seed Key in the seed secret holding the wallet seed value.
+  secrets:
+    api:
+      retainOnUninstall: true
+      existingSecret: ""
+      secretKeys:
+        adminApiKey: adminApiKey
+        jwtKey: jwt
+        walletKey: walletKey
+        webhookapiKey: webhookapi
+    seed:
+      retainOnUninstall: true
+      existingSecret: ""
+      secretKeys:
+        seed: seed
+
   ## @section ACA-Py NetworkPolicy parameters
   ##
   networkPolicy:


### PR DESCRIPTION
- Updated acapy chart dependency to 0.2.1
- Refactored `traction.acapy.api.secretName` to support existingSecrets
- Refactored proxy deployment to support a custom secret key for the admin api key
- Update README, bump chart version to 0.4.1