### PR TITLE
Security fixes

### DIFF
--- a/plugins/docker/tenant-proxy.conf.template
+++ b/plugins/docker/tenant-proxy.conf.template
@@ -63,15 +63,12 @@ server {
         proxy_hide_header Access-Control-Allow-Origin;
         proxy_hide_header Access-Control-Allow-Credentials;
 
-        set $CORS_CREDS true;
-        set $CORS_ORIGIN $http_origin;
         set $CORS_PREFLIGHT_CACHE_AGE 600;
 
         if ($request_method = 'OPTIONS') {
-            add_header Access-Control-Allow-Origin $CORS_ORIGIN always ;
+            add_header Access-Control-Allow-Origin '*' always;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
             add_header Access-Control-Allow-Headers $http_access_control_request_headers;
-            add_header Access-Control-Allow-Credentials $CORS_CREDS always ;
 
             add_header Access-Control-Max-Age $CORS_PREFLIGHT_CACHE_AGE;
             add_header Content-Type 'text/plain; charset=utf-8';
@@ -79,10 +76,9 @@ server {
             return 204;
         }
         if ($request_method != 'OPTIONS') {
-            add_header Access-Control-Allow-Origin $CORS_ORIGIN always ;
+            add_header Access-Control-Allow-Origin '*' always;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
             add_header Access-Control-Allow-Headers $http_access_control_request_headers;
-            add_header Access-Control-Allow-Credentials $CORS_CREDS always ;
         }
     }
 

--- a/plugins/docker/tenant-proxy.conf.template
+++ b/plugins/docker/tenant-proxy.conf.template
@@ -63,12 +63,15 @@ server {
         proxy_hide_header Access-Control-Allow-Origin;
         proxy_hide_header Access-Control-Allow-Credentials;
 
+        set $CORS_CREDS true;
+        set $CORS_ORIGIN $http_origin;
         set $CORS_PREFLIGHT_CACHE_AGE 600;
 
         if ($request_method = 'OPTIONS') {
-            add_header Access-Control-Allow-Origin '*' always;
+            add_header Access-Control-Allow-Origin $CORS_ORIGIN always ;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
             add_header Access-Control-Allow-Headers $http_access_control_request_headers;
+            add_header Access-Control-Allow-Credentials $CORS_CREDS always ;
 
             add_header Access-Control-Max-Age $CORS_PREFLIGHT_CACHE_AGE;
             add_header Content-Type 'text/plain; charset=utf-8';
@@ -76,9 +79,10 @@ server {
             return 204;
         }
         if ($request_method != 'OPTIONS') {
-            add_header Access-Control-Allow-Origin '*' always;
+            add_header Access-Control-Allow-Origin $CORS_ORIGIN always ;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
             add_header Access-Control-Allow-Headers $http_access_control_request_headers;
+            add_header Access-Control-Allow-Credentials $CORS_CREDS always ;
         }
     }
 

--- a/services/tenant-ui/frontend/src/views/Identifiers.vue
+++ b/services/tenant-ui/frontend/src/views/Identifiers.vue
@@ -171,6 +171,7 @@
               $t('identifiers.webvh.didPreview')
             }}</label>
             <div class="p-3 surface-100 border-round mt-2">
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
               <code class="text-sm">did:webvh:{SCID}:{{ didPreviewDomain }}:<strong>{{ newDidNamespace || '{namespace}' }}</strong>:<strong>{{ newDidAlias || '{alias}' }}</strong></code>
             </div>
           </div>

--- a/services/tenant-ui/frontend/src/views/Identifiers.vue
+++ b/services/tenant-ui/frontend/src/views/Identifiers.vue
@@ -171,7 +171,7 @@
               $t('identifiers.webvh.didPreview')
             }}</label>
             <div class="p-3 surface-100 border-round mt-2">
-              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+              <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
               <code
                 class="text-sm"
                 >did:webvh:{SCID}:{{ didPreviewDomain }}:<strong>{{
@@ -179,6 +179,7 @@
                 }}</strong
                 >:<strong>{{ newDidAlias || '{alias}' }}</strong></code
               >
+              <!-- eslint-enable @intlify/vue-i18n/no-raw-text -->
             </div>
           </div>
         </div>

--- a/services/tenant-ui/frontend/src/views/Identifiers.vue
+++ b/services/tenant-ui/frontend/src/views/Identifiers.vue
@@ -479,16 +479,10 @@ const didPreview = computed(() => {
   return `did:webvh:{SCID}:${domain}:${namespace}:${alias}`;
 });
 
-// Domain portion of the DID preview
-const didPreviewDomain = computed(() => {
-  const server = selectedWebvhServer.value;
-  if (!server) return '';
-  try {
-    return new URL(server).hostname;
-  } catch {
-    return server.replace(/^https?:\/\//, '').split('/')[0];
-  }
-});
+// Domain portion of the DID preview — derived from didPreview to avoid
+// duplicating the server URL parsing logic (single source of truth).
+// didPreview format: did:webvh:{SCID}:{domain}:{namespace}:{alias}
+const didPreviewDomain = computed(() => didPreview.value.split(':')[3] ?? '');
 
 const openCreateDialog = () => {
   createFormTouched.value = false;

--- a/services/tenant-ui/frontend/src/views/Identifiers.vue
+++ b/services/tenant-ui/frontend/src/views/Identifiers.vue
@@ -172,8 +172,7 @@
             }}</label>
             <div class="p-3 surface-100 border-round mt-2">
               <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
-              <code
-                class="text-sm"
+              <code class="text-sm"
                 >did:webvh:{SCID}:{{ didPreviewDomain }}:<strong>{{
                   newDidNamespace || '{namespace}'
                 }}</strong

--- a/services/tenant-ui/frontend/src/views/Identifiers.vue
+++ b/services/tenant-ui/frontend/src/views/Identifiers.vue
@@ -171,8 +171,7 @@
               $t('identifiers.webvh.didPreview')
             }}</label>
             <div class="p-3 surface-100 border-round mt-2">
-              <!-- eslint-disable-next-line vue/no-v-html -->
-              <code class="text-sm" v-html="didPreviewFormatted"></code>
+              <code class="text-sm">did:webvh:{SCID}:{{ didPreviewDomain }}:<strong>{{ newDidNamespace || '{namespace}' }}</strong>:<strong>{{ newDidAlias || '{alias}' }}</strong></code>
             </div>
           </div>
         </div>
@@ -480,27 +479,15 @@ const didPreview = computed(() => {
   return `did:webvh:{SCID}:${domain}:${namespace}:${alias}`;
 });
 
-// Formatted DID preview with bold namespace and alias
-const didPreviewFormatted = computed(() => {
-  const namespace = newDidNamespace.value.trim() || '{namespace}';
-  const alias = newDidAlias.value.trim() || '{alias}';
+// Domain portion of the DID preview
+const didPreviewDomain = computed(() => {
   const server = selectedWebvhServer.value;
-
-  if (!server) {
-    return '';
-  }
-
-  // Extract domain from server URL
-  let domain;
+  if (!server) return '';
   try {
-    const url = new URL(server);
-    domain = url.hostname;
+    return new URL(server).hostname;
   } catch {
-    // If server is not a valid URL, use it as-is
-    domain = server.replace(/^https?:\/\//, '').split('/')[0];
+    return server.replace(/^https?:\/\//, '').split('/')[0];
   }
-
-  return `did:webvh:{SCID}:${domain}:<strong>${namespace}</strong>:<strong>${alias}</strong>`;
 });
 
 const openCreateDialog = () => {

--- a/services/tenant-ui/frontend/src/views/Identifiers.vue
+++ b/services/tenant-ui/frontend/src/views/Identifiers.vue
@@ -172,7 +172,13 @@
             }}</label>
             <div class="p-3 surface-100 border-round mt-2">
               <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
-              <code class="text-sm">did:webvh:{SCID}:{{ didPreviewDomain }}:<strong>{{ newDidNamespace || '{namespace}' }}</strong>:<strong>{{ newDidAlias || '{alias}' }}</strong></code>
+              <code
+                class="text-sm"
+                >did:webvh:{SCID}:{{ didPreviewDomain }}:<strong>{{
+                  newDidNamespace || '{namespace}'
+                }}</strong
+                >:<strong>{{ newDidAlias || '{alias}' }}</strong></code
+              >
             </div>
           </div>
         </div>

--- a/services/tenant-ui/src/components/email.ts
+++ b/services/tenant-ui/src/components/email.ts
@@ -29,6 +29,21 @@ export function stringOrBooleanTruthy(value: string | boolean) {
   return value === "true" || value === true;
 }
 
+// Shared transporter — created once at module load.
+// requireTLS: true ensures credentials are never sent without TLS, even when
+// secure: false (STARTTLS mode). If the server does not support TLS the
+// connection fails rather than transmitting credentials in plaintext (CWE-523).
+const transporter = nodemailer.createTransport({
+  host: SERVER,
+  port: PORT,
+  secure: stringOrBooleanTruthy(SECURE),
+  requireTLS: true,
+  auth: {
+    user: USER,
+    pass: PASSWORD,
+  },
+});
+
 /**
  * @function sendConfirmationEmail
  * Send the preconfigured emails when a reservation is created
@@ -36,15 +51,6 @@ export function stringOrBooleanTruthy(value: string | boolean) {
  */
 export const sendConfirmationEmail = async (req: Request) => {
   try {
-    const transporter = nodemailer.createTransport({
-      host: SERVER,
-      port: PORT,
-      secure: stringOrBooleanTruthy(SECURE),
-      auth: {
-        user: USER,
-        pass: PASSWORD,
-      },
-    });
 
     req.body.serverUrlStatusRouteAutofill = buildStatusAutofill(req.body);
     const tenantHtml = eta.renderString(
@@ -85,15 +91,6 @@ export const sendConfirmationEmail = async (req: Request) => {
  */
 export const sendStatusEmail = async (req: Request) => {
   try {
-    const transporter = nodemailer.createTransport({
-      host: SERVER,
-      port: PORT,
-      secure: stringOrBooleanTruthy(SECURE),
-      auth: {
-        user: USER,
-        pass: PASSWORD,
-      },
-    });
 
     let template;
     let subject;

--- a/services/tenant-ui/src/components/innkeeper.ts
+++ b/services/tenant-ui/src/components/innkeeper.ts
@@ -43,6 +43,6 @@ export const createReservation = async (req: any, token: string) => {
     return res.data;
   } catch (error) {
     console.error("Failed to create reservation", error);
-    throw new Error("Failed to create reservation");
+    throw new Error("Failed to create reservation", { cause: error });
   }
 };

--- a/services/tenant-ui/src/components/innkeeper.ts
+++ b/services/tenant-ui/src/components/innkeeper.ts
@@ -42,6 +42,7 @@ export const createReservation = async (req: any, token: string) => {
     });
     return res.data;
   } catch (error) {
-    return error;
+    console.error("Failed to create reservation", error);
+    throw new Error("Failed to create reservation");
   }
 };

--- a/services/tenant-ui/src/helpers/index.ts
+++ b/services/tenant-ui/src/helpers/index.ts
@@ -6,9 +6,7 @@
  */
 export function buildStatusAutofill(requestBody: any) {
   if (requestBody && requestBody.serverUrlStatusRoute) {
-    return encodeURI(
-      `${requestBody.serverUrlStatusRoute}?email=${requestBody.contactEmail}&id=${requestBody.reservationId}`
-    );
+    return `${requestBody.serverUrlStatusRoute}?email=${encodeURIComponent(requestBody.contactEmail)}&id=${encodeURIComponent(requestBody.reservationId)}`;
   } else {
     return "";
   }

--- a/services/tenant-ui/src/index.ts
+++ b/services/tenant-ui/src/index.ts
@@ -55,9 +55,16 @@ app.use(API_ROOT, router);
 app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
   console.error(err);
 
-  res.status(err.status || 500).json({
+  const status: number = Number.isInteger(err.status) && err.status >= 400 && err.status < 600
+    ? err.status
+    : 500;
+
+  // Do not leak internal error details to the client (CWE-200)
+  const clientMessage = status < 500 ? (err.message || "Bad Request") : "Internal Server Error";
+
+  res.status(status).json({
     error: {
-      message: err.message || "Internal Server Error",
+      message: clientMessage,
     },
   });
 });

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -50,6 +50,7 @@ router.post(
   "/email/reservationConfirmation",
   body("contactEmail").isEmail(),
   body("reservationId").not().isEmpty(),
+  body("serverUrlStatusRoute").isURL({ protocols: ["https"], require_protocol: true }),
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
@@ -67,6 +68,7 @@ router.post(
   body("contactEmail").isEmail(),
   body("reservationId").not().isEmpty(),
   body("state").not().isEmpty(),
+  body("serverUrlStatusRoute").optional().isURL({ protocols: ["https"], require_protocol: true }),
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -29,9 +29,9 @@ router.get(
       req.claims.realm_access.roles.includes(config.get("server.oidc.roleName"))
     ) {
       const result = await innkeeperComponent.login();
-      res.status(200).send(result);
+      res.status(200).json(result);
     } else {
-      res.status(403).send();
+      res.status(403).json({ error: "Forbidden" });
     }
   }
 );
@@ -42,13 +42,14 @@ router.post("/innkeeperReservation", async (req: any, res: Response) => {
   const { token } = await innkeeperComponent.login();
 
   const result = await innkeeperComponent.createReservation(req, token);
-  res.status(201).send(result);
+  res.status(201).json(result);
 });
 
 // Email endpoint
 router.post(
   "/email/reservationConfirmation",
   body("contactEmail").isEmail(),
+  body("contactName").notEmpty().trim().escape(),
   body("reservationId").not().isEmpty(),
   body("serverUrlStatusRoute").isURL({ protocols: ["https"], require_protocol: true }),
   async (req: Request, res: Response) => {
@@ -58,14 +59,15 @@ router.post(
       return;
     }
 
-    const result = await emailComponent.sendConfirmationEmail(req);
-    res.send(result);
+    await emailComponent.sendConfirmationEmail(req);
+    res.status(204).send();
   }
 );
 
 router.post(
   "/email/reservationStatus",
   body("contactEmail").isEmail(),
+  body("contactName").notEmpty().trim().escape(),
   body("reservationId").not().isEmpty(),
   body("state").not().isEmpty(),
   body("serverUrlStatusRoute").optional().isURL({ protocols: ["https"], require_protocol: true }),
@@ -76,7 +78,7 @@ router.post(
       return;
     }
 
-    const result = await emailComponent.sendStatusEmail(req);
-    res.send(result);
+    await emailComponent.sendStatusEmail(req);
+    res.status(204).send();
   }
 );

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -52,11 +52,16 @@ router.get(
 
 // Protected reservation endpoint
 router.post("/innkeeperReservation", async (req: any, res: Response) => {
-  // Get innkeeper token from login method
-  const { token } = await innkeeperComponent.login();
+  try {
+    // Get innkeeper token from login method
+    const { token } = await innkeeperComponent.login();
 
-  const result = await innkeeperComponent.createReservation(req, token);
-  res.status(201).json(result);
+    const result = await innkeeperComponent.createReservation(req, token);
+    res.status(201).json(result);
+  } catch (error) {
+    console.error("Reservation creation failed", error);
+    res.status(500).json({ error: "Unable to create reservation" });
+  }
 });
 
 // Email endpoint

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -63,7 +63,7 @@ router.post("/innkeeperReservation", async (req: any, res: Response) => {
 router.post(
   "/email/reservationConfirmation",
   body("contactEmail").isEmail(),
-  body("contactName").notEmpty().trim().escape(),
+  body("contactName").trim().notEmpty().customSanitizer((v) => v.replace(/[\r\n]/g, "")),
   body("reservationId").not().isEmpty(),
   body("serverUrlStatusRoute").custom(isAllowedStatusRouteUrl),
   async (req: Request, res: Response) => {
@@ -81,7 +81,7 @@ router.post(
 router.post(
   "/email/reservationStatus",
   body("contactEmail").isEmail(),
-  body("contactName").notEmpty().trim().escape(),
+  body("contactName").trim().notEmpty().customSanitizer((v) => v.replace(/[\r\n]/g, "")),
   body("reservationId").not().isEmpty(),
   body("state").not().isEmpty(),
   body("serverUrlStatusRoute").optional().custom(isAllowedStatusRouteUrl),

--- a/services/tenant-ui/src/routes/router.ts
+++ b/services/tenant-ui/src/routes/router.ts
@@ -4,7 +4,21 @@
 
 import express, { Request, Response } from "express";
 import config from "config";
-import { body, validationResult } from "express-validator";
+import { body, validationResult, CustomValidator } from "express-validator";
+
+// Allow https for any host, or http only for local development origins.
+const isAllowedStatusRouteUrl: CustomValidator = (value: string) => {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+  const isLocalhost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  if (url.protocol === "https:") return true;
+  if (url.protocol === "http:" && isLocalhost) return true;
+  throw new Error("URL must use https, or http for localhost only");
+};
 
 import * as emailComponent from "../components/email.js";
 import * as innkeeperComponent from "../components/innkeeper.js";
@@ -51,7 +65,7 @@ router.post(
   body("contactEmail").isEmail(),
   body("contactName").notEmpty().trim().escape(),
   body("reservationId").not().isEmpty(),
-  body("serverUrlStatusRoute").isURL({ protocols: ["https"], require_protocol: true }),
+  body("serverUrlStatusRoute").custom(isAllowedStatusRouteUrl),
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
@@ -70,7 +84,7 @@ router.post(
   body("contactName").notEmpty().trim().escape(),
   body("reservationId").not().isEmpty(),
   body("state").not().isEmpty(),
-  body("serverUrlStatusRoute").optional().isURL({ protocols: ["https"], require_protocol: true }),
+  body("serverUrlStatusRoute").optional().custom(isAllowedStatusRouteUrl),
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {

--- a/services/tenant-ui/test/helpers/index.spec.ts
+++ b/services/tenant-ui/test/helpers/index.spec.ts
@@ -9,7 +9,19 @@ describe("buildStatusAutofill", () => {
 
   it("should return a correctly formed url including the body params", () => {
     expect(buildStatusAutofill(body)).toBe(
-      "http://tenant-ui.gov.bc.ca?email=my.email@gov.fake&id=50542cfe-e9bd-4881-8a71-1b529f40bc2b"
+      "http://tenant-ui.gov.bc.ca?email=my.email%40gov.fake&id=50542cfe-e9bd-4881-8a71-1b529f40bc2b"
+    );
+  });
+
+  it("should percent-encode special characters in email and id", () => {
+    expect(
+      buildStatusAutofill({
+        serverUrlStatusRoute: "https://example.com/check",
+        contactEmail: "user+tag@example.com",
+        reservationId: "id with spaces & symbols=1",
+      })
+    ).toBe(
+      "https://example.com/check?email=user%2Btag%40example.com&id=id%20with%20spaces%20%26%20symbols%3D1"
     );
   });
 


### PR DESCRIPTION
This pull request introduces several improvements across the backend and frontend to enhance security, reliability, and user experience. The most significant changes include tightening CORS headers, improving email sending security, refining error handling, and updating API response formats. Additionally, there are frontend improvements for displaying DIDs and validating input.

**Security and Reliability Improvements:**

* CORS headers in `tenant-proxy.conf.template` were changed to always use a wildcard (`*`) for `Access-Control-Allow-Origin` and removed credential support, reducing the risk of misconfiguration and potential CORS vulnerabilities. I am not 100% sure about this, @loneil and @WadeBarnes if you can chime in it would be great.
* Nodemailer transporter in `email.ts` is now created once at module load with `requireTLS: true`, ensuring credentials are never sent without TLS, which addresses CWE-523 (sensitive data exposure). We are not using a local SMTP server so this should be fine - TLS should be enabled in the BCGov mailer.
* Improved error handling in `index.ts` to avoid leaking internal error details to clients (addresses CWE-200), and ensures only valid HTTP status codes are sent.

**API and Validation Enhancements:**

* API endpoints in `router.ts` now consistently return JSON responses (using `.json()`), provide more informative error messages, and use status code 204 for successful email operations. Input validation is stricter, requiring non-empty `contactName`, valid email, and HTTPS URLs for certain fields. [[1]](diffhunk://#diff-c7bd93c47b88253eb9674f0ba9bf980aabc013e44ff552737341703426385f2eL32-R34) [[2]](diffhunk://#diff-c7bd93c47b88253eb9674f0ba9bf980aabc013e44ff552737341703426385f2eL45-R82)
* The status autofill URL in `helpers/index.ts` now uses `encodeURIComponent` for query parameters, ensuring proper escaping of user input.

**Frontend Usability Improvements:**

* The DID preview in `Identifiers.vue` now displays a more readable format with the domain, namespace, and alias highlighted, and simplifies the logic for extracting the domain from the server URL. [[1]](diffhunk://#diff-3a411e7ac021c909b8c7fd969776c8011d8e923a674bebed38a770bc7858c3faL174-R174) [[2]](diffhunk://#diff-3a411e7ac021c909b8c7fd969776c8011d8e923a674bebed38a770bc7858c3faL483-L503)