### PR TITLE
Blank out default link

### DIFF
--- a/services/tenant-ui/config/default.json
+++ b/services/tenant-ui/config/default.json
@@ -30,8 +30,8 @@
       "coverImageCopyright": "Photo by Kristoffer Fredriksson on StockSnap",
       "aboutBusiness": {
         "title": "Government of British Columbia",
-        "linkTitle": "BC Digital Trust Service Agreement",
-        "link": "https://github.com/bcgov/bc-vcpedia/blob/main/agents/bc-gov-agent-service.md",
+        "linkTitle": "",
+        "link": "",
         "imageUrl": "/img/bc/bc_logo.png"
       },
       "infoBanner": {


### PR DESCRIPTION
Set the default for the About link to nothing. We don't have an existing reachable service agreement link at the moment.