### PR TITLE
Default helm vals for about page description

### DIFF
--- a/charts/traction/README.md
+++ b/charts/traction/README.md
@@ -296,8 +296,8 @@ kubectl delete secret,pvc --selector "app.kubernetes.io/instance"=my-release
 | ui.smtp.user | string | `""` | SMTP user (use ui.smtp.existingSecret to provide SERVER_SMTP_PASSWORD) |
 | ui.tolerations | list | `[]` |  |
 | ui.ux.aboutBusiness.imageUrl | string | `"/img/bc/bc_logo.png"` |  |
-| ui.ux.aboutBusiness.link | string | `"https://github.com/bcgov/bc-vcpedia/blob/main/agents/bc-gov-agent-service.md"` |  |
-| ui.ux.aboutBusiness.linkTitle | string | `"BC Digital Trust Service Agreement"` |  |
+| ui.ux.aboutBusiness.link | string | `""` |  |
+| ui.ux.aboutBusiness.linkTitle | string | `""` |  |
 | ui.ux.aboutBusiness.title | string | `"Government of British Columbia"` |  |
 | ui.ux.appInnkeeperTitle | string | `"Traction Innkeeper Console"` | Title of the Innkeeper Console |
 | ui.ux.appTitle | string | `"Traction Tenant Console"` | Title of the application |

--- a/charts/traction/values.yaml
+++ b/charts/traction/values.yaml
@@ -503,8 +503,8 @@ ui:
     ##
     aboutBusiness:
       title: "Government of British Columbia"
-      linkTitle: "BC Digital Trust Service Agreement"
-      link: "https://github.com/bcgov/bc-vcpedia/blob/main/agents/bc-gov-agent-service.md"
+      linkTitle: ""
+      link: ""
       imageUrl: "/img/bc/bc_logo.png"
 
     ## Information banner settings

--- a/services/tenant-ui/frontend/test/__mocks__/api/responses/config.ts
+++ b/services/tenant-ui/frontend/test/__mocks__/api/responses/config.ts
@@ -22,8 +22,8 @@ const config = {
       coverImageCopyright: 'Photo by Kristoffer Fredriksson on StockSnap',
       aboutBusiness: {
         title: 'Government of British Columbia',
-        linkTitle: 'BC Digital Trust Service Agreement',
-        link: 'https://github.com/bcgov/bc-vcpedia/blob/main/agents/bc-gov-agent-service.md',
+        linkTitle: '',
+        link: '',
         imageUrl: '/img/bc/bc_logo.png',
       },
     },


### PR DESCRIPTION
Forgot to adjust these when I removed the inline defaults