### PR TITLE
Fix(actions): PR cleanup workflow not triggering for some PRs

### DIFF
--- a/.github/workflows/on_pr_closed.yaml
+++ b/.github/workflows/on_pr_closed.yaml
@@ -8,6 +8,7 @@ on:
       - "services/tenant-ui/**"
       - "charts/traction/**"
       - "charts/tenant-ui/**"
+      - "deploy/traction/**"
     types:
       - closed
 
@@ -44,7 +45,7 @@ jobs:
 
   clean-ghcr:
     runs-on: ubuntu-22.04
-    if: ${{ always }}
+    if: ${{ always() }}
     name: Delete closed PR images
     steps:
       - name: Delete Images


### PR DESCRIPTION
resolves #2000

on_pr_closed workflow preventing proper cleanup:

- Missing "deploy/traction/**" in paths filter
- `${{ always }}` evaluates the string "always", not the status check function -> `${{ always() }}`.