### PR TITLE
ci: retention policy for old tagged images

### DIFF
--- a/.github/actions/build_acapy/action.yaml
+++ b/.github/actions/build_acapy/action.yaml
@@ -45,6 +45,9 @@ runs:
       with:
         ref: ${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -73,10 +76,14 @@ runs:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/acapy-buildcache:main
-        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/acapy-buildcache:main,mode=max,ttl=168h
+        annotations: ${{ steps.meta.outputs.annotations }}
+        provenance: mode=min
+        sbom: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - id: values
       shell: bash

--- a/.github/actions/build_acapy/action.yaml
+++ b/.github/actions/build_acapy/action.yaml
@@ -41,18 +41,18 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.registry}}
         username: ${{ inputs.registry_username}}
@@ -60,7 +60,7 @@ runs:
 
     - name: Prepare docker tags for image
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ inputs.registry }}/${{ inputs.image_name }}
         tags: |
@@ -71,7 +71,7 @@ runs:
 
     - name: Build and push image
       id: builder
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}

--- a/.github/actions/build_ui/action.yaml
+++ b/.github/actions/build_ui/action.yaml
@@ -36,12 +36,12 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ inputs.ref != '' && inputs.ref ||  env.GITHUB_REF }}
 
     - name: Set up Node
-      uses: actions/setup-node@master
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 24
         cache: npm
@@ -84,13 +84,13 @@ runs:
         npm run build
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.registry}}
         username: ${{ inputs.registry_username}}
@@ -98,7 +98,7 @@ runs:
 
     - name: Prepare docker tags for image
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ inputs.registry }}/${{ inputs.image_name }}
         tags: |
@@ -109,7 +109,7 @@ runs:
 
     - name: Build and push image
       id: builder
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: ${{ inputs.context }}
         push: true

--- a/.github/actions/build_ui/action.yaml
+++ b/.github/actions/build_ui/action.yaml
@@ -83,6 +83,9 @@ runs:
         cd ${{ inputs.context }}/frontend
         npm run build
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -110,10 +113,14 @@ runs:
       with:
         context: ${{ inputs.context }}
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/ui-buildcache:main
-        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/ui-buildcache:main,mode=max,ttl=168h
+        annotations: ${{ steps.meta.outputs.annotations }}
+        provenance: mode=min
+        sbom: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - id: values
       shell: bash

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'bcgov'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: gh-pages
       - name: Download remote index file and check equality
@@ -32,7 +32,7 @@ jobs:
     if: github.repository_owner == 'bcgov'
     needs: [ validate-chart-index ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Configure Git
@@ -40,7 +40,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Add repositories
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -58,10 +58,10 @@ jobs:
     needs:
       - chart-release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Checkout services directory from the ministry-gitops-ditp repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: bcgov-c/ministry-gitops-ditp
           ssh-key: ${{ secrets.DITP_GITOPS_REPO_SECRET }}

--- a/.github/workflows/delete_images.yaml
+++ b/.github/workflows/delete_images.yaml
@@ -1,8 +1,8 @@
 name: Delete old container images
 
 on:
-  # schedule:
-  #   - cron: "0 2 * * 2" # This job runs every Tuesday
+  schedule:
+    - cron: "0 2 * * 2" # This job runs every Tuesday
   workflow_dispatch:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'bcgov'
     steps:
       - name: Delete container images older than a Month
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: bcgov
           image-names: traction-plugins-acapy, traction-tenant-proxy, traction-tenant-ui

--- a/.github/workflows/delete_images.yaml
+++ b/.github/workflows/delete_images.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'bcgov'
     steps:
       - name: Delete container images older than a Month
-        uses: snok/container-retention-policy@v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: bcgov
           image-names: traction-plugins-acapy, traction-tenant-proxy, traction-tenant-ui

--- a/.github/workflows/on_pr_closed.yaml
+++ b/.github/workflows/on_pr_closed.yaml
@@ -44,11 +44,11 @@ jobs:
 
   clean-ghcr:
     runs-on: ubuntu-22.04
-    if: ${{ false }}
+    if: ${{ always }}
     name: Delete closed PR images
     steps:
       - name: Delete Images
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: bcgov
           image-names: traction-plugins-acapy, traction-tenant-proxy, traction-tenant-ui

--- a/.github/workflows/on_pr_closed.yaml
+++ b/.github/workflows/on_pr_closed.yaml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check out manifest repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ssh-key: ${{ secrets.MANIFEST_REPO_DEPLOY_KEY }}
           repository: ${{ secrets.MANIFEST_REPO }}
           path: charts-repo
 
       - name: Authenticate and set context
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1.3
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
     name: Delete closed PR images
     steps:
       - name: Delete Images
-        uses: snok/container-retention-policy@v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: bcgov
           image-names: traction-plugins-acapy, traction-tenant-proxy, traction-tenant-ui

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -38,7 +38,7 @@ jobs:
     needs:
       - ready
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build UI
         uses: ./.github/actions/build_ui
         id: builder
@@ -60,7 +60,7 @@ jobs:
     needs:
       - ready
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Aca-Py Image
         uses: ./.github/actions/build_acapy
         id: builder
@@ -81,7 +81,7 @@ jobs:
     needs:
       - ready
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Tenant Proxy Image
         uses: ./.github/actions/build_acapy
         id: builder
@@ -106,15 +106,15 @@ jobs:
     if: ${{ always() && (fromJSON(needs.ready.outputs.deploy) == true) && !(contains(needs.*.result, 'failure')) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
         with:
           oc: "4.14"
 
       - name: Authenticate and set context
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1.3
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -137,10 +137,10 @@ jobs:
       - deploy
     if: ${{ (fromJSON(needs.ready.outputs.deploy) == true) && !(contains(needs.*.result, 'failure')) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.number }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Create comment
         if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.number }}
           body: |

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build service
         uses: ./.github/actions/build_ui
         id: builder
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Aca-Py Image
         uses: ./.github/actions/build_acapy
         id: builder
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Aca-Py Image
         uses: ./.github/actions/build_acapy
         id: builder
@@ -78,10 +78,10 @@ jobs:
       - build_proxy
     if: ${{ contains(needs.*.result, 'success') && !(contains(needs.*.result, 'failure')) && (github.repository_owner == 'bcgov') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Checkout services directory from the ministry-gitops-ditp repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: bcgov-c/ministry-gitops-ditp
           ssh-key: ${{ secrets.DITP_GITOPS_REPO_SECRET }}
@@ -90,12 +90,12 @@ jobs:
           path: ministry-gitops-ditp
 
       - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
         with:
           oc: "4.14"
 
       - name: Authenticate and set context
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1.3
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}

--- a/.github/workflows/release_assets.yaml
+++ b/.github/workflows/release_assets.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v6    
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Aca-Py Image
         uses: ./.github/actions/build_acapy
         id: builder
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bcgov'
     steps:      
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build UI
         uses: ./.github/actions/build_ui
         id: builder
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Tenant Proxy Image
         uses: ./.github/actions/build_acapy
         id: builder

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'bcgov'
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'

--- a/.github/workflows/test_innkeeper_plugin.yaml
+++ b/.github/workflows/test_innkeeper_plugin.yaml
@@ -18,16 +18,16 @@ jobs:
       #       Check out repo
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       #----------------------------------------------
       #       Install python and poetry with cache
       #----------------------------------------------
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.13"
       - name: Install poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
           version: 2.1.1
           virtualenvs-create: true

--- a/.github/workflows/test_tenant_ui.yml
+++ b/.github/workflows/test_tenant_ui.yml
@@ -22,9 +22,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -45,9 +45,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"


### PR DESCRIPTION
Addresses #1969 

## Changes:
- Updated `snok/container-retention-policy` action to `3.1.0` with a fix
- Re-enabled cron schedule and action
- Added `docker/setup-qemu-action@v4` — provides user-space CPU emulation so the `amd64` GitHub runners can cross-compile `arm64` layers
- Added `platforms: linux/amd64,linux/arm64` to every `docker/build-push-action` step
- Added `annotations: ${{ steps.meta.outputs.annotations }}` to every `docker/build-push-action` step — propagates OCI standard labels (`org.opencontainers.image.*`) to the manifest index
- Added `cache-from/cache-to: type=gha` — multi-arch builds are ~2× slower; GHA layer cache significantly reduces rebuild time on repeated pushes