### PR TITLE
chore: update sandbox WebVH witness_id

### DIFF
--- a/deploy/traction/values-pr.yaml
+++ b/deploy/traction/values-pr.yaml
@@ -38,7 +38,7 @@ acapy:
         auto_issuer: true
     webvh:
       server_url: https://sandbox.bcvh.vonx.io
-      witness_id: did:key:z6Mktqm2pXW48BZzSNnDzaA3yxo3zhfCUzAktVzFmzZHbVNn
+      witness_id: did:key:z6MkghLv3ccGvxDAuLfrhw3As2DvAb4Hn2JGwqHa5D5T88dJ
   
   resourcesPreset: micro
 

--- a/scripts/plugin-config.yml
+++ b/scripts/plugin-config.yml
@@ -36,4 +36,4 @@ basicmessage_storage:
 
 webvh:
   server_url: https://sandbox.bcvh.vonx.io
-  witness_id: did:key:z6Mktqm2pXW48BZzSNnDzaA3yxo3zhfCUzAktVzFmzZHbVNn
+  witness_id: did:key:z6MkghLv3ccGvxDAuLfrhw3As2DvAb4Hn2JGwqHa5D5T88dJ


### PR DESCRIPTION
Updates the sandbox BCVH WebVH `witness_id` to the current witness DID.

- `deploy/traction/values-pr.yaml` — PR / OpenShift preview deploy ACA-Py plugin config
- `scripts/plugin-config.yml` — local / scripted plugin config (kept in sync)

No other references to the previous `did:key` remained in this repository.

Made with [Cursor](https://cursor.com)