### PR TITLE
feat(webvh-e2e): Indy BCovrin endorser and public DID setup profile

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ New functionality is being added daily, so stay tuned as the Tenant UI grows. Ke
 For tenants to perform all their Aca-Py calls, access is done through an NGINX proxy. This allows tenants to call most all endpoints found in Aca-Py Admin plus enhancements added through the Traction Plugins. This is the API your controllers and line of business apps will call. See [NGINX Template](../plugins/docker/tenant-proxy.conf.template)
 
 ### WebVH end-to-end harness
-Automated checks against the tenant proxy for **did:webvh** configuration and DID creation live under [webvh-e2e/](webvh-e2e/README.md) (see that README for env vars and phases).
+Automated checks against the tenant proxy for **did:webvh** configuration and DID creation live under [webvh-e2e/](webvh-e2e/README.md) (see that README for env vars and phases). The same harness includes an optional **Indy / BCovrin test** profile (`indy-bcovrin-e2e`, alias `indy-bcovrin-setup`) for ledger + endorser + public DID, anoncreds publish, DIDComm over the Indy public DID, and issue / verify / revoke (aligned with the Tenant UI Indy issuance flow).
 
 ## Caveats and Cautions
 

--- a/scripts/webvh-e2e/.env.example
+++ b/scripts/webvh-e2e/.env.example
@@ -6,3 +6,7 @@ TRACTION_HOLDER_TENANT_TOKEN=
 
 # Optional WebVH (see README for other variables)
 # WEBVH_CREATE_ALIAS=
+
+# Optional Indy / BCovrin test (profile indy-bcovrin-e2e or indy-bcovrin-setup)
+# E2E_INDY_WRITE_LEDGER_ID=bcovrin-test
+# E2E_INDY_REGISTER_NYM_ALIAS=

--- a/scripts/webvh-e2e/README.md
+++ b/scripts/webvh-e2e/README.md
@@ -4,7 +4,7 @@ This directory contains the Traction WebVH E2E harness entrypoint and phase regi
 
 Current runtime behavior:
 - working CLI (`run.py`)
-- profile/phase registry (`phases/smoke.py` liveness, `phases/webvh.py` WebVH configure/create, `phases/connect.py` OOB + DID Exchange, `phases/setup.py` AnonCreds schema/cred-def, issue/verify/revoke)
+- profile/phase registry (`phases/smoke.py` liveness, `phases/webvh.py` WebVH configure/create, `phases/connect.py` OOB + DID Exchange, `phases/setup.py` AnonCreds schema/cred-def, `phases/indy.py` Indy endorser + public DID on BCovrin test, issue/verify/revoke)
 - environment + token wiring
 - smoke phase (`GET /status/live`, `GET /tenant/wallet` for issuer and holder)
 - issuer wallet upgrade, WebVH configure, `webvh-create`, **AnonCreds schema + cred-def with revocation**, **DIDComm connection using public `did:webvh`**, **issue-credential-2.0**, **present-proof-2.0**, **revocation**, second proof expecting failure
@@ -17,7 +17,7 @@ Current runtime behavior:
 - `configure-webvh-plugin`: `GET /tenant/server/status/config` (controller defaults only), optional `WEBVH_WITNESS_INVITATION` or fetch `/api/invitations` on the WebVH server, `POST /did/webvh/configuration` (INFO logs the sanitized **request** body; full **responses** and other HTTP bodies only with `run.py -v` / debug logging). Merges stored `parameter_options` from `GET /did/webvh/configuration`; sets `witness_threshold` only when `WEBVH_WITNESS_THRESHOLD` is positive, and **drops** any merged `witness_threshold` when it is not (avoids echoing an old stored value)
 - `webvh-create`: `POST /did/webvh/create` with `options` (`namespace`, `identifier` for the path segment, **`didcomm: true`**, optional `witness_threshold` when env is positive, optional `server_url` from stored config or context). Default identifier is **8** random `[a-z0-9]` characters (env `WEBVH_CREATE_ALIAS` / `WEBVH_CREATE_IDENTIFIER`). Sends **`apply_policy: true`** by default (merge with WebVH server identifier policy; matches ACA-Py). Set `WEBVH_CREATE_APPLY_POLICY=false` to skip policy merge. Sets `ctx.webvh_last_created_did` when the response includes a `did:webvh` id
 - `publish-schema-webvh` / `publish-cred-def-webvh`: `POST /anoncreds/schema` then `POST /anoncreds/credential-definition` with **`support_revocation: true`** and **`revocation_registry_size`** (default **4** in `constants.py`). Idempotent when the same schema/cred-def already exists for the WebVH issuer DID. Schema/cred-def **responses** are debug-only (`-v`); INFO logs HTTP status lines and published ids
-- `oob-didexchange-webvh-didcomm`: issuer `POST /out-of-band/create-invitation` with **`use_did`** set to the wallet’s **`did:webvh`** (no `POST /wallet/did/public` — that is Indy public-DID/endorser, not this flow) and DID Exchange 1.1; holder `POST /out-of-band/receive-invitation` (`auto_accept`); polls until issuer has a new **active** connection
+- `oob-didexchange-webvh-didcomm`: issuer `POST /out-of-band/create-invitation` with **`use_did`** set to the wallet’s **`did:webvh`** (no `POST /wallet/did/public` — that is Indy public-DID/endorser, not this flow) and DID Exchange 1.1; holder `POST /out-of-band/receive-invitation` (`auto_accept`); polls issuer-side OOB record / connection list until the exchange is **active** or **completed**
 - `issue-webvh`: `POST /issue-credential-2.0/send-offer` (anoncreds filter, `auto_issue`); holder `POST …/send-request`; polls until issuer exchange is **done**
 - `verify-webvh` / `verify-webvh-post-revoke`: `POST /present-proof-2.0/send-request` with anoncreds **non-revocation interval**, holder `POST …/send-presentation`; first round expects **verified**; after `revoke-webvh`, second round expects **not verified** (or **abandoned**)
 - `revoke-webvh`: `POST /anoncreds/revocation/revoke` with **`rev_reg_id` / `cred_rev_id`** when present (else **`cred_ex_id`**); **`publish`** / **`notify`** from `constants.py` (defaults: publish on, holder notify off)
@@ -25,12 +25,7 @@ Current runtime behavior:
 - required issuer/holder token validation at startup
 - profile execution and end-of-run **summary** (indented `run` + `webvh` sections: `traction_url`; after create, full `did:webvh:…` and BCVH-style **explorer** links `{server_url}/api/explorer/dids?scid=…` and `{server_url}/api/explorer/resources?scid=…` when a DID is present — e.g. [resources for an SCID](https://sandbox.bcvh.vonx.io/api/explorer/resources?scid=QmRZdh2ivaQNv9YkEnSqDsbk2Vhz6TQJWSbCF95zCVfNnb))
 - `--witness`: adds `endorsement: true` to the WebVH configure POST (endorser-style flow)
-
-### Not implemented yet
-
-- `issue-indy` (placeholder only)
-
-Phases that are not implemented log a short message and return success.
+- **Indy (BCovrin test)** — profile `indy-bcovrin-e2e` (see below; `indy-bcovrin-setup` is an alias): **`smoke`** (polls **`GET /tenant/wallet`** through 503 upgrade), **`upgrade-anoncreds-wallet`** (issuer), ledger + endorser + public DID + **`publish-schema-indy` / `publish-cred-def-indy`** (same anoncreds revocation options as WebVH; **unqualified** Indy `issuerId` / `schemaId` for resolver compatibility), then **`oob-didexchange-indy-didcomm`**: OOB + DID Exchange 1.1 with **`use_public_did: true`** (wallet ledger public DID; do not pass a short **`use_did`** — invalid `services` and **422** on receive), distinct OOB/holder aliases from the WebVH path (`constants.py`), then **`issue-indy` / `verify-indy` / `revoke-indy` / `verify-indy-post-revoke`** — same **`anoncreds`** filters and proof shape as the WebVH phases, using `ctx.indy_cred_def_id`.
 
 ## Prerequisites
 
@@ -52,7 +47,7 @@ Run commands from this directory (`scripts/webvh-e2e`) so `python-dotenv` picks 
 
 The checked-in **`.env.example`** comments optional WebVH create settings; other optional variables below work when set in `.env` or the shell.
 
-**Tuning** (schema/cred-def, preview attributes, polling intervals, revoke flags, wallet-upgrade wait): edit **`constants.py`** — not environment variables.
+**Tuning** (schema/cred-def, preview attributes, polling intervals, revoke flags, wallet-upgrade wait): edit **`constants.py`** — not environment variables. **`E2E_SMOKE_WALLET_READY_*`** / **`E2E_SMOKE_WALLET_POST_READY_SETTLE_SEC`** control smoke polling through **`GET /tenant/wallet`** 503s and optional settle after both wallets are OK (the settle is **skipped** when issuer and holder are already **`askar-anoncreds`**). Indy E2E builds a **fresh cred-def tag each run** (`E2E_INDY_CRED_DEF_TAG_PREFIX` + random hex) so **`publish-cred-def-indy`** always creates a new definition and does not hit duplicate-tag **400** from a prior run.
 
 **Logging:** At INFO, `TractionClient` logs the full JSON body of each POST except `POST /did/webvh/configuration` (that one is sanitized). Issue and proof requests can include attribute values—treat default logs as potentially sensitive in shared CI or support channels.
 
@@ -71,10 +66,18 @@ Optional (WebVH):
 - `WEBVH_WITNESS_THRESHOLD` (default `0`, omitted from requests) — when set to a **positive** integer, adds `options.witness_threshold` on create and `parameter_options.witness_threshold` on configure
 - `WEBVH_CREATE_APPLY_POLICY` — set to `0` / `false` / `no` / `off` to send `apply_policy: false` (omit server policy merge; default in harness is **on** / `true`)
 
+Optional (Indy / BCovrin test — profile `indy-bcovrin-e2e`):
+
+- `E2E_INDY_WRITE_LEDGER_ID` — ledger id for `PUT /ledger/…/set-write-ledger` (default **`bcovrin-test`** in `constants.py` if unset)
+- `E2E_INDY_REGISTER_NYM_ALIAS` — optional alias for `POST /ledger/register-nym` (default: tenant `tenant_name` / `wallet_id` from `GET /tenant`, else `webvh-e2e-indy`)
+
+**Issuer tenant requirements for Indy:** the Innkeeper tenant must be allowed to connect to endorsers and create a public DID on the target ledger (same as the Tenant UI “Issuance” prerequisites). Otherwise `POST /tenant/endorser-connection` returns **400** (“not configured as an issuer”).
+
 ## Profiles
 
-- `all` (default): all registered phases (including placeholders)
-- `new-issuer-webvh`: WebVH-named path from `smoke` through `verify-webvh-post-revoke`
+- `all` (default): same phases as **`new-issuer-webvh`** (WebVH end-to-end only)
+- `new-issuer-webvh`: WebVH path from `smoke` through `verify-webvh-post-revoke`
+- `indy-bcovrin-e2e`: Full Indy path on BCovrin test — smoke (wallet readiness + optional settle in `constants.py`), issuer **`upgrade-anoncreds-wallet`**, ledger, endorser, public DID, anoncreds schema/cred-def, **DIDComm over Indy public DID**, issue / verify / revoke / verify-after-revoke (holder token required). **`indy-bcovrin-setup`** is the same phases (legacy name).
 
 ## Usage
 
@@ -85,5 +88,6 @@ poetry run python3 run.py
 poetry run python3 run.py --profile new-issuer-webvh
 poetry run python3 run.py --profile all -v
 poetry run python3 run.py --profile new-issuer-webvh --witness
+poetry run python3 run.py --profile indy-bcovrin-e2e
 ```
 

--- a/scripts/webvh-e2e/constants.py
+++ b/scripts/webvh-e2e/constants.py
@@ -1,33 +1,90 @@
-"""Fixed tuning for the WebVH E2E harness — edit here instead of using env vars."""
+"""
+Harness tuning — single place to edit waits, schema, and flags.
+
+Phases import these names directly; keep names stable. ``E2E_INDY_WRITE_LEDGER_ID`` is also read from
+the environment in ``context.build_context`` when set.
+
+**Timeouts** default toward a **~1–2 minute** full profile on a healthy sandbox; raise values locally if
+a slow endorser or migration causes flaky failures.
+"""
 
 from __future__ import annotations
 
-# AnonCreds schema / cred-def (must match credential preview + proof request)
+# ---------------------------------------------------------------------------
+# AnonCreds schema / credential definition (must match preview + proof request)
+# ---------------------------------------------------------------------------
 E2E_SCHEMA_NAME = "WebVHE2EHarness"
 E2E_SCHEMA_VERSION = "1.0"
 E2E_SCHEMA_ATTR_NAMES: list[str] = ["name", "score"]
 E2E_CRED_DEF_TAG = E2E_SCHEMA_NAME
+# Indy: random tag suffix per run (``phase_publish_cred_def_indy``) avoids duplicate-tag 400.
+E2E_INDY_CRED_DEF_TAG_PREFIX = f"{E2E_SCHEMA_NAME}-indy-e2e"
 E2E_REVOCATION_REGISTRY_SIZE = 4
+# After cred-def publish/reuse with revocation, poll GET …/active-registry (``setup.py``).
+E2E_REV_REG_ACTIVE_POLL_SEC = 2.0
+E2E_REV_REG_ACTIVE_TIMEOUT_SEC = 90.0
+E2E_REV_REG_WAIT_LOG_INTERVAL_SEC = 10.0
+# Transient WebVH pool errors: retry POST cred-def until success (``setup.py``).
+E2E_CRED_DEF_POST_RETRY_TIMEOUT_SEC = 90.0
 
-# Credential offer preview (attr names must be E2E_SCHEMA_ATTR_NAMES)
+# ---------------------------------------------------------------------------
+# Credential offer (attribute names must match ``E2E_SCHEMA_ATTR_NAMES``)
+# ---------------------------------------------------------------------------
 E2E_CREDENTIAL_PREVIEW_ATTRIBUTES: list[dict[str, str]] = [
     {"name": "name", "value": "WebVH E2E"},
     {"name": "score", "value": "42"},
 ]
 
-# DIDComm (holder alias for receive-invitation)
+# ---------------------------------------------------------------------------
+# DIDComm connection aliases (issuer OOB + holder receive-invitation)
+# ---------------------------------------------------------------------------
 E2E_HOLDER_CONNECTION_ALIAS = "webvh-e2e-holder"
+E2E_INDY_ISSUER_OOB_ALIAS = "webvh-e2e-issuer-indy"
+E2E_INDY_HOLDER_CONNECTION_ALIAS = "webvh-e2e-holder-indy"
 
-# Polling intervals / timeouts (seconds)
+# ---------------------------------------------------------------------------
+# Polling / timeouts (seconds)
+# ---------------------------------------------------------------------------
+
+# Issuer wallet upgrade to askar-anoncreds (``setup.py``)
 WALLET_UPGRADE_POLL_SEC = 2.0
-WALLET_UPGRADE_TIMEOUT_SEC = 120.0
-E2E_CONNECTION_POLL_SEC = 2.0
-E2E_CONNECTION_TIMEOUT_SEC = 120.0
-E2E_ISSUE_POLL_SEC = 2.0
-E2E_ISSUE_TIMEOUT_SEC = 300.0
-E2E_PROOF_POLL_SEC = 2.0
-E2E_PROOF_TIMEOUT_SEC = 180.0
+WALLET_UPGRADE_TIMEOUT_SEC = 90.0
 
-# Revocation API
+# Smoke: ``GET /tenant/wallet`` during migration (``phases/smoke.py``)
+E2E_SMOKE_WALLET_READY_POLL_SEC = 3.0
+E2E_SMOKE_WALLET_READY_TIMEOUT_SEC = 90.0
+# Post-ready settle (0 = off). Skipped when both wallets already askar-anoncreds.
+E2E_SMOKE_WALLET_POST_READY_SETTLE_SEC = 5.0
+
+# DID Exchange (default WebVH path; ``phases/connect.py``)
+E2E_CONNECTION_POLL_SEC = 2.0
+E2E_CONNECTION_TIMEOUT_SEC = 60.0
+
+# Issue-credential-2.0 (``phases/issue.py``)
+E2E_ISSUE_POLL_SEC = 2.0
+E2E_ISSUE_TIMEOUT_SEC = 120.0
+
+# Present-proof-2.0 (``phases/verify.py``)
+E2E_PROOF_POLL_SEC = 2.0
+E2E_PROOF_TIMEOUT_SEC = 90.0
+E2E_PROOF_HOLDER_CRED_MATCH_TIMEOUT_SEC = 45.0
+
+# ---------------------------------------------------------------------------
+# Revocation (``phases/revoke.py``)
+# ---------------------------------------------------------------------------
 E2E_REVOKE_PUBLISH = True
 E2E_REVOKE_NOTIFY = False
+# Indy: wait for ledger ``…/issued/indy_recs`` after publish=True revoke.
+E2E_REVOKE_LEDGER_POLL_SEC = 2.0
+E2E_REVOKE_LEDGER_TIMEOUT_SEC = 90.0
+E2E_REVOKE_LEDGER_LOG_INTERVAL_SEC = 10.0
+
+# ---------------------------------------------------------------------------
+# Indy / BCovrin (``phases/indy.py``, ``context.py``)
+# ---------------------------------------------------------------------------
+E2E_INDY_WRITE_LEDGER_ID = "bcovrin-test"
+E2E_INDY_CONNECTION_POLL_SEC = 2.0
+E2E_INDY_CONNECTION_TIMEOUT_SEC = 90.0
+E2E_INDY_CRED_DEF_PUBLISH_SETTLE_SEC = 0.0
+E2E_INDY_TXN_POLL_SEC = 1.0
+E2E_INDY_TXN_TIMEOUT_SEC = 120.0

--- a/scripts/webvh-e2e/context.py
+++ b/scripts/webvh-e2e/context.py
@@ -8,41 +8,34 @@ from typing import Any
 
 import requests
 
+from constants import E2E_INDY_WRITE_LEDGER_ID
 from traction_client import TractionClient
 
 DEFAULT_BASE = "https://traction-sandbox-tenant-proxy.apps.silver.devops.gov.bc.ca"
 
 
-def normalize_base(url: str) -> str:
-    return url.rstrip("/")
-
-
-def issuer_tenant_token() -> str:
-    token = os.environ.get("TRACTION_ISSUER_TENANT_TOKEN", "").strip()
+def _env_token(env_var: str, *, missing_message: str) -> str:
+    token = os.environ.get(env_var, "").strip()
     if not token:
-        raise RuntimeError("Issuer tenant token required: set TRACTION_ISSUER_TENANT_TOKEN.")
+        raise RuntimeError(missing_message)
     return token
 
 
-def holder_tenant_token() -> str:
-    token = os.environ.get("TRACTION_HOLDER_TENANT_TOKEN", "").strip()
-    if not token:
-        raise RuntimeError("Holder tenant token required: set TRACTION_HOLDER_TENANT_TOKEN.")
-    return token
-
-
-def _session_headers(bearer_token: str) -> dict[str, str]:
-    return {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {bearer_token}",
-    }
+def _json_session(bearer_token: str) -> requests.Session:
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {bearer_token}",
+        }
+    )
+    return session
 
 
 def get_plugin_webvh(config_json: dict[str, Any]) -> dict[str, Any] | None:
     """``plugin_config.webvh`` or ``plugin_config.did-webvh`` from tenant server config."""
-    config_section = (config_json or {}).get("config") or {}
-    plugin_config = config_section.get("plugin_config") or {}
+    plugin_config = ((config_json or {}).get("config") or {}).get("plugin_config") or {}
     return plugin_config.get("webvh") or plugin_config.get("did-webvh")
 
 
@@ -67,6 +60,12 @@ class Context:
     holder_connection_id: str | None = None
     # Issue-credential-2.0 (issuer role record after offer / issue)
     issuer_cred_ex_id: str | None = None
+    # Indy (BCovrin test) — issuer endorser + public DID
+    indy_write_ledger_id: str | None = None
+    indy_endorser_connection_id: str | None = None
+    indy_public_did: str | None = None
+    indy_schema_id: str | None = None
+    indy_cred_def_id: str | None = None
 
     def issuer_client(self) -> TractionClient:
         return TractionClient(self.base_url, self.issuer_session)
@@ -75,15 +74,23 @@ class Context:
         return TractionClient(self.base_url, self.holder_session)
 
 
-def build_context() -> Context:
-    issuer_token = issuer_tenant_token()
-    holder_token = holder_tenant_token()
-    base = normalize_base(os.environ.get("TRACTION_TENANT_PROXY_BASE", DEFAULT_BASE).strip())
-
-    issuer_session = requests.Session()
-    issuer_session.headers.update(_session_headers(issuer_token))
-
-    holder_session = requests.Session()
-    holder_session.headers.update(_session_headers(holder_token))
-
-    return Context(base_url=base, issuer_session=issuer_session, holder_session=holder_session)
+def build_context(*, use_witness: bool = False) -> Context:
+    base = os.environ.get("TRACTION_TENANT_PROXY_BASE", DEFAULT_BASE).strip().rstrip("/")
+    indy_ledger = os.environ.get("E2E_INDY_WRITE_LEDGER_ID", "").strip()
+    return Context(
+        base_url=base,
+        issuer_session=_json_session(
+            _env_token(
+                "TRACTION_ISSUER_TENANT_TOKEN",
+                missing_message="Issuer tenant token required: set TRACTION_ISSUER_TENANT_TOKEN.",
+            )
+        ),
+        holder_session=_json_session(
+            _env_token(
+                "TRACTION_HOLDER_TENANT_TOKEN",
+                missing_message="Holder tenant token required: set TRACTION_HOLDER_TENANT_TOKEN.",
+            )
+        ),
+        use_witness=use_witness,
+        indy_write_ledger_id=indy_ledger or E2E_INDY_WRITE_LEDGER_ID,
+    )

--- a/scripts/webvh-e2e/helpers.py
+++ b/scripts/webvh-e2e/helpers.py
@@ -1,4 +1,4 @@
-"""Small helpers for WebVH harness (WebVH server calls, explorer URLs, polling)."""
+"""Shared helpers for the WebVH E2E harness (wallet JSON, WebVH URLs, polling)."""
 
 from __future__ import annotations
 
@@ -7,27 +7,77 @@ import json
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import quote, urlsplit
 
 import requests
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger("webvh-e2e")
+
+# Logging convention (default run = INFO, ``-v`` = DEBUG):
+# - INFO: phase steps, HTTP method+path, status lines, outcomes.
+# - DEBUG: request/response JSON and other large payloads (incl. ``TractionClient`` POST/PUT bodies).
+# - ERROR/WARNING: failures and retries.
+
+if TYPE_CHECKING:
+    from context import Context
 
 T = TypeVar("T")
 
 
-def v20_cred_ex_record_core(row: Any) -> dict[str, Any]:
+def format_json_for_log(data: Any) -> str:
+    """Pretty JSON for DEBUG logs by convention; non-fatal ``TypeError`` → ``str(data)``."""
+    try:
+        return json.dumps(data, indent=2, ensure_ascii=False, default=str)
+    except TypeError:
+        return str(data)
+
+
+def http_json_dict(response: requests.Response) -> dict[str, Any] | None:
+    """Parse a ``requests`` response body as a JSON object, or ``None``."""
+    try:
+        parsed = response.json()
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def v20_cred_ex_record_core(cred_ex_record: Any) -> dict[str, Any]:
     """
     ACA-Py often wraps the v2.0 credential exchange in ``cred_ex_record`` (``V20CredExRecordDetail``):
     applies to **list** ``GET /issue-credential-2.0/records`` and **single-record** GET by id.
     """
-    if not isinstance(row, dict):
+    if not isinstance(cred_ex_record, dict):
         return {}
-    inner = row.get("cred_ex_record")
+    inner = cred_ex_record.get("cred_ex_record")
     if isinstance(inner, dict):
         return inner
-    return row
+    return cred_ex_record
+
+
+def tenant_wallet_settings(tenant_wallet: dict[str, Any]) -> dict[str, Any]:
+    """``settings`` object from ``GET /tenant/wallet`` JSON (multitenant ACA-Py)."""
+    settings_value = tenant_wallet.get("settings")
+    return settings_value if isinstance(settings_value, dict) else {}
+
+
+def tenant_wallet_name(tenant_wallet: dict[str, Any]) -> str | None:
+    """
+    Wallet name for ``POST /anoncreds/wallet/upgrade`` (``settings['wallet.name']`` on tenant wallet).
+    """
+    name = tenant_wallet_settings(tenant_wallet).get("wallet.name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
+def tenant_wallet_storage_type(tenant_wallet: dict[str, Any]) -> str | None:
+    """Storage type (e.g. ``askar`` / ``askar-anoncreds``) from ``GET /tenant/wallet``."""
+    top_level = tenant_wallet.get("type")
+    if isinstance(top_level, str) and top_level:
+        return top_level
+    from_settings = tenant_wallet_settings(tenant_wallet).get("wallet.type")
+    return from_settings if isinstance(from_settings, str) else None
 
 
 def fetch_witness_invitation_json(server_url: str, witness_did_fragment: str) -> dict[str, Any]:
@@ -85,26 +135,20 @@ def webvh_scid_from_did(did: str) -> str | None:
     return segments[0] if segments else None
 
 
-def webvh_explorer_dids_url(server_url: str, scid: str) -> str:
-    """
-    BCVH-style DID explorer query (see server ``/api/explorer/dids?scid=…``).
-
-    ``server_url`` is the WebVH server base (e.g. ``https://sandbox.bcvh.vonx.io``).
-    """
+def _webvh_explorer_url(server_url: str, scid: str, *, path: str) -> str:
+    """``/api/explorer/{path}?scid=…`` on the WebVH / BCVH server base."""
     base = server_url.strip().rstrip("/")
-    encoded_scid = quote(scid, safe="")
-    return f"{base}/api/explorer/dids?scid={encoded_scid}"
+    return f"{base}/api/explorer/{path}?scid={quote(scid, safe='')}"
+
+
+def webvh_explorer_dids_url(server_url: str, scid: str) -> str:
+    """BCVH-style DID explorer (``/api/explorer/dids?scid=…``). ``server_url`` is the WebVH base."""
+    return _webvh_explorer_url(server_url, scid, path="dids")
 
 
 def webvh_explorer_resources_url(server_url: str, scid: str) -> str:
-    """
-    BCVH-style attested resources explorer (schemas, cred defs, revocation, status lists).
-
-    Path: ``/api/explorer/resources?scid=…`` on the WebVH server base.
-    """
-    base = server_url.strip().rstrip("/")
-    encoded_scid = quote(scid, safe="")
-    return f"{base}/api/explorer/resources?scid={encoded_scid}"
+    """BCVH-style resources explorer (schemas, cred defs, revocation, etc.)."""
+    return _webvh_explorer_url(server_url, scid, path="resources")
 
 
 def webvh_server_base_for_explorer(server_url: str | None, did: str | None) -> str | None:
@@ -133,12 +177,140 @@ def poll_until(
 
     ``fetch`` should return None while waiting (e.g. ACA-Py / DIDComm not ready yet).
     """
-    e2e_log = logging.getLogger("webvh-e2e")
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
         result = fetch()
         if result is not None:
             return result
         time.sleep(interval_sec)
-    e2e_log.error("Timeout waiting for: %s", description)
+    LOG.error("Timeout waiting for: %s", description)
     return None
+
+
+def log_http_failed(
+    what: str,
+    response: Any,
+    *,
+    max_body: int = 4000,
+    log_debug_body: bool = True,
+) -> None:
+    """Log a failed ``requests`` response: ERROR with status; optional DEBUG body (truncated)."""
+    code = getattr(response, "status_code", "?")
+    LOG.error("%s (HTTP %s)", what, code)
+    if not log_debug_body:
+        return
+    text = (getattr(response, "text", None) or "")[:max_body]
+    if text:
+        LOG.debug("%s\n%s", what, text)
+
+
+class HarnessLogger:
+    """CLI setup, phase banners, run footer, summary (``LOG`` is the underlying logger)."""
+
+    LOG = LOG
+    _SUMMARY_LABEL_WIDTH = 22
+
+    @classmethod
+    def configure_cli_logging(cls, *, verbose: bool) -> None:
+        logging.basicConfig(
+            level=logging.DEBUG if verbose else logging.INFO,
+            format="%(message)s",
+        )
+
+    @classmethod
+    def log_context_init_failed(cls, message: str) -> None:
+        cls.LOG.error("%s", message)
+
+    @classmethod
+    def log_run_start(cls, traction_url: str, profile: str) -> None:
+        cls.LOG.info("traction_url=%s profile=%s", traction_url, profile)
+        cls.LOG.info("")
+
+    @classmethod
+    def log_phase_begin(cls, phase_name: str, *, is_first_phase: bool) -> None:
+        if not is_first_phase:
+            cls.LOG.info("")
+        cls.LOG.info("-- %s --", phase_name)
+
+    @classmethod
+    def log_phase_uncaught_exception(cls, phase_name: str, exc: BaseException) -> None:
+        cls.LOG.error("%s: %s", phase_name, exc)
+
+    @classmethod
+    def log_run_footer(
+        cls,
+        *,
+        success: bool,
+        phases_completed: int,
+        phase_count: int,
+        elapsed_seconds: float,
+    ) -> None:
+        cls.LOG.info("")
+        cls.LOG.info(
+            "%s  %s/%s phases  %.1fs",
+            "ok" if success else "failed",
+            phases_completed,
+            phase_count,
+            elapsed_seconds,
+        )
+
+    @classmethod
+    def _log_summary_kv(cls, indent: str, label: str, value: object) -> None:
+        cls.LOG.info("%s%-*s  %s", indent, cls._SUMMARY_LABEL_WIDTH, label, value)
+
+    @classmethod
+    def log_run_summary(
+        cls, context: "Context", stop: str | None, plan: tuple[str, ...] | list[str]
+    ) -> None:
+        cls.LOG.info("")
+        cls.LOG.info("=== summary ===")
+        cls.LOG.info("")
+        cls.LOG.info("  run")
+        cls._log_summary_kv("    ", "traction_url", context.base_url)
+
+        if context.webvh_last_create_namespace is not None:
+            cls.LOG.info("")
+            cls.LOG.info("  webvh (create)")
+            if context.webvh_last_created_did:
+                last_created_did = context.webvh_last_created_did
+                cls._log_summary_kv("    ", "did", last_created_did)
+                scid = webvh_scid_from_did(last_created_did)
+                explorer_base = webvh_server_base_for_explorer(
+                    context.webvh_last_create_server_url, last_created_did
+                )
+                if scid and explorer_base:
+                    cls._log_summary_kv(
+                        "    ",
+                        "explorer (dids)",
+                        webvh_explorer_dids_url(explorer_base, scid),
+                    )
+                    cls._log_summary_kv(
+                        "    ",
+                        "explorer (resources)",
+                        webvh_explorer_resources_url(explorer_base, scid),
+                    )
+            elif stop is None:
+                cls._log_summary_kv("    ", "did", "(not in create response yet)")
+
+        elif context.webvh_server_url and "configure-webvh-plugin" in plan:
+            cls.LOG.info("")
+            cls.LOG.info("  webvh (controller)")
+            cls._log_summary_kv("    ", "server_url", context.webvh_server_url)
+
+        if context.indy_public_did or context.indy_endorser_connection_id:
+            cls.LOG.info("")
+            cls.LOG.info("  indy (bcovrin)")
+            if context.indy_write_ledger_id:
+                cls._log_summary_kv("    ", "write_ledger_id", context.indy_write_ledger_id)
+            if context.indy_endorser_connection_id:
+                cls._log_summary_kv(
+                    "    ", "endorser_connection_id", context.indy_endorser_connection_id
+                )
+            if context.indy_public_did:
+                cls._log_summary_kv("    ", "public_did", context.indy_public_did)
+            if context.indy_schema_id:
+                cls._log_summary_kv("    ", "schema_id", context.indy_schema_id)
+            if context.indy_cred_def_id:
+                cls._log_summary_kv(
+                    "    ", "credential_definition_id", context.indy_cred_def_id
+                )

--- a/scripts/webvh-e2e/phases/__init__.py
+++ b/scripts/webvh-e2e/phases/__init__.py
@@ -4,17 +4,29 @@ from __future__ import annotations
 
 from typing import Any
 
-from .connect import phase_oob_didexchange_webvh_didcomm
+from .connect import phase_oob_didexchange_indy_didcomm, phase_oob_didexchange_webvh_didcomm
 from .smoke import phase_smoke
 from .webvh import phase_configure_webvh_plugin, phase_webvh_create
 from .issue import phase_issue_indy, phase_issue_webvh
-from .revoke import phase_revoke_webvh
+from .revoke import phase_revoke_indy, phase_revoke_webvh
 from .setup import (
     phase_publish_cred_def,
+    phase_publish_cred_def_indy,
     phase_publish_schema,
+    phase_publish_schema_indy,
     phase_upgrade_anoncreds_wallet,
 )
-from .verify import phase_verify_webvh, phase_verify_webvh_post_revoke
+from .verify import (
+    phase_verify_indy,
+    phase_verify_indy_post_revoke,
+    phase_verify_webvh,
+    phase_verify_webvh_post_revoke,
+)
+from .indy import (
+    phase_indy_connect_endorser,
+    phase_indy_register_public_did,
+    phase_indy_set_write_ledger,
+)
 
 PHASES: dict[str, Any] = {
     "smoke": phase_smoke,
@@ -28,7 +40,16 @@ PHASES: dict[str, Any] = {
     "verify-webvh": phase_verify_webvh,
     "revoke-webvh": phase_revoke_webvh,
     "verify-webvh-post-revoke": phase_verify_webvh_post_revoke,
+    "oob-didexchange-indy-didcomm": phase_oob_didexchange_indy_didcomm,
     "issue-indy": phase_issue_indy,
+    "verify-indy": phase_verify_indy,
+    "revoke-indy": phase_revoke_indy,
+    "verify-indy-post-revoke": phase_verify_indy_post_revoke,
+    "indy-set-write-ledger": phase_indy_set_write_ledger,
+    "indy-connect-endorser": phase_indy_connect_endorser,
+    "indy-register-public-did": phase_indy_register_public_did,
+    "publish-schema-indy": phase_publish_schema_indy,
+    "publish-cred-def-indy": phase_publish_cred_def_indy,
 }
 
 PROFILE_NEW_ISSUER_WEBVH: tuple[str, ...] = (
@@ -46,12 +67,33 @@ PROFILE_NEW_ISSUER_WEBVH: tuple[str, ...] = (
     "verify-webvh-post-revoke",
 )
 
-ALL_PHASES_ORDERED: tuple[str, ...] = PROFILE_NEW_ISSUER_WEBVH + ("issue-indy",)
+PROFILE_INDY_BCOVRIN_E2E: tuple[str, ...] = (
+    "smoke",
+    "upgrade-anoncreds-wallet",
+    "indy-set-write-ledger",
+    "indy-connect-endorser",
+    "indy-register-public-did",
+    "publish-schema-indy",
+    "publish-cred-def-indy",
+    "oob-didexchange-indy-didcomm",
+    "issue-indy",
+    "verify-indy",
+    "revoke-indy",
+    "verify-indy-post-revoke",
+)
 
 PROFILES: dict[str, tuple[str, ...]] = {
-    "all": ALL_PHASES_ORDERED,
+    "all": PROFILE_NEW_ISSUER_WEBVH,
     "new-issuer-webvh": PROFILE_NEW_ISSUER_WEBVH,
+    "indy-bcovrin-e2e": PROFILE_INDY_BCOVRIN_E2E,
+    # Backward-compatible alias (was “setup” before issue/verify/revoke were in-profile).
+    "indy-bcovrin-setup": PROFILE_INDY_BCOVRIN_E2E,
 }
 
-if set(ALL_PHASES_ORDERED) != set(PHASES.keys()):
-    raise RuntimeError("ALL_PHASES_ORDERED must match PHASES keys exactly")
+_PROFILE_PHASE_KEYS = {p for steps in PROFILES.values() for p in steps}
+if _PROFILE_PHASE_KEYS != set(PHASES.keys()):
+    raise RuntimeError(
+        "Every phase must appear in at least one profile and PHASES must define each: "
+        f"missing_from_profiles={set(PHASES.keys()) - _PROFILE_PHASE_KEYS} "
+        f"undefined_phases={_PROFILE_PHASE_KEYS - set(PHASES.keys())}"
+    )

--- a/scripts/webvh-e2e/phases/connect.py
+++ b/scripts/webvh-e2e/phases/connect.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
 from typing import Any
 
@@ -12,24 +11,33 @@ from constants import (
     E2E_CONNECTION_POLL_SEC,
     E2E_CONNECTION_TIMEOUT_SEC,
     E2E_HOLDER_CONNECTION_ALIAS,
+    E2E_INDY_CONNECTION_POLL_SEC,
+    E2E_INDY_CONNECTION_TIMEOUT_SEC,
+    E2E_INDY_HOLDER_CONNECTION_ALIAS,
+    E2E_INDY_ISSUER_OOB_ALIAS,
 )
-from helpers import poll_until
-
-LOG = logging.getLogger("webvh-e2e")
+from helpers import LOG, format_json_for_log, log_http_failed, poll_until
 
 _CONNECTION_ALIAS_ISSUER = "webvh-e2e-issuer"
+
+# ACA-Py DID Exchange / connection records may report ``active`` or ``completed`` when ready.
+_DIDEXCHANGE_READY_STATES = frozenset({"active", "completed"})
 
 
 def _connection_ids_from_list_payload(payload: dict[str, Any]) -> set[str]:
     results = payload.get("results") or []
-    return {str(r.get("connection_id")) for r in results if r.get("connection_id")}
+    return {
+        str(connection_row.get("connection_id"))
+        for connection_row in results
+        if connection_row.get("connection_id")
+    }
 
 
 def _issuer_connection_ids_snapshot(issuer: Any) -> set[str] | None:
     """Return connection IDs before OOB; ``None`` if GET /connections failed."""
     issuer_conns = issuer.get_connections()
     if not issuer_conns.ok:
-        LOG.error("Issuer GET /connections failed: %s", issuer_conns.status_code)
+        log_http_failed("Issuer GET /connections failed", issuer_conns, max_body=800)
         return None
     try:
         return _connection_ids_from_list_payload(issuer_conns.json())
@@ -37,27 +45,40 @@ def _issuer_connection_ids_snapshot(issuer: Any) -> set[str] | None:
         return set()
 
 
-def _oob_invitation_for_didexchange(issuer: Any, webvh_did: str) -> dict[str, Any] | None:
-    """POST OOB create-invitation; return embedded ``invitation`` dict or ``None``."""
-    oob_body = {
+def _oob_invitation_for_didexchange(
+    issuer: Any,
+    *,
+    issuer_oob_alias: str,
+    my_label: str,
+    use_did: str | None = None,
+    use_wallet_public_did: bool = False,
+) -> tuple[dict[str, Any], str | None] | None:
+    """
+    POST OOB create-invitation; return ``(invitation, oob_id)`` or ``None``.
+
+    **WebVH / arbitrary DID:** pass ``use_did`` (e.g. ``did:webvh:…``) and ``use_wallet_public_did=False``.
+
+    **Indy ledger public DID:** set ``use_wallet_public_did=True`` and omit ``use_did`` (ACA-Py uses the
+    wallet public DID; a short ``use_did`` produces invitations the holder rejects with **422**).
+    """
+    oob_body: dict[str, Any] = {
         "accept": ["didcomm/aip1", "didcomm/aip2;env=rfc19"],
-        "alias": _CONNECTION_ALIAS_ISSUER,
+        "alias": issuer_oob_alias,
         "handshake_protocols": ["https://didcomm.org/didexchange/1.1"],
-        "my_label": "WebVH E2E Issuer",
+        "my_label": my_label,
         "protocol_version": "1.1",
-        "use_did": webvh_did,
-        "use_public_did": False,
     }
+    if use_wallet_public_did:
+        oob_body["use_public_did"] = True
+    else:
+        if not use_did:
+            LOG.error("OOB create-invitation requires use_did when not using wallet public DID")
+            return None
+        oob_body["use_did"] = use_did
+        oob_body["use_public_did"] = False
     create_oob = issuer.post_out_of_band_create_invitation(oob_body, multi_use=False)
     if not create_oob.ok:
-        LOG.error(
-            "POST /out-of-band/create-invitation failed (HTTP %s)",
-            create_oob.status_code,
-        )
-        LOG.debug(
-            "OOB create error body:\n%s",
-            (create_oob.text or "")[:4000],
-        )
+        log_http_failed("POST /out-of-band/create-invitation failed", create_oob)
         return None
     try:
         oob_data = create_oob.json()
@@ -68,74 +89,129 @@ def _oob_invitation_for_didexchange(issuer: Any, webvh_did: str) -> dict[str, An
     invitation = oob_data.get("invitation")
     if not isinstance(invitation, dict):
         LOG.error("OOB create response missing invitation object")
-        LOG.debug("OOB create body:\n%s", json.dumps(oob_data, indent=2, default=str))
+        LOG.debug("OOB create body:\n%s", format_json_for_log(oob_data))
         return None
-    return invitation
+    oob_id = oob_data.get("oob_id")
+    if oob_id is not None:
+        oob_id = str(oob_id)
+    return invitation, oob_id
 
 
 def _holder_receive_oob_and_connection_id(
     holder: Any, invitation: dict[str, Any], holder_alias: str
 ) -> str | None:
     """POST receive-invitation; return holder ``connection_id`` or ``None``."""
-    recv = holder.post_out_of_band_receive_invitation(
+    receive_invitation_response = holder.post_out_of_band_receive_invitation(
         invitation,
         alias=holder_alias,
     )
-    if not recv.ok:
-        LOG.error(
-            "Holder POST /out-of-band/receive-invitation failed (HTTP %s)",
-            recv.status_code,
-        )
-        LOG.debug(
-            "receive-invitation error body:\n%s",
-            (recv.text or "")[:4000],
+    if not receive_invitation_response.ok:
+        log_http_failed(
+            "Holder POST /out-of-band/receive-invitation failed", receive_invitation_response
         )
         return None
     try:
-        oob_recv = recv.json()
+        receive_invitation_payload = receive_invitation_response.json()
     except json.JSONDecodeError:
         LOG.error("Holder receive-invitation returned non-JSON")
         return None
 
-    holder_conn = oob_recv.get("connection_id")
-    if not holder_conn:
+    holder_connection_id = receive_invitation_payload.get("connection_id")
+    if not holder_connection_id:
         LOG.error("Holder OOB response missing connection_id")
-        LOG.debug("receive-invitation body:\n%s", json.dumps(oob_recv, indent=2, default=str))
+        LOG.debug("receive-invitation body:\n%s", format_json_for_log(receive_invitation_payload))
         return None
-    return str(holder_conn)
+    return str(holder_connection_id)
 
 
-def _poll_issuer_new_active_connection(
+def _issuer_connection_id_if_ready(issuer: Any, connection_id: str) -> str | None:
+    """Return ``connection_id`` if GET /connections/{id} is ``active`` or ``completed``."""
+    connection_response = issuer.get_connection(connection_id)
+    if not connection_response.ok:
+        return None
+    try:
+        connection_record = connection_response.json()
+    except json.JSONDecodeError:
+        return None
+    connection_state = (connection_record.get("state") or "").lower()
+    if connection_state in _DIDEXCHANGE_READY_STATES:
+        return connection_id
+    return None
+
+
+def _poll_issuer_didexchange_connection(
     issuer: Any,
     issuer_conns_before: set[str],
     *,
+    oob_id: str | None,
+    invitation_msg_id: str | None,
     poll_sec: float,
     timeout_sec: float,
 ) -> str | None:
-    """Poll until issuer has a new connection in ``active`` state."""
+    """
+    Resolve issuer-side connection after holder receive-invitation.
+
+    Prefer, in order: OOB record ``connection_id``; list row matching ``invitation_msg_id``; any new
+    connection id (not in the pre-OOB snapshot) in a ready state. Some deployments report **completed**
+    instead of **active**; Indy public-DID OOB may also update an existing connection row (same id as
+    before), so the snapshot-only heuristic is not enough.
+    """
 
     def issuer_connection_ready() -> str | None:
-        response = issuer.get_connections()
-        if not response.ok:
+        if oob_id:
+            oob_record_response = issuer.get_out_of_band_record(oob_id)
+            if oob_record_response.ok:
+                try:
+                    oob_record = oob_record_response.json()
+                except json.JSONDecodeError:
+                    oob_record = {}
+                oob_connection_id = oob_record.get("connection_id")
+                if oob_connection_id:
+                    ready_id = _issuer_connection_id_if_ready(issuer, str(oob_connection_id))
+                    if ready_id:
+                        return ready_id
+
+        list_response = issuer.get_connections()
+        if not list_response.ok:
             return None
         try:
-            payload = response.json()
+            list_payload = list_response.json()
         except json.JSONDecodeError:
             return None
-        for row in payload.get("results") or []:
-            cid = row.get("connection_id")
-            if not cid or str(cid) in issuer_conns_before:
+        connection_results = list_payload.get("results") or []
+
+        if invitation_msg_id:
+            for connection_row in connection_results:
+                if str(connection_row.get("invitation_msg_id") or "") != invitation_msg_id:
+                    continue
+                row_connection_id = connection_row.get("connection_id")
+                if not row_connection_id:
+                    continue
+                row_state = (connection_row.get("state") or "").lower()
+                if row_state in _DIDEXCHANGE_READY_STATES:
+                    return str(row_connection_id)
+                ready_id = _issuer_connection_id_if_ready(issuer, str(row_connection_id))
+                if ready_id:
+                    return ready_id
+
+        for connection_row in connection_results:
+            row_connection_id = connection_row.get("connection_id")
+            if not row_connection_id or str(row_connection_id) in issuer_conns_before:
                 continue
-            state = (row.get("state") or "").lower()
-            if state == "active":
-                return str(cid)
+            row_state = (connection_row.get("state") or "").lower()
+            if row_state in _DIDEXCHANGE_READY_STATES:
+                return str(row_connection_id)
+            ready_id = _issuer_connection_id_if_ready(issuer, str(row_connection_id))
+            if ready_id:
+                return ready_id
+
         return None
 
     return poll_until(
         issuer_connection_ready,
         timeout_sec=timeout_sec,
         interval_sec=poll_sec,
-        description="issuer active DIDExchange connection",
+        description="issuer DIDExchange connection (active or completed)",
     )
 
 
@@ -149,14 +225,14 @@ def _wait_holder_connection_active(
     """Best-effort wait for holder connection ``active``; warn on timeout."""
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
-        check = holder.get_connection(holder_connection_id)
-        if check.ok:
+        holder_connection_check = holder.get_connection(holder_connection_id)
+        if holder_connection_check.ok:
             try:
-                row = check.json()
+                holder_connection_record = holder_connection_check.json()
             except json.JSONDecodeError:
-                row = {}
-            st = (row.get("state") or "").lower()
-            if st == "active":
+                holder_connection_record = {}
+            holder_state = (holder_connection_record.get("state") or "").lower()
+            if holder_state in _DIDEXCHANGE_READY_STATES:
                 return
         time.sleep(poll_sec)
     LOG.warning(
@@ -165,54 +241,124 @@ def _wait_holder_connection_active(
     )
 
 
-def phase_oob_didexchange_webvh_didcomm(ctx: Context) -> bool:
+def _oob_didexchange_with_issuer_did(
+    context: Context,
+    *,
+    issuer_oob_alias: str,
+    holder_alias: str,
+    my_label: str,
+    log_label: str,
+    use_did: str | None = None,
+    use_wallet_public_did: bool = False,
+    poll_sec: float = E2E_CONNECTION_POLL_SEC,
+    timeout_sec: float = E2E_CONNECTION_TIMEOUT_SEC,
+) -> bool:
     """
-    Issuer (WebVH DID) ↔ holder via OOB + DID Exchange 1.1.
+    Issuer ↔ holder via OOB + DID Exchange 1.1.
 
-    Uses ``use_did`` on the invitation (no ``POST /wallet/did/public`` / Indy public DID).
+    Either ``use_did`` (WebVH ``did:webvh:…``) or ``use_wallet_public_did`` (Indy public DID on ledger).
 
     Steps: snapshot issuer connections → OOB create → holder receive → poll issuer new active
     connection → optionally wait for holder active.
     """
-    webvh_did = ctx.webvh_last_created_did
-    if not webvh_did:
-        LOG.error("No did:webvh on context; run webvh-create first")
-        return False
+    if not use_wallet_public_did:
+        if not (use_did or "").strip():
+            LOG.error("[%s] Missing use_did for OOB", log_label)
+            return False
+        use_did = use_did.strip()
 
-    issuer = ctx.issuer_client()
-    holder = ctx.holder_client()
+    issuer = context.issuer_client()
+    holder = context.holder_client()
 
     issuer_conns_before = _issuer_connection_ids_snapshot(issuer)
     if issuer_conns_before is None:
         return False
 
-    invitation = _oob_invitation_for_didexchange(issuer, webvh_did)
-    if not invitation:
-        return False
-
-    holder_cid = _holder_receive_oob_and_connection_id(
-        holder, invitation, E2E_HOLDER_CONNECTION_ALIAS
+    oob_created = _oob_invitation_for_didexchange(
+        issuer,
+        issuer_oob_alias=issuer_oob_alias,
+        my_label=my_label,
+        use_did=use_did,
+        use_wallet_public_did=use_wallet_public_did,
     )
-    if not holder_cid:
+    if not oob_created:
         return False
-    ctx.holder_connection_id = holder_cid
-    LOG.info("Holder connection_id=%s", ctx.holder_connection_id)
+    invitation, oob_id = oob_created
+    invitation_msg_id = invitation.get("@id")
+    if invitation_msg_id is not None:
+        invitation_msg_id = str(invitation_msg_id)
 
-    issuer_cid = _poll_issuer_new_active_connection(
+    resolved_holder_connection_id = _holder_receive_oob_and_connection_id(
+        holder, invitation, holder_alias
+    )
+    if not resolved_holder_connection_id:
+        return False
+    context.holder_connection_id = resolved_holder_connection_id
+    LOG.info("Holder connection_id=%s", context.holder_connection_id)
+
+    resolved_issuer_connection_id = _poll_issuer_didexchange_connection(
         issuer,
         issuer_conns_before,
-        poll_sec=E2E_CONNECTION_POLL_SEC,
-        timeout_sec=E2E_CONNECTION_TIMEOUT_SEC,
+        oob_id=oob_id,
+        invitation_msg_id=invitation_msg_id,
+        poll_sec=poll_sec,
+        timeout_sec=timeout_sec,
     )
-    if not issuer_cid:
+    if not resolved_issuer_connection_id:
         return False
-    ctx.issuer_connection_id = issuer_cid
-    LOG.info("Issuer connection_id=%s", ctx.issuer_connection_id)
+    context.issuer_connection_id = resolved_issuer_connection_id
+    LOG.info("Issuer connection_id=%s", context.issuer_connection_id)
 
     _wait_holder_connection_active(
         holder,
-        ctx.holder_connection_id,
-        poll_sec=E2E_CONNECTION_POLL_SEC,
-        timeout_sec=E2E_CONNECTION_TIMEOUT_SEC,
+        context.holder_connection_id,
+        poll_sec=poll_sec,
+        timeout_sec=timeout_sec,
+    )
+    LOG.info(
+        "[%s] DIDComm ready (issuer_conn=%s holder_conn=%s)",
+        log_label,
+        resolved_issuer_connection_id,
+        resolved_holder_connection_id,
     )
     return True
+
+
+def phase_oob_didexchange_webvh_didcomm(context: Context) -> bool:
+    """Issuer (``did:webvh``) ↔ holder; ``use_did`` = WebVH issuer DID."""
+    webvh_did = context.webvh_last_created_did
+    if not webvh_did:
+        LOG.error("No did:webvh on context; run webvh-create first")
+        return False
+    return _oob_didexchange_with_issuer_did(
+        context,
+        issuer_oob_alias=_CONNECTION_ALIAS_ISSUER,
+        holder_alias=E2E_HOLDER_CONNECTION_ALIAS,
+        my_label="WebVH E2E Issuer",
+        log_label="webvh",
+        use_did=webvh_did,
+        use_wallet_public_did=False,
+    )
+
+
+def phase_oob_didexchange_indy_didcomm(context: Context) -> bool:
+    """
+    Issuer (Indy public DID) ↔ holder.
+
+    Uses ``use_public_did: true`` on create-invitation (wallet’s ledger public DID). Do not pass a short
+    ``use_did`` — that yields invalid ``services`` and **422** on receive-invitation.
+    """
+    if not (context.indy_public_did or "").strip():
+        LOG.error("No Indy public DID on context; run indy-register-public-did first")
+        return False
+    return _oob_didexchange_with_issuer_did(
+        context,
+        issuer_oob_alias=E2E_INDY_ISSUER_OOB_ALIAS,
+        holder_alias=E2E_INDY_HOLDER_CONNECTION_ALIAS,
+        my_label="Indy E2E Issuer",
+        log_label="indy",
+        use_did=None,
+        use_wallet_public_did=True,
+        poll_sec=E2E_INDY_CONNECTION_POLL_SEC,
+        timeout_sec=E2E_INDY_CONNECTION_TIMEOUT_SEC,
+    )

--- a/scripts/webvh-e2e/phases/indy.py
+++ b/scripts/webvh-e2e/phases/indy.py
@@ -1,0 +1,390 @@
+"""Indy ledger setup: BCovrin test endorser connection and public DID (issuer tenant)."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from context import Context
+from constants import (
+    E2E_INDY_CONNECTION_POLL_SEC,
+    E2E_INDY_CONNECTION_TIMEOUT_SEC,
+    E2E_INDY_TXN_POLL_SEC,
+    E2E_INDY_TXN_TIMEOUT_SEC,
+)
+from helpers import LOG, http_json_dict, log_http_failed, poll_until
+
+if TYPE_CHECKING:
+    from traction_client import TractionClient
+
+
+def _endorser_connection_poll_once(issuer: "TractionClient", connection_id: str) -> bool | None:
+    """One GET /connections/{id} poll: active → True, abandoned/deleted → False, else keep waiting."""
+    poll_response = issuer.get_connection(connection_id)
+    if not poll_response.ok:
+        return None
+    poll_payload = http_json_dict(poll_response) or {}
+    poll_state = (poll_payload.get("state") or "").lower()
+    if poll_state == "active":
+        return True
+    if poll_state in ("abandoned", "deleted"):
+        LOG.error("Endorser connection entered failure state: %s", poll_state)
+        return False
+    LOG.info(
+        "Waiting for endorser connection (connection_id=%s state=%s)",
+        connection_id,
+        poll_state or "?",
+    )
+    return None
+
+
+def _endorser_verify_active_connection_row(
+    issuer: "TractionClient",
+    context: Context,
+    connection_id: str,
+) -> tuple[bool, str | None]:
+    """
+    Confirm ``GET /connections/{id}`` when the endorser summary already reported ``active``.
+
+    Returns ``(True, None)`` if the row is active (context updated). Otherwise ``(False, fold)``
+    where ``fold`` is a terminal connection state to merge into the summary ``state``, or ``None``.
+    """
+    verify_connection_response = issuer.get_connection(connection_id)
+    if not verify_connection_response.ok:
+        LOG.warning(
+            "GET /tenant/endorser-connection reported active but GET /connections/%s HTTP %s; waiting",
+            connection_id,
+            verify_connection_response.status_code,
+        )
+        return False, None
+    verify_connection_payload = http_json_dict(verify_connection_response) or {}
+    verify_connection_state = (verify_connection_payload.get("state") or "").lower()
+    if verify_connection_state == "active":
+        LOG.info(
+            "Endorser connection active (connection_id=%s); verified GET /connections, skipping POST",
+            connection_id,
+        )
+        context.indy_endorser_connection_id = connection_id
+        return True, None
+    if verify_connection_state in ("abandoned", "deleted"):
+        return False, verify_connection_state
+    LOG.info(
+        "GET /tenant/endorser-connection reported active but GET /connections/%s state=%s; waiting",
+        connection_id,
+        verify_connection_state or "?",
+    )
+    return False, None
+
+
+def _parse_public_did_from_get_public_payload(body: dict[str, Any]) -> str | None:
+    """Parse ``GET /wallet/did/public`` JSON — ACA-Py / proxies use ``result.did``, ``result`` string, or top-level ``did``."""
+    result = body.get("result")
+    if isinstance(result, dict) and result.get("did"):
+        return str(result["did"]).strip()
+    if isinstance(result, str) and result.strip():
+        return result.strip()
+    if body.get("did"):
+        return str(body["did"]).strip()
+    return None
+
+
+def _parse_public_did_from_wallet_did_list(body: dict[str, Any]) -> str | None:
+    """Pick a public Indy DID from ``GET /wallet/did`` results (fallback)."""
+    rows = body.get("results")
+    if not isinstance(rows, list):
+        return None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        posture = (row.get("posture") or "").lower()
+        method = (row.get("method") or "").lower()
+        if posture == "public" and method in ("", "sov", "indy"):
+            did = row.get("did")
+            if did:
+                return str(did).strip()
+    return None
+
+
+def _issuer_existing_public_did_short(issuer: "TractionClient") -> str | None:
+    """
+    Return existing public DID if already assigned (idempotent re-runs).
+
+    Tries ``GET /wallet/did/public``, then ``GET /wallet/did`` for a public posture row.
+    """
+    pub = issuer.get_wallet_did_public()
+    if pub.ok:
+        parsed = _parse_public_did_from_get_public_payload(http_json_dict(pub) or {})
+        if parsed:
+            return parsed
+    listed = issuer.get_wallet_dids()
+    if listed.ok:
+        return _parse_public_did_from_wallet_did_list(http_json_dict(listed) or {})
+    return None
+
+
+def phase_indy_set_write_ledger(context: Context) -> bool:
+    """
+    Issuer: PUT /ledger/{ledger_id}/set-write-ledger for the Indy write ledger (default bcovrin-test).
+
+    Uses ``context.indy_write_ledger_id`` (from ``E2E_INDY_WRITE_LEDGER_ID`` or default in constants).
+    """
+    ledger_id = (context.indy_write_ledger_id or "").strip()
+    if not ledger_id:
+        LOG.error("Missing indy_write_ledger_id; set E2E_INDY_WRITE_LEDGER_ID or Context default")
+        return False
+
+    issuer = context.issuer_client()
+    set_ledger_response = issuer.put_ledger_set_write_ledger(ledger_id)
+    if not set_ledger_response.ok:
+        log_http_failed(
+            f"PUT /ledger/{ledger_id}/set-write-ledger failed", set_ledger_response, max_body=800
+        )
+        return False
+    set_ledger_body = http_json_dict(set_ledger_response) or {}
+    write_ledger = set_ledger_body.get("write_ledger") or ledger_id
+    LOG.info("Write ledger set to %s", write_ledger)
+    return True
+
+
+def phase_indy_connect_endorser(context: Context) -> bool:
+    """
+    Issuer: GET /tenant/endorser-info, then connect to configured Indy endorser.
+
+    Reuses an existing connection from GET /tenant/endorser-connection when present.
+    Treats the connection as ready only when GET /connections/{id} reports ``active`` (even if
+    the endorser summary already says ``active``). Otherwise POST /tenant/endorser-connection and
+    polls GET /connections/{id} until ``active``.
+    """
+    issuer = context.issuer_client()
+
+    info_resp = issuer.get_tenant_endorser_info()
+    if not info_resp.ok:
+        log_http_failed("GET /tenant/endorser-info failed", info_resp, max_body=800)
+        return False
+    info = http_json_dict(info_resp) or {}
+    endorser_did = info.get("endorser_did")
+    endorser_name = info.get("endorser_name")
+    LOG.info("Configured endorser: name=%s did=%s", endorser_name, endorser_did)
+
+    existing = issuer.get_tenant_endorser_connection()
+    connection_id: str | None = None
+    if not existing.ok and existing.status_code != 404:
+        log_http_failed(
+            "GET /tenant/endorser-connection failed", existing, max_body=800
+        )
+        return False
+
+    if existing.ok:
+        endorser_summary = http_json_dict(existing) or {}
+        state = (endorser_summary.get("state") or "").lower()
+        connection_id = endorser_summary.get("connection_id")
+        if connection_id:
+            connection_id = str(connection_id)
+            if state == "active":
+                verified, fold_state = _endorser_verify_active_connection_row(
+                    issuer, context, connection_id
+                )
+                if verified:
+                    return True
+                if fold_state:
+                    state = fold_state
+        if state in ("abandoned", "deleted"):
+            LOG.warning(
+                "Existing endorser connection %s is %s; creating a new connection",
+                connection_id or "(no id)",
+                state,
+            )
+        elif connection_id:
+            LOG.info(
+                "Endorser connection exists (connection_id=%s state=%s); waiting for active (no duplicate POST)",
+                connection_id,
+                state or "?",
+            )
+
+            existing_connection_poll_result = poll_until(
+                lambda: _endorser_connection_poll_once(issuer, connection_id),
+                timeout_sec=E2E_INDY_CONNECTION_TIMEOUT_SEC,
+                interval_sec=E2E_INDY_CONNECTION_POLL_SEC,
+                description="existing endorser connection active",
+            )
+            if existing_connection_poll_result is True:
+                context.indy_endorser_connection_id = connection_id
+                LOG.info("Endorser connection active (connection_id=%s)", connection_id)
+                return True
+            return False
+        else:
+            LOG.info(
+                "GET /tenant/endorser-connection has no connection_id (state=%s); POST to create one",
+                state or "?",
+            )
+
+    if not existing.ok:
+        LOG.info("No existing endorser connection (HTTP %s); POST to create one", existing.status_code)
+
+    post = issuer.post_tenant_endorser_connection()
+    if not post.ok:
+        log_http_failed(
+            "POST /tenant/endorser-connection failed", post, max_body=1200
+        )
+        return False
+    create_endorser_payload = http_json_dict(post) or {}
+    connection_id = create_endorser_payload.get("connection_id")
+    if not connection_id:
+        LOG.error("POST /tenant/endorser-connection response missing connection_id")
+        return False
+    connection_id = str(connection_id)
+    LOG.info(
+        "Endorser connection created connection_id=%s state=%s",
+        connection_id,
+        create_endorser_payload.get("state"),
+    )
+
+    endorser_connection_poll_result = poll_until(
+        lambda: _endorser_connection_poll_once(issuer, connection_id),
+        timeout_sec=E2E_INDY_CONNECTION_TIMEOUT_SEC,
+        interval_sec=E2E_INDY_CONNECTION_POLL_SEC,
+        description="endorser connection active",
+    )
+    if endorser_connection_poll_result is not True:
+        return False
+
+    context.indy_endorser_connection_id = connection_id
+    LOG.info("Endorser connection active (connection_id=%s)", connection_id)
+    return True
+
+
+def _register_nym_alias(context: Context) -> str:
+    env_alias = os.environ.get("E2E_INDY_REGISTER_NYM_ALIAS", "").strip()
+    if env_alias:
+        return env_alias
+    issuer = context.issuer_client()
+    tenant_self_response = issuer.get_tenant_self()
+    if tenant_self_response.ok:
+        body = http_json_dict(tenant_self_response) or {}
+        name = body.get("tenant_name") or body.get("wallet_id")
+        if name:
+            return str(name)
+    return "webvh-e2e-indy"
+
+
+def phase_indy_register_public_did(context: Context) -> bool:
+    """
+    Issuer: create an Indy DID, POST /ledger/register-nym (endorsed), wait for transaction,
+    verify on ledger, POST /wallet/did/public, PUT /tenant/config/set-ledger-id.
+
+    Skips registration if GET /wallet/did/public already returns a DID (idempotent for re-runs).
+    """
+    ledger_id = (context.indy_write_ledger_id or "").strip()
+    if not ledger_id:
+        LOG.error("Missing indy_write_ledger_id")
+        return False
+
+    issuer = context.issuer_client()
+
+    existing_did = _issuer_existing_public_did_short(issuer)
+    if existing_did:
+        LOG.info("Wallet already has public DID %s; skipping register-nym flow", existing_did)
+        context.indy_public_did = existing_did
+        return True
+
+    create = issuer.post_wallet_did_create(
+        {"method": "sov", "options": {"key_type": "ed25519"}},
+    )
+    if not create.ok:
+        log_http_failed("POST /wallet/did/create failed", create, max_body=1200)
+        return False
+    create_did_payload = http_json_dict(create) or {}
+    did_create_result = (
+        create_did_payload.get("result")
+        if isinstance(create_did_payload.get("result"), dict)
+        else create_did_payload
+    )
+    if not isinstance(did_create_result, dict):
+        LOG.error("Unexpected /wallet/did/create response shape")
+        return False
+    wallet_did = did_create_result.get("did")
+    issuer_verkey = did_create_result.get("verkey")
+    if not wallet_did or not issuer_verkey:
+        LOG.error("create DID response missing did or verkey")
+        return False
+    wallet_did, issuer_verkey = str(wallet_did), str(issuer_verkey)
+    LOG.info("Created wallet DID %s (registering on ledger %s)", wallet_did, ledger_id)
+
+    alias = _register_nym_alias(context)
+    reg = issuer.post_ledger_register_nym(did=wallet_did, verkey=issuer_verkey, alias=alias)
+    if not reg.ok:
+        log_http_failed("POST /ledger/register-nym failed", reg, max_body=1200)
+        return False
+    reg_body = http_json_dict(reg) or {}
+    txn = reg_body.get("txn") if isinstance(reg_body.get("txn"), dict) else {}
+    txn_id = txn.get("transaction_id") if isinstance(txn, dict) else None
+    if not txn_id:
+        LOG.error("register-nym response missing txn.transaction_id")
+        return False
+    txn_id = str(txn_id)
+    LOG.info("Register-nym transaction_id=%s; waiting for endorsement", txn_id)
+
+    def txn_acked() -> bool | None:
+        transaction_response = issuer.get_transaction(txn_id)
+        if not transaction_response.ok:
+            return None
+        transaction_record = http_json_dict(transaction_response) or {}
+        transaction_state = (transaction_record.get("state") or "").lower()
+        if transaction_state == "transaction_acked":
+            return True
+        if transaction_state in (
+            "transaction_cancelled",
+            "transaction_rejected",
+            "transaction_abandoned",
+        ):
+            LOG.error("Transaction %s failed state=%s", txn_id, transaction_state)
+            return False
+        LOG.info(
+            "Waiting for transaction (transaction_id=%s state=%s)",
+            txn_id,
+            transaction_state or "?",
+        )
+        return None
+
+    transaction_poll_result = poll_until(
+        txn_acked,
+        timeout_sec=E2E_INDY_TXN_TIMEOUT_SEC,
+        interval_sec=E2E_INDY_TXN_POLL_SEC,
+        description="register-nym transaction endorsed",
+    )
+    if transaction_poll_result is not True:
+        return False
+
+    ledger_verkey_response = issuer.get_ledger_did_verkey(wallet_did)
+    if not ledger_verkey_response.ok:
+        log_http_failed(
+            "GET /ledger/did-verkey failed", ledger_verkey_response, max_body=800
+        )
+        return False
+    ledger_verkey_body = http_json_dict(ledger_verkey_response) or {}
+    if not ledger_verkey_body.get("verkey"):
+        LOG.error("DID %s not found on ledger after endorsement", wallet_did)
+        return False
+    posted_ledger = ledger_verkey_body.get("ledger_id")
+    if posted_ledger and str(posted_ledger) != ledger_id:
+        LOG.warning(
+            "DID posted on ledger_id=%s (expected %s); continuing",
+            posted_ledger,
+            ledger_id,
+        )
+
+    pub_post = issuer.post_wallet_did_public(wallet_did)
+    if not pub_post.ok:
+        log_http_failed("POST /wallet/did/public failed", pub_post, max_body=800)
+        return False
+
+    cfg = issuer.put_tenant_config_set_ledger_id(ledger_id)
+    if not cfg.ok:
+        LOG.warning(
+            "PUT /tenant/config/set-ledger-id failed (HTTP %s); public DID may still be set",
+            cfg.status_code,
+        )
+
+    context.indy_public_did = wallet_did
+    LOG.info("Indy public DID registered: %s (ledger=%s)", wallet_did, ledger_id)
+    return True

--- a/scripts/webvh-e2e/phases/issue.py
+++ b/scripts/webvh-e2e/phases/issue.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
 from typing import Any
 
@@ -13,72 +12,83 @@ from constants import (
     E2E_ISSUE_POLL_SEC,
     E2E_ISSUE_TIMEOUT_SEC,
 )
-from helpers import poll_until, v20_cred_ex_record_core
-
-LOG = logging.getLogger("webvh-e2e")
+from helpers import LOG, format_json_for_log, log_http_failed, poll_until, v20_cred_ex_record_core
 
 
-def _format_json_log(data: Any) -> str:
-    return json.dumps(data, indent=2, ensure_ascii=False, default=str)
+def _issuer_manual_issue_poll_once(
+    issuer: Any,
+    issuer_cred_ex_id: str,
+    issuer_terminal: frozenset[str],
+) -> str | None:
+    """Poll step for Indy manual issue: ``request-received``, ``terminal``, or still waiting."""
+    issuer_record_response = issuer.get_issue_credential_v2_record(issuer_cred_ex_id)
+    if not issuer_record_response.ok:
+        return None
+    try:
+        issuer_cred_ex_core = v20_cred_ex_record_core(issuer_record_response.json())
+    except json.JSONDecodeError:
+        return None
+    issuer_exchange_state = (issuer_cred_ex_core.get("state") or "").lower()
+    if issuer_exchange_state == "request-received":
+        return "request-received"
+    if issuer_exchange_state in issuer_terminal:
+        return "terminal"
+    return None
 
 
 def _issuer_thread_id(offer_record: dict[str, Any]) -> str | None:
     """Thread id to correlate issuer ↔ holder credential exchange records."""
-    tid = offer_record.get("thread_id") or offer_record.get("parent_thread_id")
-    return str(tid) if tid else None
+    thread_identifier = offer_record.get("thread_id") or offer_record.get("parent_thread_id")
+    return str(thread_identifier) if thread_identifier else None
 
 
 def _holder_rows_match_thread(rows: list[dict[str, Any]], thread_id: str | None) -> list[dict[str, Any]]:
     if not thread_id:
         return list(rows)
-    out: list[dict[str, Any]] = []
-    for row in rows:
-        core = v20_cred_ex_record_core(row)
-        if core.get("thread_id") == thread_id or core.get("parent_thread_id") == thread_id:
-            out.append(row)
-    return out
+    matching_rows: list[dict[str, Any]] = []
+    for cred_ex_row in rows:
+        cred_ex_core = v20_cred_ex_record_core(cred_ex_row)
+        if cred_ex_core.get("thread_id") == thread_id or cred_ex_core.get("parent_thread_id") == thread_id:
+            matching_rows.append(cred_ex_row)
+    return matching_rows
 
 
-def _placeholder_phase(phase_name: str) -> bool:
-    LOG.info("%s phase is not implemented yet.", phase_name)
-    return True
-
-
-def phase_issue_webvh(ctx: Context) -> bool:
+def _phase_issue_anoncreds_cred_def(
+    context: Context,
+    cred_def_id: str,
+    *,
+    log_label: str,
+    explicit_issue_fallback: bool = False,
+) -> bool:
     """
-    Issuer: POST /issue-credential-2.0/send-offer (anoncreds, auto_issue).
+    Issuer: POST /issue-credential-2.0/send-offer (anoncreds).
 
-    Holder: POST …/send-request when offer is received.
-    Poll until issuer exchange reaches a terminal issued state.
+    WebVH uses ``auto_issue: true``. Indy uses ``auto_issue: false`` and a single
+    ``POST …/issue`` after the holder’s ``send-request`` — Traction/BCovrin often leaves
+    ``auto_issue`` stuck in ``request-received``, and a manual issue while ``auto_issue`` is
+    true returns **400** and abandons the exchange.
     """
-    if not ctx.webvh_cred_def_id or not ctx.issuer_connection_id:
-        LOG.error("Missing cred_def_id or issuer connection; run prior phases")
+    if not cred_def_id or not context.issuer_connection_id:
+        LOG.error("[%s] Missing cred_def_id or issuer connection; run prior phases", log_label)
         return False
 
-    issuer = ctx.issuer_client()
-    holder = ctx.holder_client()
+    issuer = context.issuer_client()
+    holder = context.holder_client()
 
     offer_body = {
-        "auto_issue": True,
+        "auto_issue": not explicit_issue_fallback,
         "auto_remove": False,
-        "connection_id": ctx.issuer_connection_id,
+        "connection_id": context.issuer_connection_id,
         "credential_preview": {
             "@type": "issue-credential/2.0/credential-preview",
             "attributes": E2E_CREDENTIAL_PREVIEW_ATTRIBUTES,
         },
-        "filter": {"anoncreds": {"cred_def_id": ctx.webvh_cred_def_id}},
+        "filter": {"anoncreds": {"cred_def_id": cred_def_id}},
         "trace": False,
     }
     offer_response = issuer.post_issue_credential_v2_send_offer(offer_body)
     if not offer_response.ok:
-        LOG.error(
-            "POST /issue-credential-2.0/send-offer failed (HTTP %s)",
-            offer_response.status_code,
-        )
-        LOG.debug(
-            "send-offer error body:\n%s",
-            (offer_response.text or "")[:4000],
-        )
+        log_http_failed("POST /issue-credential-2.0/send-offer failed", offer_response)
         return False
 
     try:
@@ -86,16 +96,13 @@ def phase_issue_webvh(ctx: Context) -> bool:
     except json.JSONDecodeError:
         LOG.error("send-offer returned non-JSON")
         return False
-    LOG.debug(
-        "POST /issue-credential-2.0/send-offer response:\n%s",
-        _format_json_log(offer_record),
-    )
+    LOG.debug("POST /issue-credential-2.0/send-offer response:\n%s", format_json_for_log(offer_record))
 
     offer_core = v20_cred_ex_record_core(offer_record)
     raw_cred_ex_id = offer_record.get("cred_ex_id") or offer_core.get("cred_ex_id")
     if not raw_cred_ex_id:
         LOG.error("send-offer response missing cred_ex_id")
-        LOG.debug("send-offer body:\n%s", _format_json_log(offer_record))
+        LOG.debug("send-offer body:\n%s", format_json_for_log(offer_record))
         return False
     issuer_cred_ex_id = str(raw_cred_ex_id)
     thread_id = _issuer_thread_id(offer_record) or _issuer_thread_id(offer_core)
@@ -107,13 +114,22 @@ def phase_issue_webvh(ctx: Context) -> bool:
     diag_interval = 30.0
     last_diag = time.monotonic()
 
+    issuer_terminal = frozenset(
+        {
+            "done",
+            "credential-issued",
+            "credential-acked",
+            "credential-received",
+        }
+    )
+
     # Do not filter GET by state=offer-received — some agents omit rows or move state quickly.
     def holder_exchange_status() -> str | None:
         nonlocal last_diag
         records = holder.get_issue_credential_v2_records(
             params={
                 "role": "holder",
-                "connection_id": ctx.holder_connection_id,
+                "connection_id": context.holder_connection_id,
             }
         )
         if not records.ok:
@@ -137,28 +153,32 @@ def phase_issue_webvh(ctx: Context) -> bool:
         if time.monotonic() - last_diag >= diag_interval:
             last_diag = time.monotonic()
             summary = []
-            for r in candidates[:8]:
-                c = v20_cred_ex_record_core(r)
+            for cred_ex_row in candidates[:8]:
+                cred_ex_core = v20_cred_ex_record_core(cred_ex_row)
                 summary.append(
-                    (c.get("cred_ex_id"), (c.get("state") or "").lower(), c.get("thread_id"))
+                    (
+                        cred_ex_core.get("cred_ex_id"),
+                        (cred_ex_core.get("state") or "").lower(),
+                        cred_ex_core.get("thread_id"),
+                    )
                 )
             LOG.info(
                 "Waiting for holder credential exchange (connection_id=%s); "
                 "matching rows (up to 8): %s",
-                ctx.holder_connection_id,
+                context.holder_connection_id,
                 summary,
             )
 
-        for row in candidates:
-            core = v20_cred_ex_record_core(row)
-            state = (core.get("state") or "").lower()
-            cid = core.get("cred_ex_id")
-            if not cid:
+        for cred_ex_row in candidates:
+            cred_ex_core = v20_cred_ex_record_core(cred_ex_row)
+            holder_state = (cred_ex_core.get("state") or "").lower()
+            holder_cred_ex_id = cred_ex_core.get("cred_ex_id")
+            if not holder_cred_ex_id:
                 continue
-            if state == "offer-received":
-                return f"send:{cid}"
-            if state in ("done", "credential-received"):
-                return f"done:{cid}"
+            if holder_state == "offer-received":
+                return f"send:{holder_cred_ex_id}"
+            if holder_state in ("done", "credential-received"):
+                return f"done:{holder_cred_ex_id}"
 
         return None
 
@@ -180,24 +200,41 @@ def phase_issue_webvh(ctx: Context) -> bool:
         LOG.info("Holder cred_ex_id=%s state=offer-received; POST send-request", holder_cred_ex_id)
         send_req = holder.post_issue_credential_v2_send_request(holder_cred_ex_id)
         if not send_req.ok:
-            LOG.error(
-                "Holder POST /issue-credential-2.0/records/…/send-request failed (HTTP %s)",
-                send_req.status_code,
-            )
-            LOG.debug(
-                "send-request error body:\n%s",
-                (send_req.text or "")[:4000],
+            log_http_failed(
+                "Holder POST /issue-credential-2.0/records/…/send-request failed", send_req
             )
             return False
         LOG.info(
             "Holder send-request accepted (HTTP %s); polling issuer until terminal state",
             send_req.status_code,
         )
-        try:
-            LOG.debug(
-                "Holder send-request response:\n%s",
-                _format_json_log(send_req.json()),
+        if explicit_issue_fallback:
+            manual_phase = poll_until(
+                lambda: _issuer_manual_issue_poll_once(
+                    issuer, issuer_cred_ex_id, issuer_terminal
+                ),
+                timeout_sec=timeout_sec,
+                interval_sec=poll_sec,
+                description="issuer request-received for Indy manual issue",
             )
+            if manual_phase == "request-received":
+                issue_resp = issuer.post_issue_credential_v2_issue(issuer_cred_ex_id)
+                if not issue_resp.ok:
+                    log_http_failed(
+                        f"[{log_label}] Issuer POST …/issue failed", issue_resp
+                    )
+                    return False
+                LOG.info("[%s] Issuer POST …/issue accepted after holder send-request", log_label)
+            elif manual_phase != "terminal":
+                LOG.error(
+                    "[%s] Issuer did not reach request-received for manual issue (got %s)",
+                    log_label,
+                    manual_phase,
+                )
+                return False
+
+        try:
+            LOG.debug("Holder send-request response:\n%s", format_json_for_log(send_req.json()))
         except json.JSONDecodeError:
             pass
     elif holder_outcome.startswith("done:"):
@@ -210,80 +247,108 @@ def phase_issue_webvh(ctx: Context) -> bool:
         LOG.error("Unexpected holder outcome: %s", holder_outcome)
         return False
 
-    issuer_terminal = frozenset(
-        {
-            "done",
-            "credential-issued",
-            "credential-acked",
-            "credential-received",
-        }
-    )
-
     def issuer_cred_ex_done() -> bool | None:
         nonlocal last_diag
-        response = issuer.get_issue_credential_v2_record(issuer_cred_ex_id)
-        if not response.ok:
+        issuer_record_response = issuer.get_issue_credential_v2_record(issuer_cred_ex_id)
+        if not issuer_record_response.ok:
             if time.monotonic() - last_diag >= diag_interval:
                 last_diag = time.monotonic()
                 LOG.warning(
                     "Issuer GET /issue-credential-2.0/records/%s failed: %s",
                     issuer_cred_ex_id,
-                    response.status_code,
+                    issuer_record_response.status_code,
                 )
             return None
         try:
-            row = response.json()
+            issuer_record = issuer_record_response.json()
         except json.JSONDecodeError:
             return None
-        core = v20_cred_ex_record_core(row)
-        state = (core.get("state") or "").lower()
-        if state in issuer_terminal:
-            LOG.info("Issuer cred_ex_id=%s state=%s (terminal)", issuer_cred_ex_id, state)
+        issuer_cred_ex_core = v20_cred_ex_record_core(issuer_record)
+        issuer_exchange_state = (issuer_cred_ex_core.get("state") or "").lower()
+
+        if issuer_exchange_state in issuer_terminal:
+            LOG.info(
+                "Issuer cred_ex_id=%s state=%s (terminal)",
+                issuer_cred_ex_id,
+                issuer_exchange_state,
+            )
             return True
-        if state in ("abandoned", "credential-revoked", "deleted"):
-            LOG.error("Issuer cred exchange entered failure state: %s", state)
+        if issuer_exchange_state in ("abandoned", "credential-revoked", "deleted"):
+            LOG.error("Issuer cred exchange entered failure state: %s", issuer_exchange_state)
             return False
         if time.monotonic() - last_diag >= diag_interval:
             last_diag = time.monotonic()
             LOG.info(
                 "Waiting for issuer credential exchange (cred_ex_id=%s state=%s)",
                 issuer_cred_ex_id,
-                state or "?",
+                issuer_exchange_state or "?",
             )
         return None
 
     last_diag = time.monotonic()
-    done = poll_until(
+    issuer_exchange_poll_result = poll_until(
         lambda: issuer_cred_ex_done(),
         timeout_sec=timeout_sec,
         interval_sec=poll_sec,
         description="issuer credential exchange completed",
     )
-    if done is not True:
+    if issuer_exchange_poll_result is not True:
         # Final snapshot for debugging
-        snap = issuer.get_issue_credential_v2_record(issuer_cred_ex_id)
-        if snap.ok:
+        final_issuer_record_response = issuer.get_issue_credential_v2_record(issuer_cred_ex_id)
+        if final_issuer_record_response.ok:
             try:
-                snap_row = snap.json()
-                snap_core = v20_cred_ex_record_core(snap_row)
-                st = (snap_core.get("state") or "") if snap_core else ""
+                final_issuer_record = final_issuer_record_response.json()
+                final_issuer_core = v20_cred_ex_record_core(final_issuer_record)
+                final_issuer_state = (final_issuer_core.get("state") or "") if final_issuer_core else ""
                 LOG.error(
                     "Issuer exchange still not terminal (cred_ex_id=%s state=%s)",
                     issuer_cred_ex_id,
-                    st or "?",
+                    final_issuer_state or "?",
                 )
-                LOG.debug(
-                    "Issuer last record:\n%s",
-                    _format_json_log(snap_row),
-                )
+                LOG.debug("Issuer last record:\n%s", format_json_for_log(final_issuer_record))
             except json.JSONDecodeError:
                 pass
         return False
 
-    ctx.issuer_cred_ex_id = issuer_cred_ex_id
-    LOG.info("Issued credential; issuer cred_ex_id=%s", issuer_cred_ex_id)
+    context.issuer_cred_ex_id = issuer_cred_ex_id
+    LOG.info("[%s] Issued credential; issuer cred_ex_id=%s", log_label, issuer_cred_ex_id)
     return True
 
 
-def phase_issue_indy(_ctx: Context) -> bool:
-    return _placeholder_phase("issue-indy")
+def _issue_phase(
+    context: Context,
+    *,
+    cred_def_attr: str,
+    publish_phase_hint: str,
+    log_label: str,
+    explicit_issue_fallback: bool,
+) -> bool:
+    cred_def_id = (getattr(context, cred_def_attr, None) or "").strip()
+    if not cred_def_id:
+        LOG.error("Missing %s; run %s first", cred_def_attr, publish_phase_hint)
+        return False
+    return _phase_issue_anoncreds_cred_def(
+        context, cred_def_id, log_label=log_label, explicit_issue_fallback=explicit_issue_fallback
+    )
+
+
+def phase_issue_webvh(context: Context) -> bool:
+    """AnonCreds issue using WebVH issuer cred def."""
+    return _issue_phase(
+        context,
+        cred_def_attr="webvh_cred_def_id",
+        publish_phase_hint="publish-cred-def-webvh",
+        log_label="webvh",
+        explicit_issue_fallback=False,
+    )
+
+
+def phase_issue_indy(context: Context) -> bool:
+    """AnonCreds issue using Indy (BCovrin) issuer cred def."""
+    return _issue_phase(
+        context,
+        cred_def_attr="indy_cred_def_id",
+        publish_phase_hint="publish-cred-def-indy",
+        log_label="indy",
+        explicit_issue_fallback=True,
+    )

--- a/scripts/webvh-e2e/phases/revoke.py
+++ b/scripts/webvh-e2e/phases/revoke.py
@@ -3,20 +3,24 @@
 from __future__ import annotations
 
 import json
-import logging
+import time
 from typing import Any
 
 from context import Context
-from constants import E2E_REVOKE_NOTIFY, E2E_REVOKE_PUBLISH
-from helpers import v20_cred_ex_record_core
+from constants import (
+    E2E_REVOKE_LEDGER_LOG_INTERVAL_SEC,
+    E2E_REVOKE_LEDGER_POLL_SEC,
+    E2E_REVOKE_LEDGER_TIMEOUT_SEC,
+    E2E_REVOKE_NOTIFY,
+    E2E_REVOKE_PUBLISH,
+)
+from helpers import LOG, log_http_failed, poll_until, v20_cred_ex_record_core
 
-LOG = logging.getLogger("webvh-e2e")
 
-
-def _revocation_ids_from_flat_cred_ex(d: dict[str, Any]) -> tuple[str | None, str | None]:
+def _revocation_ids_from_flat_cred_ex(cred_ex_dict: dict[str, Any]) -> tuple[str | None, str | None]:
     """``rev_reg_id`` / ``cred_rev_id`` under ``anoncreds`` or ``indy`` on one record object."""
     for key in ("anoncreds", "indy"):
-        block = d.get(key)
+        block = cred_ex_dict.get(key)
         if not isinstance(block, dict):
             continue
         rev_reg_id = block.get("rev_reg_id")
@@ -32,37 +36,141 @@ def _revocation_ids_from_cred_ex_payload(detail: dict[str, Any]) -> tuple[str | 
     Same unwrapping as issue phase: try outer ``V20CredExRecordDetail``, then ``cred_ex_record`` core.
     Revocation fields may live only on the inner object.
     """
-    seen: set[int] = set()
-    for cand in (detail, v20_cred_ex_record_core(detail)):
-        cid = id(cand)
-        if cid in seen:
+    seen_object_ids: set[int] = set()
+    for candidate in (detail, v20_cred_ex_record_core(detail)):
+        candidate_id = id(candidate)
+        if candidate_id in seen_object_ids:
             continue
-        seen.add(cid)
-        rev_reg_id, cred_rev_id = _revocation_ids_from_flat_cred_ex(cand)
+        seen_object_ids.add(candidate_id)
+        rev_reg_id, cred_rev_id = _revocation_ids_from_flat_cred_ex(candidate)
         if rev_reg_id and cred_rev_id:
             return rev_reg_id, cred_rev_id
     return None, None
 
 
-def phase_revoke_webvh(ctx: Context) -> bool:
-    """POST /anoncreds/revocation/revoke for the issued credential (publish)."""
-    cred_ex_id = ctx.issuer_cred_ex_id
-    if not cred_ex_id:
-        LOG.error("No issuer cred_ex_id; run issue-webvh first")
+def _ledger_revoked_cred_indices(payload: dict[str, Any]) -> set[int]:
+    """Indices from ``GET …/issued/indy_recs`` ``rev_reg_delta.value.revoked``."""
+    delta = payload.get("rev_reg_delta")
+    if not isinstance(delta, dict):
+        return set()
+    value = delta.get("value")
+    if not isinstance(value, dict):
+        return set()
+    raw = value.get("revoked")
+    if not isinstance(raw, (list, tuple)):
+        return set()
+    revoked_indices: set[int] = set()
+    for raw_index in raw:
+        try:
+            revoked_indices.add(int(raw_index))
+        except (TypeError, ValueError):
+            continue
+    return revoked_indices
+
+
+def _wait_for_revocation_on_ledger(
+    client: Any,
+    *,
+    rev_reg_id: str,
+    cred_rev_id: str,
+    log_label: str,
+) -> bool:
+    """
+    Poll ledger until ``cred_rev_id`` appears in the revocation registry delta.
+
+    With ``publish: true`` the admin revoke call can still return before an endorser finishes
+    writing the registry entry; verifiers read the ledger, so post-revoke proofs need this.
+    """
+    try:
+        expected_cred_rev_index = int(str(cred_rev_id).strip())
+    except ValueError:
+        LOG.error("[%s] Invalid cred_rev_id for ledger wait: %r", log_label, cred_rev_id)
         return False
 
-    client = ctx.issuer_client()
-    rec = client.get_issue_credential_v2_record(cred_ex_id)
-    if not rec.ok:
-        LOG.error(
-            "GET /issue-credential-2.0/records/%s failed (HTTP %s); cannot revoke",
-            cred_ex_id,
-            rec.status_code,
+    last_progress_log = 0.0
+
+    def maybe_progress(msg: str) -> None:
+        nonlocal last_progress_log
+        now = time.monotonic()
+        if now - last_progress_log >= E2E_REVOKE_LEDGER_LOG_INTERVAL_SEC:
+            last_progress_log = now
+            LOG.info("[%s] %s", log_label, msg)
+
+    LOG.info(
+        "[%s] Waiting for cred_rev_id=%s on ledger (rev_reg_id=%s, timeout=%.0fs)",
+        log_label,
+        expected_cred_rev_index,
+        rev_reg_id,
+        E2E_REVOKE_LEDGER_TIMEOUT_SEC,
+    )
+
+    def fetch() -> bool | None:
+        indy_recs_response = client.get_anoncreds_revocation_registry_issued_indy_recs(rev_reg_id)
+        if not indy_recs_response.ok:
+            maybe_progress(
+                f"indy_recs HTTP {indy_recs_response.status_code} rev_reg_id={rev_reg_id} — still waiting"
+            )
+            return None
+        try:
+            indy_recs_payload = indy_recs_response.json()
+        except json.JSONDecodeError:
+            maybe_progress("indy_recs non-JSON — still waiting")
+            return None
+        if not isinstance(indy_recs_payload, dict):
+            return None
+        ledger_revoked = _ledger_revoked_cred_indices(indy_recs_payload)
+        if expected_cred_rev_index in ledger_revoked:
+            LOG.info(
+                "[%s] Ledger shows cred_rev_id=%s revoked (rev_reg_id=%s)",
+                log_label,
+                expected_cred_rev_index,
+                rev_reg_id,
+            )
+            return True
+        maybe_progress(
+            f"cred_rev_id={expected_cred_rev_index} not in ledger revoked set "
+            f"{sorted(ledger_revoked)!r} (rev_reg_id={rev_reg_id})"
         )
-        LOG.debug("GET cred ex error:\n%s", (rec.text or "")[:2000])
+        return None
+
+    poll_result = poll_until(
+        fetch,
+        timeout_sec=E2E_REVOKE_LEDGER_TIMEOUT_SEC,
+        interval_sec=E2E_REVOKE_LEDGER_POLL_SEC,
+        description=(
+            f"{log_label} revocation on ledger (rev_reg_id={rev_reg_id} "
+            f"cred_rev_id={expected_cred_rev_index})"
+        ),
+    )
+    if poll_result is True:
+        return True
+    LOG.error(
+        "[%s] Timed out waiting for cred_rev_id=%s on ledger (rev_reg_id=%s)",
+        log_label,
+        expected_cred_rev_index,
+        rev_reg_id,
+    )
+    return False
+
+
+def _phase_revoke_issued_cred_ex(context: Context, *, log_label: str) -> bool:
+    """POST /anoncreds/revocation/revoke for the last issued credential (publish)."""
+    cred_ex_id = context.issuer_cred_ex_id
+    if not cred_ex_id:
+        LOG.error("[%s] No issuer cred_ex_id; run issue phase first", log_label)
+        return False
+
+    client = context.issuer_client()
+    cred_ex_response = client.get_issue_credential_v2_record(cred_ex_id)
+    if not cred_ex_response.ok:
+        log_http_failed(
+            f"GET /issue-credential-2.0/records/{cred_ex_id} failed; cannot revoke",
+            cred_ex_response,
+            max_body=2000,
+        )
         return False
     try:
-        detail = rec.json()
+        detail = cred_ex_response.json()
     except json.JSONDecodeError:
         LOG.error("Issuer credential exchange record returned non-JSON")
         return False
@@ -89,21 +197,50 @@ def phase_revoke_webvh(ctx: Context) -> bool:
 
     response = client.post_anoncreds_revocation_revoke(body)
     if not response.ok:
-        err = (response.text or "").strip()
-        LOG.error(
-            "POST /anoncreds/revocation/revoke failed (HTTP %s)%s",
-            response.status_code,
-            f": {err[:500]}" if err else "",
-        )
-        LOG.debug(
-            "revoke error body:\n%s",
-            (response.text or "")[:4000],
-        )
+        log_http_failed("POST /anoncreds/revocation/revoke failed", response)
         return False
     try:
         payload = response.json()
     except json.JSONDecodeError:
         payload = {}
-    LOG.info("Revoked credential cred_ex_id=%s", cred_ex_id)
+    LOG.info("[%s] Revoked credential cred_ex_id=%s", log_label, cred_ex_id)
     LOG.debug("revoke response: %s", payload)
+
+    wait_rev_reg, wait_cred_rev = rev_reg_id, cred_rev_id
+    if (not wait_rev_reg or not wait_cred_rev) and E2E_REVOKE_PUBLISH:
+        cred_ex_refresh_response = client.get_issue_credential_v2_record(cred_ex_id)
+        if cred_ex_refresh_response.ok:
+            try:
+                refreshed_detail = cred_ex_refresh_response.json()
+            except json.JSONDecodeError:
+                refreshed_detail = None
+            if isinstance(refreshed_detail, dict):
+                wait_rev_reg, wait_cred_rev = _revocation_ids_from_cred_ex_payload(refreshed_detail)
+
+    # Indy BCovrin: endorser can return from revoke before the delta is readable on-ledger; WebVH paths
+    # use a different registry — ``indy_recs`` is not applicable there.
+    if (
+        log_label == "indy"
+        and E2E_REVOKE_PUBLISH
+        and wait_rev_reg
+        and wait_cred_rev
+    ):
+        if not _wait_for_revocation_on_ledger(
+            client,
+            rev_reg_id=wait_rev_reg,
+            cred_rev_id=wait_cred_rev,
+            log_label=log_label,
+        ):
+            return False
+
     return True
+
+
+def phase_revoke_webvh(context: Context) -> bool:
+    """Revoke credential from WebVH issue flow."""
+    return _phase_revoke_issued_cred_ex(context, log_label="webvh")
+
+
+def phase_revoke_indy(context: Context) -> bool:
+    """Revoke credential from Indy issue flow."""
+    return _phase_revoke_issued_cred_ex(context, log_label="indy")

--- a/scripts/webvh-e2e/phases/setup.py
+++ b/scripts/webvh-e2e/phases/setup.py
@@ -3,28 +3,35 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
-
+import uuid
+from collections.abc import Callable
 from typing import Any
 
 from context import Context
 from constants import (
+    E2E_CRED_DEF_POST_RETRY_TIMEOUT_SEC,
     E2E_CRED_DEF_TAG,
+    E2E_INDY_CRED_DEF_TAG_PREFIX,
+    E2E_INDY_CRED_DEF_PUBLISH_SETTLE_SEC,
     E2E_REVOCATION_REGISTRY_SIZE,
+    E2E_REV_REG_ACTIVE_POLL_SEC,
+    E2E_REV_REG_ACTIVE_TIMEOUT_SEC,
+    E2E_REV_REG_WAIT_LOG_INTERVAL_SEC,
     E2E_SCHEMA_ATTR_NAMES,
     E2E_SCHEMA_NAME,
     E2E_SCHEMA_VERSION,
     WALLET_UPGRADE_POLL_SEC,
     WALLET_UPGRADE_TIMEOUT_SEC,
 )
-
-LOG = logging.getLogger(__name__)
-
-
-def _format_json_log(data: Any) -> str:
-    """Pretty JSON for logs (matches ``webvh._format_webvh_config_json`` style)."""
-    return json.dumps(data, indent=2, ensure_ascii=False, default=str)
+from helpers import (
+    LOG,
+    format_json_for_log,
+    log_http_failed,
+    poll_until,
+    tenant_wallet_name,
+    tenant_wallet_storage_type,
+)
 
 
 _CRED_DEF_LOG_OMIT_KEYS = frozenset({"value"})
@@ -58,53 +65,20 @@ def _log_http_response(
         parsed = json.loads(raw)
         if redact_keys:
             parsed = _omit_json_keys(parsed, redact_keys)
-        LOG.debug("%s response body:\n%s", label, _format_json_log(parsed))
+        LOG.debug("%s response body:\n%s", label, format_json_for_log(parsed))
     except (json.JSONDecodeError, TypeError):
         snippet = raw[:2000] if raw else "(empty body)"
         LOG.debug("%s response text:\n%s", label, snippet)
 
 
-def _wallet_settings_blob(wallet: dict[str, Any]) -> dict[str, Any]:
-    settings_value = wallet.get("settings")
-    return settings_value if isinstance(settings_value, dict) else {}
-
-
-def _wallet_name_from_response(wallet: dict[str, Any]) -> str | None:
-    """
-    Multitenant wallet name for ``POST /anoncreds/wallet/upgrade``.
-
-    ACA-Py ``GET /settings`` does not return ``wallet.name`` (filtered dict); use
-    ``GET /tenant/wallet`` → ``settings['wallet.name']``.
-    """
-    name = _wallet_settings_blob(wallet).get("wallet.name")
-    if isinstance(name, str) and name.strip():
-        return name.strip()
-    return None
-
-
-def _wallet_type_from_response(wallet: dict[str, Any]) -> str | None:
-    """Wallet storage type (e.g. askar / askar-anoncreds) from tenant wallet payload."""
-    top_level = wallet.get("type")
-    if isinstance(top_level, str) and top_level:
-        return top_level
-    from_settings = _wallet_settings_blob(wallet).get("wallet.type")
-    return from_settings if isinstance(from_settings, str) else None
-
-
-def phase_upgrade_anoncreds_wallet(ctx: Context) -> bool:
-    """
-    Ensure issuer wallet is upgraded to askar-anoncreds (POST /anoncreds/wallet/upgrade, poll GET /tenant/wallet).
-
-    Requires issuer bearer token. Skips if already askar-anoncreds.
-    """
-    client = ctx.issuer_client()
+def phase_upgrade_anoncreds_wallet(context: Context) -> bool:
+    """POST /anoncreds/wallet/upgrade + poll GET /tenant/wallet until askar-anoncreds (or skip if already)."""
+    client = context.issuer_client()
 
     initial_wallet_response = client.get_tenant_wallet()
     if not initial_wallet_response.ok:
-        LOG.error(
-            "GET /tenant/wallet failed: %s %s",
-            initial_wallet_response.status_code,
-            initial_wallet_response.text[:500],
+        log_http_failed(
+            "GET /tenant/wallet failed", initial_wallet_response, max_body=500
         )
         return False
     try:
@@ -113,14 +87,14 @@ def phase_upgrade_anoncreds_wallet(ctx: Context) -> bool:
         LOG.error("GET /tenant/wallet returned non-JSON")
         return False
 
-    wallet_name = _wallet_name_from_response(wallet)
+    wallet_name = tenant_wallet_name(wallet)
     if not wallet_name:
         LOG.error(
             "GET /tenant/wallet missing settings.wallet.name; cannot upgrade wallet"
         )
         return False
 
-    wallet_storage_type = _wallet_type_from_response(wallet)
+    wallet_storage_type = tenant_wallet_storage_type(wallet)
     if wallet_storage_type == "askar-anoncreds":
         LOG.info("Issuer wallet already askar-anoncreds; skipping upgrade")
         return True
@@ -131,10 +105,8 @@ def phase_upgrade_anoncreds_wallet(ctx: Context) -> bool:
     )
     upgrade_response = client.post_anoncreds_wallet_upgrade(wallet_name)
     if not upgrade_response.ok:
-        LOG.error(
-            "POST /anoncreds/wallet/upgrade failed: %s %s",
-            upgrade_response.status_code,
-            upgrade_response.text[:500],
+        log_http_failed(
+            "POST /anoncreds/wallet/upgrade failed", upgrade_response, max_body=500
         )
         return False
 
@@ -154,7 +126,7 @@ def phase_upgrade_anoncreds_wallet(ctx: Context) -> bool:
         except json.JSONDecodeError:
             time.sleep(poll_interval_sec)
             continue
-        if _wallet_type_from_response(polled_wallet) == "askar-anoncreds":
+        if tenant_wallet_storage_type(polled_wallet) == "askar-anoncreds":
             LOG.info("Issuer wallet upgraded to askar-anoncreds")
             return True
         time.sleep(poll_interval_sec)
@@ -164,55 +136,123 @@ def phase_upgrade_anoncreds_wallet(ctx: Context) -> bool:
 
 
 def _extract_schema_id_from_post(body: dict[str, Any]) -> str | None:
-    state = body.get("schema_state") or body.get("sent") or {}
-    sid = state.get("schema_id")
-    return str(sid) if sid else None
+    schema_state_block = body.get("schema_state") or body.get("sent") or {}
+    schema_id_value = schema_state_block.get("schema_id")
+    return str(schema_id_value) if schema_id_value else None
 
 
 def _extract_cred_def_id_from_post(body: dict[str, Any]) -> str | None:
-    state = body.get("credential_definition_state") or body.get("sent") or {}
-    cid = state.get("credential_definition_id")
-    return str(cid) if cid else None
+    cred_def_state_block = body.get("credential_definition_state") or body.get("sent") or {}
+    credential_definition_id_value = cred_def_state_block.get("credential_definition_id")
+    return str(credential_definition_id_value) if credential_definition_id_value else None
 
 
-def phase_publish_schema(ctx: Context) -> bool:
+def _indy_unqualified_issuer_id(did: str | None) -> str | None:
     """
-    POST /anoncreds/schema for the WebVH issuer DID (``ctx.webvh_last_created_did``).
-
-    Idempotent: if a matching schema exists (name, version, issuer), reuse it.
+    Indy anoncreds list/write APIs on some deployments resolve ``issuerId`` / ``schema_issuer_id``
+    only when the issuer is **unqualified** (no ``did:sov:`` prefix). Short public DID or
+    ``did:sov:…`` both normalize to the ledger short form.
     """
-    issuer_did = ctx.webvh_last_created_did
+    if not did:
+        return None
+    did_str = did.strip()
+    if did_str.startswith("did:sov:"):
+        return did_str[8:]
+    return did_str
+
+
+def _indy_strip_did_sov_prefix(resource_id: str | None) -> str | None:
+    """Strip leading ``did:sov:`` so Indy ledger ids match unqualified anoncreds resolution."""
+    if not resource_id:
+        return None
+    resource_id_str = resource_id.strip()
+    if resource_id_str.startswith("did:sov:"):
+        return resource_id_str[8:]
+    return resource_id_str
+
+
+_SCHEMA_DUP_PHRASES = (
+    "already exists",
+    "already exist",
+    "duplicate",
+    "schema already",
+    "exists on",
+)
+
+
+def _phase_publish_anoncreds_schema(
+    context: Context,
+    *,
+    issuer_did: str | None,
+    schema_attr: str,
+    log_label: str,
+    indy_unqualified_ids: bool = False,
+) -> bool:
+    """POST /anoncreds/schema (idempotent list); store on context.<schema_attr>. Indy path strips did:sov:."""
     if not issuer_did:
-        LOG.error("No did:webvh on context; run webvh-create first")
+        if log_label == "webvh":
+            LOG.error("No did:webvh on context; run webvh-create first")
+        else:
+            LOG.error("No Indy public DID on context; run indy-register-public-did first")
         return False
+
+    if indy_unqualified_ids:
+        issuer_did = _indy_unqualified_issuer_id(issuer_did)
+        if not issuer_did:
+            LOG.error("[%s] Could not derive unqualified issuer id", log_label)
+            return False
 
     name = E2E_SCHEMA_NAME
     version = E2E_SCHEMA_VERSION
     attr_names = E2E_SCHEMA_ATTR_NAMES
-    client = ctx.issuer_client()
-
+    client = context.issuer_client()
     list_query = {
         "schema_name": name,
         "schema_version": version,
         "schema_issuer_id": issuer_did,
     }
-    list_response = client.get_anoncreds_schemas(params=list_query)
-    LOG.info(
-        "GET /anoncreds/schemas\nquery:\n%s",
-        _format_json_log(list_query),
-    )
-    _log_http_response("GET /anoncreds/schemas", list_response.status_code, list_response.text or "")
 
-    if list_response.ok:
+    def _schemas_get(note: str = "") -> Any:
+        suffix = f" {note}" if note else ""
+        LOG.info("[%s] GET /anoncreds/schemas%s", log_label, suffix)
+        LOG.debug("[%s] GET /anoncreds/schemas query:\n%s", log_label, format_json_for_log(list_query))
+        r = client.get_anoncreds_schemas(params=list_query)
+        _log_http_response("GET /anoncreds/schemas", r.status_code, r.text or "")
+        return r
+
+    def _try_schema_reuse_from_list(resp: Any, *, after_dup_post: bool) -> bool:
+        if not resp.ok:
+            return False
         try:
-            data = list_response.json()
+            data = resp.json()
         except json.JSONDecodeError:
             data = {}
         ids = data.get("schema_ids") or []
         if ids:
-            ctx.webvh_schema_id = str(ids[0])
-            LOG.info("Reusing existing schema_id=%s", ctx.webvh_schema_id)
+            sid = (
+                _indy_strip_did_sov_prefix(str(ids[0]))
+                if indy_unqualified_ids
+                else str(ids[0])
+            )
+            setattr(context, schema_attr, sid)
+            if after_dup_post:
+                LOG.info("[%s] Schema already exists; schema_id=%s", log_label, sid)
+            else:
+                LOG.info("[%s] Reusing existing schema_id=%s", log_label, sid)
             return True
+        if after_dup_post and indy_unqualified_ids and issuer_did:
+            sid = f"{issuer_did}:2:{name}:{version}"
+            setattr(context, schema_attr, sid)
+            LOG.info(
+                "[%s] Schema already on ledger (list empty); using Indy schema_id=%s",
+                log_label,
+                sid,
+            )
+            return True
+        return False
+
+    if _try_schema_reuse_from_list(_schemas_get(), after_dup_post=False):
+        return True
 
     post_body = {
         "schema": {
@@ -227,66 +267,210 @@ def phase_publish_schema(ctx: Context) -> bool:
     if not create_response.ok:
         text = create_response.text or ""
         _log_http_response("POST /anoncreds/schema", create_response.status_code, text)
-        if create_response.status_code == 400 and "already exists" in text.lower():
-            list_response = client.get_anoncreds_schemas(params=list_query)
-            LOG.info(
-                "GET /anoncreds/schemas (after already-exists)\nquery:\n%s",
-                _format_json_log(list_query),
-            )
-            _log_http_response(
-                "GET /anoncreds/schemas",
-                list_response.status_code,
-                list_response.text or "",
-            )
-            if list_response.ok:
-                data = list_response.json()
-                ids = data.get("schema_ids") or []
-                if ids:
-                    ctx.webvh_schema_id = str(ids[0])
-                    LOG.info("Schema already exists; schema_id=%s", ctx.webvh_schema_id)
-                    return True
-        LOG.error("POST /anoncreds/schema failed")
+        tl = text.lower()
+        if create_response.status_code == 400 and any(p in tl for p in _SCHEMA_DUP_PHRASES):
+            if _try_schema_reuse_from_list(
+                _schemas_get("(after already-exists)"),
+                after_dup_post=True,
+            ):
+                return True
+        LOG.error("[%s] POST /anoncreds/schema failed", log_label)
         return False
 
     try:
         created = create_response.json()
     except json.JSONDecodeError:
-        LOG.error("POST /anoncreds/schema returned non-JSON")
+        LOG.error("[%s] POST /anoncreds/schema returned non-JSON", log_label)
         return False
 
-    LOG.debug("POST /anoncreds/schema response:\n%s", _format_json_log(created))
+    LOG.debug("[%s] POST /anoncreds/schema response:\n%s", log_label, format_json_for_log(created))
 
     schema_id = _extract_schema_id_from_post(created)
     if not schema_id:
-        LOG.error("Schema create response missing schema_id")
-        LOG.debug("Schema create body:\n%s", _format_json_log(created))
+        LOG.error("[%s] Schema create response missing schema_id", log_label)
+        LOG.debug("Schema create body:\n%s", format_json_for_log(created))
         return False
-    ctx.webvh_schema_id = schema_id
-    LOG.info("Published schema_id=%s", schema_id)
+    if indy_unqualified_ids:
+        schema_id = _indy_strip_did_sov_prefix(schema_id) or schema_id
+    setattr(context, schema_attr, schema_id)
+    LOG.info("[%s] Published schema_id=%s", log_label, schema_id)
     return True
 
 
-def phase_publish_cred_def(ctx: Context) -> bool:
-    """
-    POST /anoncreds/credential-definition with revocation (default registry size 4).
+def _anoncreds_cred_def_tag_from_id(cred_def_id: str) -> str:
+    """Last ``:`` segment of a cred def id (the publish ``tag``)."""
+    parts = cred_def_id.rsplit(":", 1)
+    return parts[-1] if parts else ""
 
-    Requires ``ctx.webvh_schema_id`` and WebVH issuer DID.
-    """
-    issuer_did = ctx.webvh_last_created_did
-    schema_id = ctx.webvh_schema_id
+
+def _rev_reg_record_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Unwrap ``{"result": IssuerRevRegRecord}`` or occasional double-wrapped responses."""
+    top = payload.get("result")
+    if isinstance(top, dict) and isinstance(top.get("result"), dict):
+        return top["result"]
+    if isinstance(top, dict):
+        return top
+    return None
+
+
+# Issuable for issue-credential (Indy often active/posted; WebVH may use finished).
+_REV_REG_READY_STATES = frozenset({"active", "finished"})
+_REV_REG_TERMINAL_BAD = frozenset({"full", "decommissioned"})
+
+
+def _active_registry_poll_step(
+    client: Any,
+    cred_def_id: str,
+    log_label: str,
+    emit_progress: Callable[[str], None],
+) -> bool | None:
+    """Single GET active-registry poll: ``True`` ready, ``False`` error, ``None`` keep waiting."""
+    active_registry_response = client.get_anoncreds_revocation_active_registry(cred_def_id)
+    if active_registry_response.status_code == 404:
+        emit_progress(
+            f"active-registry 404 (no record yet) cred_def_id={cred_def_id} — still waiting"
+        )
+        return None
+    if not active_registry_response.ok:
+        emit_progress(
+            f"active-registry HTTP {active_registry_response.status_code} "
+            f"cred_def_id={cred_def_id} — still waiting"
+        )
+        return None
+    try:
+        payload = active_registry_response.json()
+    except json.JSONDecodeError:
+        emit_progress("active-registry returned non-JSON — still waiting")
+        return None
+    if not isinstance(payload, dict):
+        return None
+    registry_record = _rev_reg_record_from_payload(payload)
+    if registry_record is None:
+        emit_progress(
+            f"active-registry missing result object; keys={list(payload.keys())!r} — still waiting"
+        )
+        return None
+    err = (registry_record.get("error_msg") or "").strip()
+    if err:
+        LOG.error(
+            "[%s] Active revocation registry error for cred_def_id=%s: %s",
+            log_label,
+            cred_def_id,
+            err,
+        )
+        return False
+    state = (registry_record.get("state") or "").strip().lower()
+    rev_reg_id = registry_record.get("revoc_reg_id") or registry_record.get("rev_reg_id")
+    if state in _REV_REG_TERMINAL_BAD:
+        LOG.error(
+            "[%s] Revocation registry in terminal state %r (cred_def_id=%s rev_reg_id=%s)",
+            log_label,
+            state,
+            cred_def_id,
+            rev_reg_id,
+        )
+        return False
+    if state in _REV_REG_READY_STATES:
+        LOG.info(
+            "[%s] Revocation registry ready state=%s (rev_reg_id=%s cred_def_id=%s)",
+            log_label,
+            state,
+            rev_reg_id,
+            cred_def_id,
+        )
+        return True
+    if state == "posted" and rev_reg_id:
+        LOG.info(
+            "[%s] Revocation registry state=posted with rev_reg_id (treating as ready; "
+            "cred_def_id=%s)",
+            log_label,
+            cred_def_id,
+        )
+        return True
+    emit_progress(
+        f"revocation registry state={state or '?'} rev_reg_id={rev_reg_id!r} — still waiting"
+    )
+    return None
+
+
+def _wait_for_active_revocation_registry(client: Any, cred_def_id: str, log_label: str) -> bool:
+    """Poll GET …/active-registry/{cred_def_id} until ready (active/finished/posted+rev_reg_id) or fail."""
+    last_progress_log = 0.0
+
+    def maybe_progress(msg: str) -> None:
+        nonlocal last_progress_log
+        now = time.monotonic()
+        if now - last_progress_log >= E2E_REV_REG_WAIT_LOG_INTERVAL_SEC:
+            last_progress_log = now
+            LOG.info("[%s] %s", log_label, msg)
+
+    LOG.info(
+        "[%s] Checking revocation active-registry for cred_def_id=%s (timeout=%.0fs)",
+        log_label,
+        cred_def_id,
+        E2E_REV_REG_ACTIVE_TIMEOUT_SEC,
+    )
+
+    def fetch() -> bool | None:
+        return _active_registry_poll_step(client, cred_def_id, log_label, maybe_progress)
+
+    registry_poll_result = poll_until(
+        fetch,
+        timeout_sec=E2E_REV_REG_ACTIVE_TIMEOUT_SEC,
+        interval_sec=E2E_REV_REG_ACTIVE_POLL_SEC,
+        description=f"{log_label} revocation registry active (cred_def_id={cred_def_id})",
+    )
+    if registry_poll_result is True:
+        return True
+    if registry_poll_result is False:
+        return False
+    LOG.error(
+        "[%s] Timed out waiting for active revocation registry (cred_def_id=%s)",
+        log_label,
+        cred_def_id,
+    )
+    return False
+
+
+def _phase_publish_anoncreds_cred_def(
+    context: Context,
+    *,
+    issuer_did: str | None,
+    schema_id: str | None,
+    cred_def_attr: str,
+    log_label: str,
+    webvh_resource_retry: bool,
+    indy_unqualified_ids: bool = False,
+    cred_def_tag: str | None = None,
+) -> bool:
+    """POST anoncreds cred-def + rev reg; reuse from list; WebVH optional resolver retry; wait active-registry."""
+    schema_phase = "publish-schema-webvh" if log_label == "webvh" else "publish-schema-indy"
     if not issuer_did or not schema_id:
-        LOG.error("Missing issuer DID or schema_id; run publish-schema-webvh first")
+        LOG.error(
+            "[%s] Missing issuer DID or schema_id; run %s first",
+            log_label,
+            schema_phase,
+        )
         return False
 
-    tag = E2E_CRED_DEF_TAG
+    if indy_unqualified_ids:
+        issuer_did = _indy_unqualified_issuer_id(issuer_did)
+        schema_id = _indy_strip_did_sov_prefix(schema_id)
+        if not issuer_did or not schema_id:
+            LOG.error("[%s] Missing unqualified issuer or schema_id after normalization", log_label)
+            return False
+
+    tag = cred_def_tag if cred_def_tag is not None else E2E_CRED_DEF_TAG
     reg_size = E2E_REVOCATION_REGISTRY_SIZE
-    client = ctx.issuer_client()
+    client = context.issuer_client()
 
     list_query = {"schema_id": schema_id, "issuer_id": issuer_did}
     list_response = client.get_anoncreds_credential_definitions(params=list_query)
-    LOG.info(
-        "GET /anoncreds/credential-definitions\nquery:\n%s",
-        _format_json_log(list_query),
+    LOG.info("[%s] GET /anoncreds/credential-definitions", log_label)
+    LOG.debug(
+        "[%s] GET /anoncreds/credential-definitions query:\n%s",
+        log_label,
+        format_json_for_log(list_query),
     )
     _log_http_response(
         "GET /anoncreds/credential-definitions",
@@ -302,9 +486,26 @@ def phase_publish_cred_def(ctx: Context) -> bool:
             data = {}
         ids = data.get("credential_definition_ids") or []
         if ids:
-            ctx.webvh_cred_def_id = str(ids[0])
-            LOG.info("Reusing existing credential_definition_id=%s", ctx.webvh_cred_def_id)
-            return True
+            chosen: str | None = None
+            for raw in ids:
+                candidate_cred_def_id = str(raw)
+                if indy_unqualified_ids:
+                    candidate_cred_def_id = (
+                        _indy_strip_did_sov_prefix(candidate_cred_def_id) or candidate_cred_def_id
+                    )
+                if cred_def_tag is not None:
+                    if _anoncreds_cred_def_tag_from_id(candidate_cred_def_id) == tag:
+                        chosen = candidate_cred_def_id
+                        break
+                else:
+                    chosen = candidate_cred_def_id
+                    break
+            if chosen:
+                setattr(context, cred_def_attr, chosen)
+                LOG.info("[%s] Reusing existing credential_definition_id=%s", log_label, chosen)
+                if not _wait_for_active_revocation_registry(client, chosen, log_label):
+                    return False
+                return True
 
     body = {
         "credential_definition": {
@@ -318,7 +519,7 @@ def phase_publish_cred_def(ctx: Context) -> bool:
         },
     }
 
-    deadline = time.monotonic() + 120.0
+    deadline = time.monotonic() + E2E_CRED_DEF_POST_RETRY_TIMEOUT_SEC
     attempt = 0
     while time.monotonic() < deadline:
         create_response = client.post_anoncreds_credential_definition(body)
@@ -326,26 +527,39 @@ def phase_publish_cred_def(ctx: Context) -> bool:
             try:
                 created = create_response.json()
             except json.JSONDecodeError:
-                LOG.error("POST /anoncreds/credential-definition returned non-JSON")
+                LOG.error("[%s] POST /anoncreds/credential-definition returned non-JSON", log_label)
                 return False
             LOG.debug(
-                "POST /anoncreds/credential-definition response:\n%s",
-                _format_json_log(_omit_json_keys(created, _CRED_DEF_LOG_OMIT_KEYS)),
+                "[%s] POST /anoncreds/credential-definition response:\n%s",
+                log_label,
+                format_json_for_log(_omit_json_keys(created, _CRED_DEF_LOG_OMIT_KEYS)),
             )
             cred_def_id = _extract_cred_def_id_from_post(created)
             if not cred_def_id:
-                LOG.error("Cred def create response missing credential_definition_id")
+                LOG.error("[%s] Cred def create response missing credential_definition_id", log_label)
                 LOG.debug(
                     "Cred def create body:\n%s",
-                    _format_json_log(_omit_json_keys(created, _CRED_DEF_LOG_OMIT_KEYS)),
+                    format_json_for_log(_omit_json_keys(created, _CRED_DEF_LOG_OMIT_KEYS)),
                 )
                 return False
-            ctx.webvh_cred_def_id = cred_def_id
+            if indy_unqualified_ids:
+                cred_def_id = _indy_strip_did_sov_prefix(cred_def_id) or cred_def_id
+            setattr(context, cred_def_attr, cred_def_id)
             LOG.info(
-                "Published credential_definition_id=%s (revocation_registry_size=%s)",
+                "[%s] Published credential_definition_id=%s (revocation_registry_size=%s)",
+                log_label,
                 cred_def_id,
                 reg_size,
             )
+            if log_label == "indy" and E2E_INDY_CRED_DEF_PUBLISH_SETTLE_SEC > 0:
+                LOG.info(
+                    "[%s] Waiting %.0fs for revocation registry / endorser to settle before issue",
+                    log_label,
+                    E2E_INDY_CRED_DEF_PUBLISH_SETTLE_SEC,
+                )
+                time.sleep(E2E_INDY_CRED_DEF_PUBLISH_SETTLE_SEC)
+            if not _wait_for_active_revocation_registry(client, cred_def_id, log_label):
+                return False
             return True
 
         err_text = (create_response.text or "").lower()
@@ -355,17 +569,68 @@ def phase_publish_cred_def(ctx: Context) -> bool:
             create_response.text or "",
             redact_keys=_CRED_DEF_LOG_OMIT_KEYS,
         )
-        if "resolving resource" in err_text:
+        if webvh_resource_retry and "resolving resource" in err_text:
             attempt += 1
             LOG.info(
-                "Cred-def create retry (attempt %s) after WebVH resource lag…",
+                "[%s] Cred-def create retry (attempt %s) after WebVH resource lag…",
+                log_label,
                 attempt,
             )
             time.sleep(min(2.0 ** min(attempt, 5), 20.0))
             continue
 
-        LOG.error("POST /anoncreds/credential-definition failed")
+        LOG.error("[%s] POST /anoncreds/credential-definition failed", log_label)
         return False
 
-    LOG.error("Timed out publishing credential definition (WebVH resource lag)")
+    LOG.error("[%s] Timed out publishing credential definition", log_label)
     return False
+
+
+def phase_publish_schema(context: Context) -> bool:
+    """WebVH issuer schema publish (idempotent)."""
+    return _phase_publish_anoncreds_schema(
+        context,
+        issuer_did=context.webvh_last_created_did,
+        schema_attr="webvh_schema_id",
+        log_label="webvh",
+    )
+
+
+def phase_publish_cred_def(context: Context) -> bool:
+    """WebVH cred-def + rev reg (needs webvh_schema_id + issuer DID)."""
+    return _phase_publish_anoncreds_cred_def(
+        context,
+        issuer_did=context.webvh_last_created_did,
+        schema_id=context.webvh_schema_id,
+        cred_def_attr="webvh_cred_def_id",
+        log_label="webvh",
+        webvh_resource_retry=True,
+    )
+
+
+def phase_publish_schema_indy(context: Context) -> bool:
+    """Indy issuer schema (unqualified issuer id for anoncreds/ledger)."""
+    return _phase_publish_anoncreds_schema(
+        context,
+        issuer_did=_indy_unqualified_issuer_id(context.indy_public_did),
+        schema_attr="indy_schema_id",
+        log_label="indy",
+        indy_unqualified_ids=True,
+    )
+
+
+def phase_publish_cred_def_indy(context: Context) -> bool:
+    """POST /anoncreds/credential-definition with revocation (same options as WebVH E2E)."""
+    issuer = _indy_unqualified_issuer_id(context.indy_public_did)
+    tag = f"{E2E_INDY_CRED_DEF_TAG_PREFIX}-{uuid.uuid4().hex[:12]}"
+    LOG.info("[indy] Publishing credential definition with unique tag=%s", tag)
+    return _phase_publish_anoncreds_cred_def(
+        context,
+        issuer_did=issuer,
+        schema_id=context.indy_schema_id,
+        cred_def_attr="indy_cred_def_id",
+        log_label="indy",
+        webvh_resource_retry=False,
+        indy_unqualified_ids=True,
+        cred_def_tag=tag,
+    )

--- a/scripts/webvh-e2e/phases/smoke.py
+++ b/scripts/webvh-e2e/phases/smoke.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
-import logging
+import json
+import time
+from typing import Any
 
 import requests
 
+from constants import (
+    E2E_SMOKE_WALLET_POST_READY_SETTLE_SEC,
+    E2E_SMOKE_WALLET_READY_POLL_SEC,
+    E2E_SMOKE_WALLET_READY_TIMEOUT_SEC,
+)
 from context import Context
-
-LOG = logging.getLogger("webvh-e2e")
+from helpers import LOG, tenant_wallet_storage_type
 
 
 def _smoke_status_live(client_label: str, live_response: requests.Response) -> None:
@@ -23,24 +29,69 @@ def _smoke_status_live(client_label: str, live_response: requests.Response) -> N
         LOG.info("[%s] GET /status/live ok", client_label)
 
 
-def _smoke_tenant_wallet(client_label: str, resp: requests.Response) -> None:
-    if not resp.ok:
+def _wait_tenant_wallet_ready(
+    client_label: str, client: object
+) -> tuple[bool, dict[str, Any] | None]:
+    """
+    Poll GET /tenant/wallet until OK or timeout (handles 503 during wallet upgrade).
+
+    Returns ``(True, body)`` on success with parsed JSON object, else ``(False, None)``.
+    """
+    deadline = time.monotonic() + E2E_SMOKE_WALLET_READY_TIMEOUT_SEC
+    poll_interval_sec = E2E_SMOKE_WALLET_READY_POLL_SEC
+    fetch_tenant_wallet = getattr(client, "get_tenant_wallet")
+    while time.monotonic() < deadline:
+        wallet_response = fetch_tenant_wallet()
+        if wallet_response.ok:
+            LOG.info("[%s] GET /tenant/wallet ok", client_label)
+            try:
+                wallet_payload = wallet_response.json()
+            except json.JSONDecodeError:
+                LOG.error("[%s] GET /tenant/wallet returned non-JSON", client_label)
+                return False, None
+            if not isinstance(wallet_payload, dict):
+                LOG.error("[%s] GET /tenant/wallet JSON is not an object", client_label)
+                return False, None
+            return True, wallet_payload
         LOG.warning(
-            "[%s] GET /tenant/wallet returned HTTP %s; continuing (response snippet: %s)",
+            "[%s] GET /tenant/wallet HTTP %s; retrying in %.0fs (wallet upgrade / platform load)",
             client_label,
-            resp.status_code,
-            resp.text[:160].replace("\n", " "),
+            wallet_response.status_code,
+            poll_interval_sec,
         )
-    else:
-        LOG.info("[%s] GET /tenant/wallet ok", client_label)
+        time.sleep(poll_interval_sec)
+    LOG.error(
+        "[%s] GET /tenant/wallet still failing after %.0fs",
+        client_label,
+        E2E_SMOKE_WALLET_READY_TIMEOUT_SEC,
+    )
+    return False, None
 
 
-def phase_smoke(ctx: Context) -> bool:
-    """Smoke check: unauthenticated liveness plus authenticated tenant wallet for both tenants."""
-    issuer = ctx.issuer_client()
-    holder = ctx.holder_client()
+def phase_smoke(context: Context) -> bool:
+    """Smoke check: liveness plus tenant wallet ready for both tenants (polls through upgrade 503)."""
+    issuer = context.issuer_client()
+    holder = context.holder_client()
     _smoke_status_live("issuer", issuer.get_status_live())
     _smoke_status_live("holder", holder.get_status_live())
-    _smoke_tenant_wallet("issuer", issuer.get_tenant_wallet())
-    _smoke_tenant_wallet("holder", holder.get_tenant_wallet())
+    issuer_wallet_ok, issuer_wallet_payload = _wait_tenant_wallet_ready("issuer", issuer)
+    holder_wallet_ok, holder_wallet_payload = _wait_tenant_wallet_ready("holder", holder)
+    if not issuer_wallet_ok or not holder_wallet_ok:
+        return False
+
+    post_ready_settle_sec = E2E_SMOKE_WALLET_POST_READY_SETTLE_SEC
+    if post_ready_settle_sec > 0:
+        issuer_storage_type = tenant_wallet_storage_type(issuer_wallet_payload or {})
+        holder_storage_type = tenant_wallet_storage_type(holder_wallet_payload or {})
+        if issuer_storage_type == "askar-anoncreds" and holder_storage_type == "askar-anoncreds":
+            LOG.info(
+                "Smoke: skipping %.0fs post-ready settle (issuer and holder already askar-anoncreds)",
+                post_ready_settle_sec,
+            )
+        else:
+            LOG.info(
+                "Smoke: waiting %.0fs after wallets ready (post-upgrade settle)",
+                post_ready_settle_sec,
+            )
+            time.sleep(post_ready_settle_sec)
     return True

--- a/scripts/webvh-e2e/phases/verify.py
+++ b/scripts/webvh-e2e/phases/verify.py
@@ -3,22 +3,94 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
 from typing import Any
 
 from context import Context
 from constants import (
+    E2E_PROOF_HOLDER_CRED_MATCH_TIMEOUT_SEC,
     E2E_PROOF_POLL_SEC,
     E2E_PROOF_TIMEOUT_SEC,
     E2E_SCHEMA_ATTR_NAMES,
 )
-from helpers import poll_until
-
-LOG = logging.getLogger("webvh-e2e")
+from helpers import LOG, format_json_for_log, log_http_failed, poll_until
 
 # Must match ``requested_attributes`` key in ``presentation_request.anoncreds`` below.
 _E2E_PROOF_ATTR_REFERENT = "e2e_attrs"
+
+
+def _normalize_cred_def_id(cred_def_id: str | None) -> str:
+    """Match wallet ``cred_info.cred_def_id`` to harness ``cred_def_id`` (Indy may use ``did:sov:``)."""
+    if not cred_def_id:
+        return ""
+    cred_def_id_str = str(cred_def_id).strip()
+    if cred_def_id_str.startswith("did:sov:"):
+        return cred_def_id_str[8:]
+    return cred_def_id_str
+
+
+def _thread_thid_from_pres_dict(presentation_exchange: dict[str, Any]) -> str | None:
+    """Best-effort thread id for correlating issuer ↔ holder present-proof exchanges."""
+    thread_id = presentation_exchange.get("thread_id")
+    if isinstance(thread_id, str) and thread_id.strip():
+        return thread_id.strip()
+    for key in ("pres_request", "pres_proposal", "presentation_request"):
+        message = presentation_exchange.get(key)
+        if not isinstance(message, dict):
+            continue
+        thread_block = message.get("~thread") or message.get("thread")
+        if isinstance(thread_block, dict):
+            thread_hint = thread_block.get("thid") or thread_block.get("pthid")
+            if isinstance(thread_hint, str) and thread_hint.strip():
+                return thread_hint.strip()
+    return None
+
+
+def _cred_def_id_from_wallet_row(
+    wallet_cred_row: dict[str, Any], credential_info: dict[str, Any]
+) -> str | None:
+    """ACA-Py / wallet payloads vary: pull cred def id from cred_info or top-level row."""
+    for source in (credential_info, wallet_cred_row):
+        for field_name in ("cred_def_id", "credential_definition_id", "credDefId"):
+            raw_value = source.get(field_name)
+            if isinstance(raw_value, str) and raw_value.strip():
+                return raw_value.strip()
+    return None
+
+
+def _pick_wallet_cred_id_for_proof(
+    cred_rows: list[Any],
+    want_cred_def_id: str,
+) -> str | None:
+    """Wallet referent for send-presentation; match cred_def_id when set (avoid stale pres_ex rows)."""
+    normalized_target_cred_def_id = _normalize_cred_def_id(want_cred_def_id)
+    if not normalized_target_cred_def_id:
+        for wallet_cred_row in cred_rows:
+            if not isinstance(wallet_cred_row, dict):
+                continue
+            credential_info = wallet_cred_row.get("cred_info")
+            if isinstance(credential_info, dict) and credential_info.get("referent"):
+                return str(credential_info["referent"])
+        return None
+    for wallet_cred_row in cred_rows:
+        if not isinstance(wallet_cred_row, dict):
+            continue
+        credential_info = wallet_cred_row.get("cred_info")
+        if not isinstance(credential_info, dict):
+            continue
+        referent = credential_info.get("referent")
+        if not referent:
+            continue
+        normalized_wallet_cred_def_id = _normalize_cred_def_id(
+            _cred_def_id_from_wallet_row(wallet_cred_row, credential_info)
+        )
+        if (
+            not normalized_wallet_cred_def_id
+            or normalized_wallet_cred_def_id != normalized_target_cred_def_id
+        ):
+            continue
+        return str(referent)
+    return None
 
 
 def _verified_is_true(value: Any) -> bool:
@@ -29,26 +101,78 @@ def _verified_is_true(value: Any) -> bool:
     return False
 
 
-def _present_proof_round(ctx: Context, *, expect_verified: bool) -> bool:
-    if not ctx.webvh_cred_def_id or not ctx.issuer_connection_id or not ctx.holder_connection_id:
-        LOG.error("Missing cred_def or connection IDs for proof")
+def _holder_pres_candidates_request_received(
+    records_payload: Any,
+    holder_connection_id: str | None,
+) -> list[dict[str, Any]]:
+    """Filter present-proof rows to ``request-received`` for this holder connection."""
+    if not isinstance(records_payload, dict):
+        return []
+    expected_holder_connection_id = (holder_connection_id or "").strip()
+    candidate_pres_exchanges: list[dict[str, Any]] = []
+    for pres_ex_row in records_payload.get("results") or []:
+        if not isinstance(pres_ex_row, dict):
+            continue
+        if (pres_ex_row.get("state") or "").lower() != "request-received":
+            continue
+        row_connection_id = str(pres_ex_row.get("connection_id") or "").strip()
+        if expected_holder_connection_id and row_connection_id != expected_holder_connection_id:
+            continue
+        candidate_pres_exchanges.append(pres_ex_row)
+    return candidate_pres_exchanges
+
+
+def _pick_holder_pres_ex_id_from_candidates(
+    candidate_pres_exchanges: list[dict[str, Any]],
+    issuer_proof_thread_id_hint: str | None,
+) -> str | None:
+    """Pick holder ``pres_ex_id``: match issuer thread id if possible, else newest row."""
+    if not candidate_pres_exchanges:
+        return None
+    if issuer_proof_thread_id_hint:
+        for pres_ex_row in candidate_pres_exchanges:
+            if _thread_thid_from_pres_dict(pres_ex_row) != issuer_proof_thread_id_hint:
+                continue
+            pres_ex_id_value = pres_ex_row.get("pres_ex_id")
+            if pres_ex_id_value:
+                return str(pres_ex_id_value)
+    candidate_pres_exchanges.sort(
+        key=lambda pres_ex_row: str(
+            pres_ex_row.get("updated_at") or pres_ex_row.get("created_at") or ""
+        ),
+        reverse=True,
+    )
+    pres_ex_id_value = candidate_pres_exchanges[0].get("pres_ex_id")
+    return str(pres_ex_id_value) if pres_ex_id_value else None
+
+
+def _present_proof_round(
+    context: Context,
+    *,
+    cred_def_id: str,
+    proof_name: str,
+    expect_verified: bool,
+    log_label: str,
+) -> bool:
+    if not cred_def_id or not context.issuer_connection_id or not context.holder_connection_id:
+        LOG.error("[%s] Missing cred_def or connection IDs for proof", log_label)
         return False
 
-    issuer = ctx.issuer_client()
-    holder = ctx.holder_client()
+    issuer = context.issuer_client()
+    holder = context.holder_client()
     attr_names = E2E_SCHEMA_ATTR_NAMES
 
     now = int(time.time())
     proof_body = {
-        "connection_id": ctx.issuer_connection_id,
+        "connection_id": context.issuer_connection_id,
         "presentation_request": {
             "anoncreds": {
-                "name": "WebVH E2E proof",
+                "name": proof_name,
                 "version": "1.0",
                 "requested_attributes": {
                     _E2E_PROOF_ATTR_REFERENT: {
                         "names": attr_names,
-                        "restrictions": [{"cred_def_id": ctx.webvh_cred_def_id}],
+                        "restrictions": [{"cred_def_id": cred_def_id}],
                         "non_revoked": {"from": now - 86_400, "to": now},
                     }
                 },
@@ -61,123 +185,116 @@ def _present_proof_round(ctx: Context, *, expect_verified: bool) -> bool:
 
     send_response = issuer.post_present_proof_v2_send_request(proof_body)
     if not send_response.ok:
-        LOG.error(
-            "POST /present-proof-2.0/send-request failed (HTTP %s)",
-            send_response.status_code,
-        )
-        LOG.debug(
-            "send-request error body:\n%s",
-            (send_response.text or "")[:4000],
-        )
+        log_http_failed("POST /present-proof-2.0/send-request failed", send_response)
         return False
 
     try:
-        sent = send_response.json()
+        send_request_payload = send_response.json()
     except json.JSONDecodeError:
         LOG.error("send-request returned non-JSON")
         return False
-    pres_ex_id_verifier = sent.get("pres_ex_id")
-    if not pres_ex_id_verifier:
+    verifier_pres_ex_id = send_request_payload.get("pres_ex_id")
+    if not verifier_pres_ex_id:
         LOG.error("send-request response missing pres_ex_id")
-        LOG.debug("send-request body:\n%s", json.dumps(sent, indent=2, default=str))
+        LOG.debug("send-request body:\n%s", format_json_for_log(send_request_payload))
         return False
-    pres_ex_id_verifier = str(pres_ex_id_verifier)
+    verifier_pres_ex_id = str(verifier_pres_ex_id)
+    issuer_proof_thread_id_hint = (
+        _thread_thid_from_pres_dict(send_request_payload)
+        if isinstance(send_request_payload, dict)
+        else None
+    )
 
-    poll_sec = E2E_PROOF_POLL_SEC
-    timeout_sec = E2E_PROOF_TIMEOUT_SEC
+    poll_interval_sec = E2E_PROOF_POLL_SEC
+    proof_poll_timeout_sec = E2E_PROOF_TIMEOUT_SEC
 
-    def holder_pres_ex_id() -> str | None:
-        # First matching exchange only; fine for this linear harness (no concurrent proofs).
-        records = holder.get_present_proof_v2_records(
+    def poll_holder_pres_ex_id() -> str | None:
+        """Resolve holder pres_ex_id: correlate by issuer thread id else newest request-received row."""
+        records_response = holder.get_present_proof_v2_records(
             params={
                 "role": "prover",
                 "state": "request-received",
-                "connection_id": ctx.holder_connection_id,
+                "connection_id": context.holder_connection_id,
             }
         )
-        if not records.ok:
+        if not records_response.ok:
             return None
         try:
-            payload = records.json()
+            records_payload = records_response.json()
         except json.JSONDecodeError:
             return None
-        for row in payload.get("results") or []:
-            pid = row.get("pres_ex_id")
-            if pid:
-                return str(pid)
-        return None
+        candidates = _holder_pres_candidates_request_received(
+            records_payload, context.holder_connection_id
+        )
+        return _pick_holder_pres_ex_id_from_candidates(candidates, issuer_proof_thread_id_hint)
 
-    holder_pres_ex = poll_until(
-        holder_pres_ex_id,
-        timeout_sec=timeout_sec,
-        interval_sec=poll_sec,
+    holder_pres_exchange_id = poll_until(
+        poll_holder_pres_ex_id,
+        timeout_sec=proof_poll_timeout_sec,
+        interval_sec=poll_interval_sec,
         description="holder presentation exchange (request-received)",
     )
-    if not holder_pres_ex:
+    if not holder_pres_exchange_id:
         return False
 
-    creds_resp = holder.get_present_proof_v2_credentials(
-        holder_pres_ex,
-        params={"referent": _E2E_PROOF_ATTR_REFERENT, "limit": 20},
-    )
-    if not creds_resp.ok:
-        LOG.error(
-            "Holder GET /present-proof-2.0/records/…/credentials failed (HTTP %s)",
-            creds_resp.status_code,
-        )
-        LOG.debug(
-            "credentials error body:\n%s",
-            (creds_resp.text or "")[:4000],
-        )
-        return False
-    try:
-        cred_rows = creds_resp.json()
-    except json.JSONDecodeError:
-        LOG.error("Holder credentials lookup returned non-JSON")
-        return False
-    if not isinstance(cred_rows, list) or not cred_rows:
-        LOG.error(
-            "No wallet credentials match proof referent %r for pres_ex_id=%s; "
-            "ensure issue-webvh completed on this holder",
-            _E2E_PROOF_ATTR_REFERENT,
-            holder_pres_ex,
-        )
-        return False
-
+    target_cred_def_id = (cred_def_id or "").strip()
     wallet_cred_id: str | None = None
-    want_cd = (ctx.webvh_cred_def_id or "").strip()
-    for row in cred_rows:
-        if not isinstance(row, dict):
-            continue
-        ci = row.get("cred_info")
-        if not isinstance(ci, dict):
-            continue
-        ref = ci.get("referent")
-        if not ref:
-            continue
-        cdid = (ci.get("cred_def_id") or "").strip()
-        if want_cd and cdid and cdid != want_cd:
-            continue
-        wallet_cred_id = str(ref)
-        break
-    if not wallet_cred_id:
-        for row in cred_rows:
-            if not isinstance(row, dict):
-                continue
-            ci = row.get("cred_info")
-            if isinstance(ci, dict) and ci.get("referent"):
-                wallet_cred_id = str(ci["referent"])
+    cred_deadline = time.monotonic() + E2E_PROOF_HOLDER_CRED_MATCH_TIMEOUT_SEC
+    while time.monotonic() < cred_deadline:
+        credentials_http_response = holder.get_present_proof_v2_credentials(
+            holder_pres_exchange_id,
+            params={"referent": _E2E_PROOF_ATTR_REFERENT, "limit": 20},
+        )
+        if not credentials_http_response.ok:
+            if credentials_http_response.status_code in (502, 503, 504):
                 LOG.warning(
-                    "Using first matching credential referent without cred_def_id filter "
-                    "(wanted cred_def_id=%s)",
-                    want_cd or "(unset)",
+                    "Holder GET …/credentials HTTP %s; retrying (proxy/upstream)",
+                    credentials_http_response.status_code,
                 )
-                break
+                time.sleep(E2E_PROOF_POLL_SEC)
+                continue
+            log_http_failed(
+                "Holder GET /present-proof-2.0/records/…/credentials failed",
+                credentials_http_response,
+            )
+            return False
+        try:
+            cred_rows = credentials_http_response.json()
+        except json.JSONDecodeError:
+            LOG.error("Holder credentials lookup returned non-JSON")
+            return False
+        if not isinstance(cred_rows, list) or not cred_rows:
+            LOG.info(
+                "[%s] No credentials listed yet for referent %r pres_ex_id=%s; "
+                "waiting for wallet / cred_def_id=%s",
+                log_label,
+                _E2E_PROOF_ATTR_REFERENT,
+                holder_pres_exchange_id,
+                target_cred_def_id or "(any)",
+            )
+            time.sleep(E2E_PROOF_POLL_SEC)
+            continue
+        wallet_cred_id = _pick_wallet_cred_id_for_proof(cred_rows, target_cred_def_id)
+        if wallet_cred_id:
+            break
+        LOG.info(
+            "[%s] Credentials for referent %r present but none match cred_def_id=%s; retrying",
+            log_label,
+            _E2E_PROOF_ATTR_REFERENT,
+            target_cred_def_id or "(any)",
+        )
+        time.sleep(E2E_PROOF_POLL_SEC)
+
     if not wallet_cred_id:
         LOG.error(
-            "Could not resolve wallet credential id for referent %r (cred_def_id=%s)",
+            "[%s] No wallet credential matching cred_def_id=%s for referent %r pres_ex_id=%s "
+            "within %.0fs (wrong/stale holder pres_ex is common if multiple request-received rows; "
+            "or holder has no credential for this cred_def_id)",
+            log_label,
+            target_cred_def_id or "(unset)",
             _E2E_PROOF_ATTR_REFERENT,
-            want_cd or "(any)",
+            holder_pres_exchange_id,
+            E2E_PROOF_HOLDER_CRED_MATCH_TIMEOUT_SEC,
         )
         return False
 
@@ -198,62 +315,115 @@ def _present_proof_round(ctx: Context, *, expect_verified: bool) -> bool:
         wallet_cred_id,
         _E2E_PROOF_ATTR_REFERENT,
     )
-    pres = holder.post_present_proof_v2_send_presentation(holder_pres_ex, pres_body)
-    if not pres.ok:
-        LOG.error(
-            "Holder send-presentation failed (HTTP %s)",
-            pres.status_code,
-        )
-        LOG.debug(
-            "send-presentation error body:\n%s",
-            (pres.text or "")[:4000],
-        )
+    send_presentation_response = holder.post_present_proof_v2_send_presentation(
+        holder_pres_exchange_id, pres_body
+    )
+    if not send_presentation_response.ok:
+        log_http_failed("Holder send-presentation failed", send_presentation_response)
         return False
 
     def verifier_outcome() -> str | None:
-        check = issuer.get_present_proof_v2_record(pres_ex_id_verifier)
-        if not check.ok:
+        verifier_record_response = issuer.get_present_proof_v2_record(verifier_pres_ex_id)
+        if not verifier_record_response.ok:
             return None
         try:
-            row = check.json()
+            verifier_exchange_payload = verifier_record_response.json()
         except json.JSONDecodeError:
             return None
-        state = (row.get("state") or "").lower()
-        if state == "done":
-            verified = _verified_is_true(row.get("verified"))
+        exchange_state = (verifier_exchange_payload.get("state") or "").lower()
+        if exchange_state == "done":
+            verified = _verified_is_true(verifier_exchange_payload.get("verified"))
             return "verified" if verified else "not_verified"
-        if state == "abandoned":
+        if exchange_state == "abandoned":
             return "abandoned"
         return None
 
-    outcome = poll_until(
+    presentation_outcome = poll_until(
         verifier_outcome,
-        timeout_sec=timeout_sec,
-        interval_sec=poll_sec,
+        timeout_sec=proof_poll_timeout_sec,
+        interval_sec=poll_interval_sec,
         description="verifier presentation exchange completed",
     )
-    if outcome is None:
+    if presentation_outcome is None:
         return False
 
+    if expect_verified and presentation_outcome != "verified":
+        LOG.error("Expected verified proof, got outcome=%s", presentation_outcome)
+        return False
     if expect_verified:
-        if outcome == "verified":
-            LOG.info("Presentation verified as expected")
-            return True
-        LOG.error("Expected verified proof, got outcome=%s", outcome)
-        return False
-
-    if outcome in ("not_verified", "abandoned"):
-        LOG.info("Presentation not verified after revocation (outcome=%s)", outcome)
+        LOG.info("Presentation verified as expected")
         return True
-    LOG.error("Expected unverifiable proof after revocation, got outcome=%s", outcome)
-    return False
+
+    if presentation_outcome not in ("not_verified", "abandoned"):
+        LOG.error(
+            "Expected unverifiable proof after revocation, got outcome=%s",
+            presentation_outcome,
+        )
+        return False
+    LOG.info("Presentation not verified after revocation (outcome=%s)", presentation_outcome)
+    return True
 
 
-def phase_verify_webvh(ctx: Context) -> bool:
-    """Request anoncreds proof with non-revocation interval; expect verification success."""
-    return _present_proof_round(ctx, expect_verified=True)
+def _verify_phase(
+    context: Context,
+    *,
+    cred_def_attr: str,
+    proof_name: str,
+    expect_verified: bool,
+    log_label: str,
+) -> bool:
+    cred_def_id = (getattr(context, cred_def_attr, None) or "").strip()
+    if not cred_def_id:
+        LOG.error("Missing %s", cred_def_attr)
+        return False
+    return _present_proof_round(
+        context,
+        cred_def_id=cred_def_id,
+        proof_name=proof_name,
+        expect_verified=expect_verified,
+        log_label=log_label,
+    )
 
 
-def phase_verify_webvh_post_revoke(ctx: Context) -> bool:
-    """Same proof request after revocation; expect verification to fail."""
-    return _present_proof_round(ctx, expect_verified=False)
+def phase_verify_webvh(context: Context) -> bool:
+    """WebVH: present-proof, expect verified."""
+    return _verify_phase(
+        context,
+        cred_def_attr="webvh_cred_def_id",
+        proof_name="WebVH E2E proof",
+        expect_verified=True,
+        log_label="webvh",
+    )
+
+
+def phase_verify_webvh_post_revoke(context: Context) -> bool:
+    """WebVH: present-proof after revoke, expect not verified."""
+    return _verify_phase(
+        context,
+        cred_def_attr="webvh_cred_def_id",
+        proof_name="WebVH E2E proof",
+        expect_verified=False,
+        log_label="webvh",
+    )
+
+
+def phase_verify_indy(context: Context) -> bool:
+    """Indy: present-proof, expect verified."""
+    return _verify_phase(
+        context,
+        cred_def_attr="indy_cred_def_id",
+        proof_name="Indy E2E proof",
+        expect_verified=True,
+        log_label="indy",
+    )
+
+
+def phase_verify_indy_post_revoke(context: Context) -> bool:
+    """Indy: present-proof after revoke, expect not verified."""
+    return _verify_phase(
+        context,
+        cred_def_attr="indy_cred_def_id",
+        proof_name="Indy E2E proof",
+        expect_verified=False,
+        log_label="indy",
+    )

--- a/scripts/webvh-e2e/phases/webvh.py
+++ b/scripts/webvh-e2e/phases/webvh.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import secrets
 import string
@@ -12,9 +11,13 @@ from typing import Any
 import requests
 
 from context import Context, get_plugin_webvh
-from helpers import build_witness_invitation_didcomm, sanitized_webvh_config_for_log
-
-LOG = logging.getLogger("webvh-e2e")
+from helpers import (
+    LOG,
+    build_witness_invitation_didcomm,
+    format_json_for_log,
+    log_http_failed,
+    sanitized_webvh_config_for_log,
+)
 
 
 def _witness_threshold_from_env() -> int:
@@ -44,13 +47,11 @@ def _witness_oob_id(plugin: dict[str, Any]) -> str | None:
     return None
 
 
-def _read_webvh_plugin(ctx: Context) -> bool:
-    status_config_response = ctx.issuer_client().get_tenant_server_status_config()
+def _read_webvh_plugin(context: Context) -> bool:
+    status_config_response = context.issuer_client().get_tenant_server_status_config()
     if not status_config_response.ok:
-        LOG.error(
-            "GET /tenant/server/status/config failed: %s %s",
-            status_config_response.status_code,
-            status_config_response.text[:500],
+        log_http_failed(
+            "GET /tenant/server/status/config failed", status_config_response, max_body=500
         )
         return False
     try:
@@ -66,32 +67,27 @@ def _read_webvh_plugin(ctx: Context) -> bool:
         )
         return False
 
-    ctx.plugin_webvh = plugin
-    ctx.webvh_server_url = plugin.get("server_url")
+    context.plugin_webvh = plugin
+    context.webvh_server_url = plugin.get("server_url")
     witnesses = plugin.get("witnesses")
     if isinstance(witnesses, list):
-        ctx.webvh_witnesses = [
+        context.webvh_witnesses = [
             witness_did for witness_did in witnesses if isinstance(witness_did, str)
         ]
 
     # Controller plugin_config only — tenant-stored config is logged on POST /did/webvh/configuration response.
     LOG.debug(
         "WebVH controller plugin_config (defaults): server_url=%s witness_id=%s witnesses=%s",
-        ctx.webvh_server_url,
+        context.webvh_server_url,
         plugin.get("witness_id"),
-        ctx.webvh_witnesses,
+        context.webvh_witnesses,
     )
     return True
 
 
-def _format_webvh_config_json(data: Any) -> str:
-    """Pretty JSON for logs (double quotes, indented)."""
-    return json.dumps(data, indent=2, ensure_ascii=False, default=str)
-
-
-def _fetch_stored_webvh_config(ctx: Context) -> dict[str, Any] | None:
+def _fetch_stored_webvh_config(context: Context) -> dict[str, Any] | None:
     """GET /did/webvh/configuration (tenant-stored WebVH config)."""
-    configuration_response = ctx.issuer_client().get_did_webvh_configuration()
+    configuration_response = context.issuer_client().get_did_webvh_configuration()
     if not configuration_response.ok:
         LOG.warning(
             "GET /did/webvh/configuration failed: %s %s",
@@ -107,13 +103,13 @@ def _fetch_stored_webvh_config(ctx: Context) -> dict[str, Any] | None:
     return stored_config if isinstance(stored_config, dict) else None
 
 
-def _post_webvh_configuration(ctx: Context) -> bool:
-    plugin = ctx.plugin_webvh
+def _post_webvh_configuration(context: Context) -> bool:
+    plugin = context.plugin_webvh
     if not plugin:
         LOG.error("Internal error: plugin_webvh not set")
         return False
 
-    server_url = (ctx.webvh_server_url or plugin.get("server_url") or "").strip()
+    server_url = (context.webvh_server_url or plugin.get("server_url") or "").strip()
     if not server_url:
         LOG.error("WebVH server_url missing from plugin config")
         return False
@@ -142,12 +138,12 @@ def _post_webvh_configuration(ctx: Context) -> bool:
         "witness": False,
         "witness_invitation": witness_invitation,
     }
-    if ctx.use_witness:
+    if context.use_witness:
         body["endorsement"] = True
 
     # Optional: persist witness_threshold under parameter_options when > 0 (merge with existing).
     parameter_options: dict[str, Any] = {}
-    prior_stored_config = _fetch_stored_webvh_config(ctx)
+    prior_stored_config = _fetch_stored_webvh_config(context)
     if isinstance(prior_stored_config, dict):
         existing_parameter_options = prior_stored_config.get("parameter_options")
         if isinstance(existing_parameter_options, dict):
@@ -161,20 +157,10 @@ def _post_webvh_configuration(ctx: Context) -> bool:
     if parameter_options:
         body["parameter_options"] = parameter_options
 
-    post_configuration_response = ctx.issuer_client().post_did_webvh_configuration(body)
+    post_configuration_response = context.issuer_client().post_did_webvh_configuration(body)
     if not post_configuration_response.ok:
-        response_text = post_configuration_response.text or ""
-        LOG.error(
-            "POST /did/webvh/configuration failed (HTTP %s)",
-            post_configuration_response.status_code,
-        )
-        try:
-            formatted_response_body = _format_webvh_config_json(json.loads(response_text))
-        except (json.JSONDecodeError, TypeError):
-            formatted_response_body = response_text[:2000] if response_text else "(empty body)"
-        LOG.debug(
-            "POST /did/webvh/configuration error response:\n%s",
-            formatted_response_body,
+        log_http_failed(
+            "POST /did/webvh/configuration failed", post_configuration_response
         )
         return False
 
@@ -192,7 +178,7 @@ def _post_webvh_configuration(ctx: Context) -> bool:
         LOG.error("POST /did/webvh/configuration returned status=error in JSON body")
         LOG.debug(
             "POST /did/webvh/configuration error body:\n%s",
-            _format_webvh_config_json(response_body),
+            format_json_for_log(response_body),
         )
         return False
 
@@ -207,16 +193,16 @@ def _post_webvh_configuration(ctx: Context) -> bool:
     )
     LOG.debug(
         "POST /did/webvh/configuration response:\n%s",
-        _format_webvh_config_json(response_body_for_log),
+        format_json_for_log(response_body_for_log),
     )
     return True
 
 
-def phase_configure_webvh_plugin(ctx: Context) -> bool:
+def phase_configure_webvh_plugin(context: Context) -> bool:
     """Load WebVH defaults from server config and POST /did/webvh/configuration (issuer)."""
-    if not _read_webvh_plugin(ctx):
+    if not _read_webvh_plugin(context):
         return False
-    return _post_webvh_configuration(ctx)
+    return _post_webvh_configuration(context)
 
 
 def _webvh_did_from_create_response(response_data: Any) -> str | None:
@@ -236,7 +222,7 @@ def _webvh_did_from_create_response(response_data: Any) -> str | None:
     return None
 
 
-def phase_webvh_create(ctx: Context) -> bool:
+def phase_webvh_create(context: Context) -> bool:
     """
     ``POST /did/webvh/create`` with ``options`` (issuer).
 
@@ -271,35 +257,23 @@ def phase_webvh_create(ctx: Context) -> bool:
     if witness_threshold > 0:
         options["witness_threshold"] = witness_threshold
 
-    stored_webvh_config = _fetch_stored_webvh_config(ctx)
+    stored_webvh_config = _fetch_stored_webvh_config(context)
     if stored_webvh_config:
         stored_server_url = stored_webvh_config.get("server_url")
         if isinstance(stored_server_url, str) and stored_server_url.strip():
             options["server_url"] = stored_server_url.strip()
-    if "server_url" not in options and ctx.webvh_server_url:
-        options["server_url"] = ctx.webvh_server_url.strip()
+    if "server_url" not in options and context.webvh_server_url:
+        options["server_url"] = context.webvh_server_url.strip()
 
-    ctx.webvh_last_create_namespace = namespace
-    ctx.webvh_last_create_alias = alias
-    ctx.webvh_last_create_server_url = options.get("server_url")
+    context.webvh_last_create_namespace = namespace
+    context.webvh_last_create_alias = alias
+    context.webvh_last_create_server_url = options.get("server_url")
 
     body = {"options": options}
 
-    create_response = ctx.issuer_client().post_did_webvh_create(body)
+    create_response = context.issuer_client().post_did_webvh_create(body)
     if not create_response.ok:
-        response_text = create_response.text or ""
-        LOG.error(
-            "POST /did/webvh/create failed (HTTP %s)",
-            create_response.status_code,
-        )
-        try:
-            formatted_response_body = _format_webvh_config_json(json.loads(response_text))
-        except (json.JSONDecodeError, TypeError):
-            formatted_response_body = response_text[:2000] if response_text else "(empty body)"
-        LOG.debug(
-            "POST /did/webvh/create error response:\n%s",
-            formatted_response_body,
-        )
+        log_http_failed("POST /did/webvh/create failed", create_response)
         return False
 
     try:
@@ -320,7 +294,7 @@ def phase_webvh_create(ctx: Context) -> bool:
         LOG.error("POST /did/webvh/create returned status=error in JSON body")
         LOG.debug(
             "POST /did/webvh/create error body:\n%s",
-            _format_webvh_config_json(create_response_body),
+            format_json_for_log(create_response_body),
         )
         return False
 
@@ -330,12 +304,12 @@ def phase_webvh_create(ctx: Context) -> bool:
     )
     LOG.debug(
         "POST /did/webvh/create response:\n%s",
-        _format_webvh_config_json(create_response_body),
+        format_json_for_log(create_response_body),
     )
 
     created_webvh_did = _webvh_did_from_create_response(create_response_body)
     if created_webvh_did:
-        ctx.webvh_last_created_did = created_webvh_did
+        context.webvh_last_created_did = created_webvh_did
     else:
         LOG.debug(
             "No did:webvh id in create response yet (e.g. pending witness); see run summary"

--- a/scripts/webvh-e2e/run.py
+++ b/scripts/webvh-e2e/run.py
@@ -3,67 +3,15 @@
 
 from __future__ import annotations
 
-import logging
-import sys
 import time
 
 import click
 import requests
 from dotenv import load_dotenv
 
-from context import Context, build_context
-from helpers import (
-    webvh_explorer_dids_url,
-    webvh_explorer_resources_url,
-    webvh_scid_from_did,
-    webvh_server_base_for_explorer,
-)
+from context import build_context
+from helpers import HarnessLogger
 from phases import PHASES, PROFILES
-
-LOG = logging.getLogger("webvh-e2e")
-
-_SUMMARY_LABEL_WIDTH = 22
-
-
-def _log_summary_kv(indent: str, label: str, value: object) -> None:
-    LOG.info("%s%-*s  %s", indent, _SUMMARY_LABEL_WIDTH, label, value)
-
-
-def _log_run_summary(ctx: Context, stop: str | None, plan: tuple[str, ...] | list[str]) -> None:
-    LOG.info("")
-    LOG.info("=== summary ===")
-    LOG.info("")
-    LOG.info("  run")
-    _log_summary_kv("    ", "traction_url", ctx.base_url)
-
-    if ctx.webvh_last_create_namespace is not None:
-        LOG.info("")
-        LOG.info("  webvh (create)")
-        if ctx.webvh_last_created_did:
-            last_created_did = ctx.webvh_last_created_did
-            _log_summary_kv("    ", "did", last_created_did)
-            scid = webvh_scid_from_did(last_created_did)
-            explorer_base = webvh_server_base_for_explorer(
-                ctx.webvh_last_create_server_url, last_created_did
-            )
-            if scid and explorer_base:
-                _log_summary_kv(
-                    "    ",
-                    "explorer (dids)",
-                    webvh_explorer_dids_url(explorer_base, scid),
-                )
-                _log_summary_kv(
-                    "    ",
-                    "explorer (resources)",
-                    webvh_explorer_resources_url(explorer_base, scid),
-                )
-        elif stop is None:
-            _log_summary_kv("    ", "did", "(not in create response yet)")
-
-    elif ctx.webvh_server_url and "configure-webvh-plugin" in plan:
-        LOG.info("")
-        LOG.info("  webvh (controller)")
-        _log_summary_kv("    ", "server_url", ctx.webvh_server_url)
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -83,46 +31,40 @@ def _log_run_summary(ctx: Context, stop: str | None, plan: tuple[str, ...] | lis
 def main(profile: str, verbose: bool, witness: bool) -> int:
     """Run WebVH E2E phases against the Traction tenant proxy."""
     load_dotenv()
-    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="%(message)s")
+    HarnessLogger.configure_cli_logging(verbose=verbose)
 
     try:
-        ctx = build_context()
-        ctx.use_witness = witness
+        context = build_context(use_witness=witness)
     except RuntimeError as err:
-        LOG.error("%s", err)
+        HarnessLogger.log_context_init_failed(str(err))
         return 1
 
     plan = PROFILES[profile]
-    LOG.info("traction_url=%s profile=%s", ctx.base_url, profile)
-    LOG.info("")
+    HarnessLogger.log_run_start(context.base_url, profile)
 
     run_started_at_monotonic = time.perf_counter()
     phases_completed = 0
     stop: str | None = None
 
     for phase_index, name in enumerate(plan):
-        if phase_index:
-            LOG.info("")
-        LOG.info("-- %s --", name)
+        HarnessLogger.log_phase_begin(name, is_first_phase=(phase_index == 0))
         try:
-            if not PHASES[name](ctx):
+            if not PHASES[name](context):
                 stop = name
                 break
         except (RuntimeError, requests.RequestException) as phase_error:
-            LOG.error("%s: %s", name, phase_error)
+            HarnessLogger.log_phase_uncaught_exception(name, phase_error)
             stop = name
             break
         phases_completed += 1
 
-    LOG.info("")
-    LOG.info(
-        "%s  %s/%s phases  %.1fs",
-        "ok" if stop is None else "failed",
-        phases_completed,
-        len(plan),
-        time.perf_counter() - run_started_at_monotonic,
+    HarnessLogger.log_run_footer(
+        success=(stop is None),
+        phases_completed=phases_completed,
+        phase_count=len(plan),
+        elapsed_seconds=time.perf_counter() - run_started_at_monotonic,
     )
-    _log_run_summary(ctx, stop, plan)
+    HarnessLogger.log_run_summary(context, stop, plan)
     return 0 if stop is None else 1
 
 

--- a/scripts/webvh-e2e/traction_client.py
+++ b/scripts/webvh-e2e/traction_client.py
@@ -1,28 +1,34 @@
 """
 HTTP client for the Traction tenant proxy (ACA-Py admin–style routes).
 
-Add methods as phases need them; each public method should map to one REST call.
+Most ``get_*`` / ``post_*`` wrappers are registered from tables in ``_install_generated_routes``;
+non-uniform calls (path templates, extra query params, redacted logs) stay as explicit methods.
+
+Request bodies and query params log at **DEBUG**; each ``POST``/``PUT`` emits one **INFO** line
+(``POST /path`` / ``PUT /path``) so default runs stay readable (see ``helpers.LOG`` convention).
 """
 
 from __future__ import annotations
 
-import json
-import logging
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import quote
 
 import requests
 
-from helpers import sanitized_webvh_config_for_log
-
-LOG = logging.getLogger("webvh-e2e")
+from helpers import LOG, format_json_for_log, sanitized_webvh_config_for_log
 
 
-def _format_request_body_for_log(data: Any) -> str:
-    try:
-        return json.dumps(data, indent=2, ensure_ascii=False, default=str)
-    except TypeError:
-        return str(data)
+def _enc(segment: str) -> str:
+    return quote(segment, safe="")
+
+
+def _issue_cred_ex_path(cred_ex_id: str) -> str:
+    return f"/issue-credential-2.0/records/{_enc(cred_ex_id)}"
+
+
+def _pres_ex_path(pres_ex_id: str) -> str:
+    return f"/present-proof-2.0/records/{_enc(pres_ex_id)}"
 
 
 class TractionClient:
@@ -35,6 +41,28 @@ class TractionClient:
     def _url(self, path: str) -> str:
         return f"{self._base}{path}" if path.startswith("/") else f"{self._base}/{path}"
 
+    def _get(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        timeout: float = 60,
+    ) -> requests.Response:
+        return self._session.get(self._url(path), params=params or {}, timeout=timeout)
+
+    def _put(
+        self,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        timeout: float = 60,
+    ) -> requests.Response:
+        body = json_body if json_body is not None else {}
+        LOG.info("PUT %s", path)
+        if body:
+            LOG.debug("PUT %s request body:\n%s", path, format_json_for_log(body))
+        return self._session.put(self._url(path), json=body, timeout=timeout)
+
     def _post_json(
         self,
         path: str,
@@ -42,105 +70,78 @@ class TractionClient:
         json_body: Any | None = None,
         params: dict[str, Any] | None = None,
         timeout: float = 60,
+        log_body: Any | None = None,
     ) -> requests.Response:
-        """POST JSON to ``{base}{path}``. Logs the outgoing body at INFO before send."""
-        url = self._url(path)
         if json_body is None:
             json_body = {}
-        LOG.info(
-            "POST %s\nrequest body:\n%s",
-            path,
-            _format_request_body_for_log(json_body),
-        )
+        shown = log_body if log_body is not None else json_body
+        LOG.info("POST %s", path)
+        if params:
+            LOG.debug("POST %s query params:\n%s", path, format_json_for_log(params))
+        LOG.debug("POST %s request body:\n%s", path, format_json_for_log(shown))
         return self._session.post(
-            url,
+            self._url(path),
             json=json_body,
             params=params or {},
             timeout=timeout,
         )
 
-    def get_status_live(self, *, timeout: float = 30) -> requests.Response:
-        """GET /status/live"""
-        return self._session.get(f"{self._base}/status/live", timeout=timeout)
+    # --- routes that do not fit the tables below ---
 
-    def get_tenant_wallet(self, *, timeout: float = 60) -> requests.Response:
-        """GET /tenant/wallet"""
-        return self._session.get(f"{self._base}/tenant/wallet", timeout=timeout)
+    def get_connection(self, connection_id: str, *, timeout: float = 60) -> requests.Response:
+        return self._get(f"/connections/{connection_id}", timeout=timeout)
 
-    def get_settings(self, *, timeout: float = 60) -> requests.Response:
-        """GET /settings"""
-        return self._session.get(f"{self._base}/settings", timeout=timeout)
+    def get_ledger_did_verkey(self, did: str, *, timeout: float = 60) -> requests.Response:
+        return self._get(f"/ledger/did-verkey?did={_enc(did)}", timeout=timeout)
 
-    def get_tenant_server_status_config(self, *, timeout: float = 60) -> requests.Response:
-        """GET /tenant/server/status/config"""
-        return self._session.get(f"{self._base}/tenant/server/status/config", timeout=timeout)
-
-    def post_anoncreds_wallet_upgrade(self, wallet_name: str, *, timeout: float = 120) -> requests.Response:
-        """POST /anoncreds/wallet/upgrade?wallet_name=…"""
-        encoded_wallet_name = quote(wallet_name, safe="")
-        return self._post_json(
-            "/anoncreds/wallet/upgrade",
-            json_body={},
-            params={"wallet_name": encoded_wallet_name},
+    def put_tenant_config_set_ledger_id(self, ledger_id: str, *, timeout: float = 60) -> requests.Response:
+        return self._put(
+            "/tenant/config/set-ledger-id",
+            json_body={"ledger_id": ledger_id},
             timeout=timeout,
         )
-
-    def get_did_webvh_configuration(self, *, timeout: float = 60) -> requests.Response:
-        """GET /did/webvh/configuration (tenant-stored WebVH config)."""
-        return self._session.get(f"{self._base}/did/webvh/configuration", timeout=timeout)
 
     def post_did_webvh_configuration(self, body: dict[str, Any], *, timeout: float = 120) -> requests.Response:
-        """POST /did/webvh/configuration. INFO log is redacted; the request sends ``body`` unchanged."""
         path = "/did/webvh/configuration"
         for_log = sanitized_webvh_config_for_log(body) if isinstance(body, dict) else body
-        LOG.info(
-            "POST %s\nrequest body:\n%s",
-            path,
-            _format_request_body_for_log(for_log),
-        )
-        return self._session.post(
-            self._url(path),
-            json=body,
-            params={},
-            timeout=timeout,
-        )
+        return self._post_json(path, json_body=body, log_body=for_log, timeout=timeout)
 
-    def post_did_webvh_create(self, body: dict[str, Any], *, timeout: float = 180) -> requests.Response:
-        """POST /did/webvh/create (body includes ``options`` for namespace, identifier, etc.)."""
+    def post_wallet_did_create(
+        self, body: dict[str, Any] | None = None, *, timeout: float = 120
+    ) -> requests.Response:
         return self._post_json(
-            "/did/webvh/create",
-            json_body=body,
+            "/wallet/did/create",
+            json_body=body if body is not None else {},
             timeout=timeout,
         )
 
     def post_wallet_did_public(self, did: str, *, timeout: float = 60) -> requests.Response:
-        """POST /wallet/did/public?did=… (Indy-style public DID; requires endorser where enforced)."""
-        encoded_did = quote(did, safe="")
+        return self._post_json(f"/wallet/did/public?did={_enc(did)}", json_body={}, timeout=timeout)
+
+    def post_anoncreds_wallet_upgrade(self, wallet_name: str, *, timeout: float = 120) -> requests.Response:
         return self._post_json(
-            f"/wallet/did/public?did={encoded_did}",
+            "/anoncreds/wallet/upgrade",
             json_body={},
+            params={"wallet_name": _enc(wallet_name)},
             timeout=timeout,
         )
 
-    def get_connections(self, *, params: dict[str, Any] | None = None, timeout: float = 60) -> requests.Response:
-        """GET /connections"""
-        return self._session.get(f"{self._base}/connections", params=params or {}, timeout=timeout)
+    def put_ledger_set_write_ledger(self, ledger_id: str, *, timeout: float = 60) -> requests.Response:
+        return self._put(f"/ledger/{_enc(ledger_id)}/set-write-ledger", json_body={}, timeout=timeout)
 
-    def get_connection(self, connection_id: str, *, timeout: float = 60) -> requests.Response:
-        """GET /connections/{connection_id}"""
-        return self._session.get(
-            f"{self._base}/connections/{connection_id}",
+    def post_ledger_register_nym(
+        self, *, did: str, verkey: str, alias: str, timeout: float = 120
+    ) -> requests.Response:
+        return self._post_json(
+            "/ledger/register-nym",
+            json_body={},
+            params={"did": did, "verkey": verkey, "alias": alias},
             timeout=timeout,
         )
 
     def post_out_of_band_create_invitation(
-        self,
-        body: dict[str, Any],
-        *,
-        multi_use: bool = False,
-        timeout: float = 120,
+        self, body: dict[str, Any], *, multi_use: bool = False, timeout: float = 120
     ) -> requests.Response:
-        """POST /out-of-band/create-invitation"""
         return self._post_json(
             "/out-of-band/create-invitation",
             json_body=body,
@@ -149,13 +150,8 @@ class TractionClient:
         )
 
     def post_out_of_band_receive_invitation(
-        self,
-        invitation: dict[str, Any],
-        *,
-        alias: str,
-        timeout: float = 120,
+        self, invitation: dict[str, Any], *, alias: str, timeout: float = 120
     ) -> requests.Response:
-        """POST /out-of-band/receive-invitation (body is the invitation message; auto_accept=true)."""
         return self._post_json(
             "/out-of-band/receive-invitation",
             json_body=invitation,
@@ -163,103 +159,25 @@ class TractionClient:
             timeout=timeout,
         )
 
-    def post_anoncreds_schema(self, body: dict[str, Any], *, timeout: float = 120) -> requests.Response:
-        """POST /anoncreds/schema"""
-        return self._post_json("/anoncreds/schema", json_body=body, timeout=timeout)
-
-    def get_anoncreds_schemas(self, *, params: dict[str, Any] | None = None, timeout: float = 60) -> requests.Response:
-        """GET /anoncreds/schemas"""
-        return self._session.get(f"{self._base}/anoncreds/schemas", params=params or {}, timeout=timeout)
-
-    def get_anoncreds_schema(self, schema_id: str, *, timeout: float = 60) -> requests.Response:
-        """GET /anoncreds/schema/{schema_id}"""
-        encoded = quote(schema_id, safe="")
-        return self._session.get(f"{self._base}/anoncreds/schema/{encoded}", timeout=timeout)
-
-    def post_anoncreds_credential_definition(
-        self, body: dict[str, Any], *, timeout: float = 120
-    ) -> requests.Response:
-        """POST /anoncreds/credential-definition"""
-        return self._post_json(
-            "/anoncreds/credential-definition",
-            json_body=body,
-            timeout=timeout,
-        )
-
-    def get_anoncreds_credential_definitions(
-        self, *, params: dict[str, Any] | None = None, timeout: float = 60
-    ) -> requests.Response:
-        """GET /anoncreds/credential-definitions"""
-        return self._session.get(
-            f"{self._base}/anoncreds/credential-definitions",
-            params=params or {},
-            timeout=timeout,
-        )
-
-    def post_issue_credential_v2_send_offer(
-        self, body: dict[str, Any], *, timeout: float = 120
-    ) -> requests.Response:
-        """POST /issue-credential-2.0/send-offer"""
-        return self._post_json(
-            "/issue-credential-2.0/send-offer",
-            json_body=body,
-            timeout=timeout,
-        )
-
-    def get_issue_credential_v2_records(
-        self, *, params: dict[str, Any] | None = None, timeout: float = 60
-    ) -> requests.Response:
-        """GET /issue-credential-2.0/records"""
-        return self._session.get(
-            f"{self._base}/issue-credential-2.0/records",
-            params=params or {},
-            timeout=timeout,
-        )
-
     def post_issue_credential_v2_send_request(
         self, cred_ex_id: str, *, timeout: float = 120
     ) -> requests.Response:
-        """POST /issue-credential-2.0/records/{cred_ex_id}/send-request"""
-        encoded = quote(cred_ex_id, safe="")
         return self._post_json(
-            f"/issue-credential-2.0/records/{encoded}/send-request",
+            f"{_issue_cred_ex_path(cred_ex_id)}/send-request",
             json_body={},
             timeout=timeout,
         )
 
-    def get_issue_credential_v2_record(self, cred_ex_id: str, *, timeout: float = 60) -> requests.Response:
-        """GET /issue-credential-2.0/records/{cred_ex_id}"""
-        encoded = quote(cred_ex_id, safe="")
-        return self._session.get(
-            f"{self._base}/issue-credential-2.0/records/{encoded}",
-            timeout=timeout,
-        )
-
-    def post_present_proof_v2_send_request(
-        self, body: dict[str, Any], *, timeout: float = 120
+    def post_issue_credential_v2_issue(
+        self,
+        cred_ex_id: str,
+        *,
+        body: dict[str, Any] | None = None,
+        timeout: float = 120,
     ) -> requests.Response:
-        """POST /present-proof-2.0/send-request"""
         return self._post_json(
-            "/present-proof-2.0/send-request",
-            json_body=body,
-            timeout=timeout,
-        )
-
-    def get_present_proof_v2_records(
-        self, *, params: dict[str, Any] | None = None, timeout: float = 60
-    ) -> requests.Response:
-        """GET /present-proof-2.0/records"""
-        return self._session.get(
-            f"{self._base}/present-proof-2.0/records",
-            params=params or {},
-            timeout=timeout,
-        )
-
-    def get_present_proof_v2_record(self, pres_ex_id: str, *, timeout: float = 60) -> requests.Response:
-        """GET /present-proof-2.0/records/{pres_ex_id}"""
-        encoded = quote(pres_ex_id, safe="")
-        return self._session.get(
-            f"{self._base}/present-proof-2.0/records/{encoded}",
+            f"{_issue_cred_ex_path(cred_ex_id)}/issue",
+            json_body=body if body is not None else {},
             timeout=timeout,
         )
 
@@ -270,13 +188,7 @@ class TractionClient:
         params: dict[str, Any] | None = None,
         timeout: float = 60,
     ) -> requests.Response:
-        """GET /present-proof-2.0/records/{pres_ex_id}/credentials (wallet creds matching the proof request)."""
-        encoded = quote(pres_ex_id, safe="")
-        return self._session.get(
-            f"{self._base}/present-proof-2.0/records/{encoded}/credentials",
-            params=params or {},
-            timeout=timeout,
-        )
+        return self._get(f"{_pres_ex_path(pres_ex_id)}/credentials", params=params, timeout=timeout)
 
     def post_present_proof_v2_send_presentation(
         self,
@@ -285,20 +197,127 @@ class TractionClient:
         *,
         timeout: float = 120,
     ) -> requests.Response:
-        """POST /present-proof-2.0/records/{pres_ex_id}/send-presentation"""
-        encoded = quote(pres_ex_id, safe="")
         return self._post_json(
-            f"/present-proof-2.0/records/{encoded}/send-presentation",
+            f"{_pres_ex_path(pres_ex_id)}/send-presentation",
             json_body=body,
             timeout=timeout,
         )
 
-    def post_anoncreds_revocation_revoke(
-        self, body: dict[str, Any], *, timeout: float = 120
+
+def _make_get(path: str, default_timeout: float) -> Callable[..., Any]:
+    def GET(self: TractionClient, *, timeout: float = default_timeout) -> requests.Response:
+        return self._get(path, timeout=timeout)
+
+    return GET
+
+
+def _make_get_params(path: str, default_timeout: float = 60) -> Callable[..., Any]:
+    def GET(
+        self: TractionClient,
+        *,
+        params: dict[str, Any] | None = None,
+        timeout: float = default_timeout,
     ) -> requests.Response:
-        """POST /anoncreds/revocation/revoke"""
-        return self._post_json(
-            "/anoncreds/revocation/revoke",
-            json_body=body,
-            timeout=timeout,
-        )
+        return self._get(path, params=params, timeout=timeout)
+
+    return GET
+
+
+def _make_get_seg(prefix: str, suffix: str = "", default_timeout: float = 60) -> Callable[..., Any]:
+    def GET(self: TractionClient, segment: str, *, timeout: float = default_timeout) -> requests.Response:
+        return self._get(f"{prefix}{_enc(segment)}{suffix}", timeout=timeout)
+
+    return GET
+
+
+def _make_get_path(path_fn: Callable[[str], str], default_timeout: float = 60) -> Callable[..., Any]:
+    def GET(self: TractionClient, record_id: str, *, timeout: float = default_timeout) -> requests.Response:
+        return self._get(path_fn(record_id), timeout=timeout)
+
+    return GET
+
+
+def _make_post_body(path: str, default_timeout: float) -> Callable[..., Any]:
+    def POST(self: TractionClient, body: dict[str, Any], *, timeout: float = default_timeout) -> requests.Response:
+        return self._post_json(path, json_body=body, timeout=timeout)
+
+    return POST
+
+
+def _make_post_empty(path: str, default_timeout: float) -> Callable[..., Any]:
+    def POST(self: TractionClient, *, timeout: float = default_timeout) -> requests.Response:
+        return self._post_json(path, json_body={}, timeout=timeout)
+
+    return POST
+
+
+def _attach_route(cls: type[TractionClient], name: str, fn: Callable[..., Any]) -> None:
+    fn.__name__ = name
+    fn.__qualname__ = f"{cls.__name__}.{name}"
+    setattr(cls, name, fn)
+
+
+def _install_generated_routes() -> None:
+    simple_gets: list[tuple[str, Callable[..., Any]]] = [
+        ("get_status_live", _make_get("/status/live", 30)),
+        *[
+            (n, _make_get(p, 60))
+            for n, p in (
+                ("get_tenant_wallet", "/tenant/wallet"),
+                ("get_settings", "/settings"),
+                ("get_tenant_server_status_config", "/tenant/server/status/config"),
+                ("get_tenant_self", "/tenant"),
+                ("get_tenant_endorser_info", "/tenant/endorser-info"),
+                ("get_tenant_endorser_connection", "/tenant/endorser-connection"),
+                ("get_did_webvh_configuration", "/did/webvh/configuration"),
+                ("get_wallet_did_public", "/wallet/did/public"),
+                ("get_ledger_write_ledger", "/ledger/get-write-ledger"),
+            )
+        ],
+    ]
+    for name, m in simple_gets:
+        _attach_route(TractionClient, name, m)
+
+    for name, path in (
+        ("get_connections", "/connections"),
+        ("get_anoncreds_schemas", "/anoncreds/schemas"),
+        ("get_anoncreds_credential_definitions", "/anoncreds/credential-definitions"),
+        ("get_issue_credential_v2_records", "/issue-credential-2.0/records"),
+        ("get_present_proof_v2_records", "/present-proof-2.0/records"),
+        ("get_wallet_dids", "/wallet/did"),
+    ):
+        _attach_route(TractionClient, name, _make_get_params(path))
+
+    for name, prefix, suffix in (
+        ("get_out_of_band_record", "/out-of-band/records/", ""),
+        ("get_anoncreds_schema", "/anoncreds/schema/", ""),
+        ("get_anoncreds_revocation_active_registry", "/anoncreds/revocation/active-registry/", ""),
+        ("get_transaction", "/transactions/", ""),
+        (
+            "get_anoncreds_revocation_registry_issued_indy_recs",
+            "/anoncreds/revocation/registry/",
+            "/issued/indy_recs",
+        ),
+    ):
+        _attach_route(TractionClient, name, _make_get_seg(prefix, suffix))
+
+    for name, fn in (
+        ("get_issue_credential_v2_record", _issue_cred_ex_path),
+        ("get_present_proof_v2_record", _pres_ex_path),
+    ):
+        _attach_route(TractionClient, name, _make_get_path(fn))
+
+    for name, path, dt in (
+        ("post_anoncreds_schema", "/anoncreds/schema", 120),
+        ("post_anoncreds_credential_definition", "/anoncreds/credential-definition", 120),
+        ("post_issue_credential_v2_send_offer", "/issue-credential-2.0/send-offer", 120),
+        ("post_present_proof_v2_send_request", "/present-proof-2.0/send-request", 120),
+        ("post_did_webvh_create", "/did/webvh/create", 180),
+        ("post_anoncreds_revocation_revoke", "/anoncreds/revocation/revoke", 120),
+    ):
+        _attach_route(TractionClient, name, _make_post_body(path, dt))
+
+    _attach_route(TractionClient, "post_tenant_endorser_connection", _make_post_empty("/tenant/endorser-connection", 120))
+
+
+_install_generated_routes()


### PR DESCRIPTION
## Summary

Adds an **Indy / BCovrin test** path to the WebVH E2E harness: set write ledger, connect to the configured endorser, register a public DID (aligned with Tenant UI).

## Changes

- New phases: `indy-set-write-ledger`, `indy-connect-endorser`, `indy-register-public-did`
- New profile: `indy-bcovrin-setup`
- `TractionClient` helpers for tenant endorser, ledger, wallet DID, transactions
- Context fields + run summary for Indy
- Docs: `scripts/webvh-e2e/README.md`, `.env.example`, `scripts/README.md`
- Profile registry validation: union of all profile phases vs `PHASES` keys

## Testing

- `poetry run python3 run.py --profile indy-bcovrin-setup` against BC sandbox (smoke, ledger, endorser connection, register-nym, public DID).

Signed-off-by: (commit already includes DCO)

Made with [Cursor](https://cursor.com)