### PR TITLE
Migrate workflows to push to ministry-gitops-ditp repository.

### DIFF
--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -60,14 +60,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Checkout services directory from the trust-over-ip-configurations repo
+      - name: Checkout services directory from the ministry-gitops-ditp repo
         uses: actions/checkout@v6
         with:
-          repository: bcgov/trust-over-ip-configurations
+          repository: bcgov-c/ministry-gitops-ditp
           ssh-key: ${{ secrets.DITP_CONFIGS_REPO_SECRET }}
           sparse-checkout: |
             services
-          path: trust-over-ip-configurations
+          path: ministry-gitops-ditp
 
       - name: Lookup latest chart
         id: chart_version
@@ -82,7 +82,7 @@ jobs:
           APP_VERSION: ${{ steps.chart_version.outputs.APP_VERSION }}
           CHART_VERSION: ${{ steps.chart_version.outputs.CHART_VERSION }}
         run: |
-          cd trust-over-ip-configurations
+          cd ministry-gitops-ditp
           yq e -i '.appVersion = env(APP_VERSION)' services/traction/charts/test/Chart.yaml
           yq e -i '.version = env(CHART_VERSION)' services/traction/charts/test/Chart.yaml
           yq e -i '.dependencies[0].version = env(CHART_VERSION)' services/traction/charts/test/Chart.yaml
@@ -92,14 +92,14 @@ jobs:
           APP_VERSION: ${{ steps.chart_version.outputs.APP_VERSION }}
           CHART_VERSION: ${{ steps.chart_version.outputs.CHART_VERSION }}
         run: |
-          cd trust-over-ip-configurations
+          cd ministry-gitops-ditp
           yq e -i '.appVersion = env(APP_VERSION)' services/traction/charts/prod/Chart.yaml
           yq e -i '.version = env(CHART_VERSION)' services/traction/charts/prod/Chart.yaml
           yq e -i '.dependencies[0].version = env(CHART_VERSION)' services/traction/charts/prod/Chart.yaml
 
-      - name: Commit and Push to trust-over-ip-configurations Repo
+      - name: Commit and Push to ministry-gitops-ditp Repo
         run: |
-          cd trust-over-ip-configurations
+          cd ministry-gitops-ditp
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add services/traction/charts/test/Chart.yaml services/traction/charts/prod/Chart.yaml

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -80,14 +80,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Checkout services directory from the trust-over-ip-configurations repo
+      - name: Checkout services directory from the ministry-gitops-ditp repo
         uses: actions/checkout@v6
         with:
-          repository: bcgov/trust-over-ip-configurations
+          repository: bcgov-c/ministry-gitops-ditp
           ssh-key: ${{ secrets.DITP_CONFIGS_REPO_SECRET }}
           sparse-checkout: |
             services
-          path: trust-over-ip-configurations
+          path: ministry-gitops-ditp
 
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
@@ -103,8 +103,8 @@ jobs:
 
       - name: Deploy Traction to Development
         run: |
-          cp trust-over-ip-configurations/services/traction/charts/dev/values.yaml ./dev-values.yaml
-          yq e -i 'del(.traction) | . *= load("trust-over-ip-configurations/services/traction/charts/dev/values.yaml").traction' ./dev-values.yaml
+          cp ministry-gitops-ditp/services/traction/charts/dev/values.yaml ./dev-values.yaml
+          yq e -i 'del(.traction) | . *= load("ministry-gitops-ditp/services/traction/charts/dev/values.yaml").traction' ./dev-values.yaml
           helm upgrade --install traction -f ./dev-values.yaml --set acapy.image.tag=${{ needs.build_acapy.outputs.image_version }} --set tenant_proxy.image.tag=${{ needs.build_acapy.outputs.image_version }} --set ui.image.tag=${{ needs.build_ui.outputs.image_version }} ./charts/traction --wait --timeout 10m
 
       - name: Restart Deployments


### PR DESCRIPTION
As part of the plan to sunset the `trust-over-ip-configurations` repo, the workflows must be updated.
- Updated required secret with the new SSH deploy key for `ministry-gitops-ditp` repo
- Updated chart_release workflow
- Updated on_push_main workflow