### PR TITLE
Add "adopt wallet" tenant creation endpoint

### DIFF
--- a/plugins/traction_innkeeper/README.md
+++ b/plugins/traction_innkeeper/README.md
@@ -57,6 +57,7 @@ This is useful for the innkeeper as the `tenant_id` can be configured, so it is 
 - `GET /innkeeper/reservations`
 - `PUT /innkeeper/reservations/{reservation_id}/approve`
 - `GET /innkeeper/tenants`
+- `POST /innkeeper/tenants/adopt` (create a tenant record over an existing wallet - e.g. one relocated via acapy-tools `tenant-import`)
 - `GET /innkeeper/tenants/{tenant_id}`
 
 innkeeper is a "special" tenant, use middleware to restrict these calls.  

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
@@ -1000,6 +1000,7 @@ async def innkeeper_tenant_adopt(request: web.BaseRequest):
         raise web.HTTPConflict(reason=f"Wallet {wallet_id} already belongs to tenant {existing.tenant_id}.")
 
     connected_to_endorsers = [EndorserLedgerConfig(**config) for config in body.get("connect_to_endorser") or []]
+    # Admin adoption persists config as-is; unlike create_wallet, no auto_issuer gating.
     tenant = await mgr.create_tenant(
         wallet_id=wallet_id,
         email=body.get("contact_email"),

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/routes.py
@@ -29,7 +29,7 @@ from multitenant_provider.v1_0.routes import plugin_wallet_create_token
 from marshmallow import fields, validate
 
 from . import TenantManager
-from .config import InnkeeperWalletConfig
+from .config import EndorserLedgerConfig, InnkeeperWalletConfig
 from .models import (
     ReservationRecord,
     ReservationRecordSchema,
@@ -267,6 +267,67 @@ class TenantIdMatchInfoSchema(OpenAPISchema):
     tenant_id = fields.Str(
         required=True,
         metadata={"description": "Tenant identifier", "example": UUIDFour.EXAMPLE},
+    )
+
+
+class TenantAdoptRequestSchema(OpenAPISchema):
+    """Request schema for adopting an existing wallet as a tenant."""
+
+    wallet_id = fields.Str(
+        required=True,
+        metadata={
+            "description": "Existing Wallet Record identifier (e.g. an imported wallet)",
+            "example": UUIDFour.EXAMPLE,
+        },
+    )
+
+    tenant_name = fields.Str(
+        required=False,
+        metadata={
+            "description": "Name of Tenant; defaults to the wallet label/name",
+            "example": "line of business short name",
+        },
+    )
+
+    contact_email = fields.Str(
+        required=False,
+        metadata={
+            "description": "Contact email for this tenant",
+        },
+    )
+
+    connect_to_endorser = fields.List(
+        fields.Nested(EndorserLedgerConfigSchema()),
+        required=False,
+        metadata={
+            "description": "Endorser config",
+        },
+    )
+
+    create_public_did = fields.List(
+        fields.Str(
+            metadata={
+                "description": "Ledger identifier",
+            },
+        ),
+        required=False,
+        metadata={
+            "description": "Public DID config",
+        },
+    )
+
+    auto_issuer = fields.Bool(
+        required=False,
+        metadata={
+            "description": "True if tenant can make itself issuer, false if only innkeeper can",
+        },
+    )
+
+    enable_ledger_switch = fields.Bool(
+        required=False,
+        metadata={
+            "description": "True if tenant can switch endorser/ledger",
+        },
     )
 
 
@@ -913,6 +974,45 @@ async def innkeeper_tenant_restore(request: web.BaseRequest):
             raise web.HTTPNotFound(reason=f"Tenant {tenant_id} not found.")
 
 
+@docs(tags=[SWAGGER_CATEGORY], summary="Adopt an existing wallet as a tenant")
+@request_schema(TenantAdoptRequestSchema())
+@response_schema(TenantRecordSchema(), 200, description="")
+@innkeeper_only
+@error_handler
+async def innkeeper_tenant_adopt(request: web.BaseRequest):
+    context: AdminRequestContext = request["context"]
+
+    body = await request.json()
+    wallet_id = body.get("wallet_id")
+
+    # records are under base/root profile, use Tenant Manager profile
+    mgr = context.inject(TenantManager)
+    profile = mgr.profile
+
+    async with profile.session() as session:
+        # 404 if there is no wallet to adopt...
+        await WalletRecord.retrieve_by_id(session, wallet_id)
+        try:
+            existing = await TenantRecord.query_by_wallet_id(session, wallet_id)
+        except StorageNotFoundError:
+            existing = None
+    if existing:
+        raise web.HTTPConflict(reason=f"Wallet {wallet_id} already belongs to tenant {existing.tenant_id}.")
+
+    connected_to_endorsers = [EndorserLedgerConfig(**config) for config in body.get("connect_to_endorser") or []]
+    tenant = await mgr.create_tenant(
+        wallet_id=wallet_id,
+        email=body.get("contact_email"),
+        connected_to_endorsers=connected_to_endorsers,
+        created_public_did=body.get("create_public_did") or [],
+        auto_issuer=body.get("auto_issuer") or False,
+        enable_ledger_switch=body.get("enable_ledger_switch") or False,
+        tenant_name=body.get("tenant_name"),
+    )
+
+    return web.json_response(tenant.serialize())
+
+
 @docs(tags=[SWAGGER_CATEGORY], summary="Create API Key Record")
 @request_schema(TenantAuthenticationsApiRequestSchema())
 @response_schema(TenantAuthenticationsApiResponseSchema(), 200, description="")
@@ -1101,6 +1201,7 @@ async def register(app: web.Application):
                 innkeeper_reservations_refresh_password,
             ),
             web.get("/innkeeper/tenants/", innkeeper_tenants_list, allow_head=False),
+            web.post("/innkeeper/tenants/adopt", innkeeper_tenant_adopt),
             web.get("/innkeeper/tenants/{tenant_id}", innkeeper_tenant_get, allow_head=False),
             web.put("/innkeeper/tenants/{tenant_id}/config", tenant_config_update),
             web.delete("/innkeeper/tenants/{tenant_id}", innkeeper_tenant_delete),

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/tenant_manager.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/innkeeper/tenant_manager.py
@@ -143,15 +143,17 @@ class TenantManager:
         auto_issuer: bool = False,
         tenant_id: str = None,
         enable_ledger_switch: bool = False,
+        tenant_name: str = None,
     ):
         try:
             async with self._profile.session() as session:
                 wallet_record = await WalletRecord.retrieve_by_id(session, wallet_id)
-                tenant_name = (
-                    wallet_record.settings.get("default_label")
-                    if wallet_record.settings.get("default_label")
-                    else wallet_record.wallet_name
-                )
+                if not tenant_name:
+                    tenant_name = (
+                        wallet_record.settings.get("default_label")
+                        if wallet_record.settings.get("default_label")
+                        else wallet_record.wallet_name
+                    )
                 tenant: TenantRecord = TenantRecord(
                     tenant_id=tenant_id,
                     tenant_name=tenant_name,

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_innkeeper_routes.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_innkeeper_routes.py
@@ -799,6 +799,172 @@ async def test_innkeeper_tenant_restore_not_deleted(
     MockTenantRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_TENANT_ID)
 
 
+# Test Tenant Adopt (POST /innkeeper/tenants/adopt)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tenant_mgr")
+@patch(f"{test_module.__name__}.WalletRecord", autospec=True)
+@patch(f"{test_module.__name__}.TenantRecord", autospec=True)
+async def test_innkeeper_tenant_adopt(
+    MockTenantRecordCls: MagicMock,
+    MockWalletRecordCls: MagicMock,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_tenant_mgr: MagicMock,
+):
+    """Test POST /innkeeper/tenants/adopt endpoint."""
+    profile = mock_context.profile
+    adopt_body = {
+        "wallet_id": TEST_WALLET_ID,
+        "tenant_name": "Adopted Tenant",
+        "contact_email": "adopted@example.com",
+        "connect_to_endorser": [{"endorser_alias": "test-endorser", "ledger_id": "ledger-1"}],
+        "create_public_did": ["ledger-1"],
+        "auto_issuer": True,
+    }
+
+    # Mock request body
+    mock_request._set_json_body(adopt_body)
+
+    # Mock WalletRecord retrieval (wallet exists) and no existing TenantRecord
+    MockWalletRecordCls.retrieve_by_id = AsyncMock()
+    MockTenantRecordCls.query_by_wallet_id = AsyncMock(side_effect=StorageNotFoundError("No TenantRecord"))
+
+    # Mock TenantManager create_tenant
+    mock_tenant_rec = MagicMock(spec=TenantRecord)
+    mock_tenant_rec.serialize.return_value = {
+        "tenant_id": TEST_TENANT_ID,
+        "wallet_id": TEST_WALLET_ID,
+    }
+    mock_tenant_mgr.create_tenant = AsyncMock(return_value=mock_tenant_rec)
+
+    mock_context.inject.return_value = mock_tenant_mgr
+
+    response = await test_module.innkeeper_tenant_adopt(mock_request)
+
+    assert profile.settings.get("wallet.innkeeper") is True
+    mock_context.inject.assert_called_once_with(test_module.TenantManager)
+    mock_request.json.assert_awaited_once()
+    MockWalletRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_WALLET_ID)
+    MockTenantRecordCls.query_by_wallet_id.assert_awaited_once_with(ANY, TEST_WALLET_ID)
+    mock_tenant_mgr.create_tenant.assert_awaited_once_with(
+        wallet_id=TEST_WALLET_ID,
+        email="adopted@example.com",
+        connected_to_endorsers=[EndorserLedgerConfig(endorser_alias="test-endorser", ledger_id="ledger-1")],
+        created_public_did=["ledger-1"],
+        auto_issuer=True,
+        enable_ledger_switch=False,
+        tenant_name="Adopted Tenant",
+    )
+    mock_tenant_rec.serialize.assert_called_once()
+    assert response.status == 200
+    assert json.loads(response.body) == {
+        "tenant_id": TEST_TENANT_ID,
+        "wallet_id": TEST_WALLET_ID,
+    }
+
+
+# Test Tenant Adopt - defaults (minimal body)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tenant_mgr")
+@patch(f"{test_module.__name__}.WalletRecord", autospec=True)
+@patch(f"{test_module.__name__}.TenantRecord", autospec=True)
+async def test_innkeeper_tenant_adopt_defaults(
+    MockTenantRecordCls: MagicMock,
+    MockWalletRecordCls: MagicMock,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_tenant_mgr: MagicMock,
+):
+    """Test POST /innkeeper/tenants/adopt endpoint with only wallet_id."""
+
+    # Mock request body
+    mock_request._set_json_body({"wallet_id": TEST_WALLET_ID})
+
+    # Mock WalletRecord retrieval (wallet exists) and no existing TenantRecord
+    MockWalletRecordCls.retrieve_by_id = AsyncMock()
+    MockTenantRecordCls.query_by_wallet_id = AsyncMock(side_effect=StorageNotFoundError("No TenantRecord"))
+
+    # Mock TenantManager create_tenant
+    mock_tenant_rec = MagicMock(spec=TenantRecord)
+    mock_tenant_rec.serialize.return_value = {"tenant_id": TEST_TENANT_ID}
+    mock_tenant_mgr.create_tenant = AsyncMock(return_value=mock_tenant_rec)
+
+    mock_context.inject.return_value = mock_tenant_mgr
+
+    response = await test_module.innkeeper_tenant_adopt(mock_request)
+
+    mock_tenant_mgr.create_tenant.assert_awaited_once_with(
+        wallet_id=TEST_WALLET_ID,
+        email=None,
+        connected_to_endorsers=[],
+        created_public_did=[],
+        auto_issuer=False,
+        enable_ledger_switch=False,
+        tenant_name=None,
+    )
+    assert response.status == 200
+    assert json.loads(response.body) == {"tenant_id": TEST_TENANT_ID}
+
+
+# Test Tenant Adopt - Conflict (wallet already belongs to a tenant)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tenant_mgr")
+@patch(f"{test_module.__name__}.WalletRecord", autospec=True)
+@patch(f"{test_module.__name__}.TenantRecord", autospec=True)
+async def test_innkeeper_tenant_adopt_conflict(
+    MockTenantRecordCls: MagicMock,
+    MockWalletRecordCls: MagicMock,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_tenant_mgr: MagicMock,
+):
+    """Test POST /innkeeper/tenants/adopt endpoint conflict."""
+
+    # Mock request body
+    mock_request._set_json_body({"wallet_id": TEST_WALLET_ID})
+
+    # Mock WalletRecord retrieval (wallet exists) and an existing TenantRecord
+    MockWalletRecordCls.retrieve_by_id = AsyncMock()
+    mock_existing_rec = MagicMock(spec=TenantRecord, tenant_id=TEST_TENANT_ID)
+    MockTenantRecordCls.query_by_wallet_id = AsyncMock(return_value=mock_existing_rec)
+
+    mock_context.inject.return_value = mock_tenant_mgr
+
+    with pytest.raises(web.HTTPConflict) as excinfo:
+        await test_module.innkeeper_tenant_adopt(mock_request)
+    assert f"Wallet {TEST_WALLET_ID} already belongs to tenant {TEST_TENANT_ID}" in str(excinfo.value)
+
+    MockTenantRecordCls.query_by_wallet_id.assert_awaited_once_with(ANY, TEST_WALLET_ID)
+    mock_tenant_mgr.create_tenant.assert_not_awaited()
+
+
+# Test Tenant Adopt - Wallet Not Found
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tenant_mgr")
+@patch(f"{test_module.__name__}.WalletRecord", autospec=True)
+async def test_innkeeper_tenant_adopt_wallet_not_found(
+    MockWalletRecordCls: MagicMock,
+    mock_request: MagicMock,
+    mock_context: MagicMock,
+    mock_tenant_mgr: MagicMock,
+):
+    """Test POST /innkeeper/tenants/adopt endpoint when wallet does not exist."""
+
+    # Mock request body
+    mock_request._set_json_body({"wallet_id": TEST_WALLET_ID})
+
+    # Mock WalletRecord retrieval to raise error
+    MockWalletRecordCls.retrieve_by_id = AsyncMock(side_effect=StorageNotFoundError("Not found"))
+
+    mock_context.inject.return_value = mock_tenant_mgr
+
+    with pytest.raises(web.HTTPNotFound):
+        await test_module.innkeeper_tenant_adopt(mock_request)
+
+    MockWalletRecordCls.retrieve_by_id.assert_awaited_once_with(ANY, TEST_WALLET_ID)
+    mock_tenant_mgr.create_tenant.assert_not_awaited()
+
+
 # Test Create API Key (POST /innkeeper/authentications/api)
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_tenant_mgr")

--- a/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_tenant_manager.py
+++ b/plugins/traction_innkeeper/traction_innkeeper/v1_0/tests/test_tenant_manager.py
@@ -830,6 +830,52 @@ async def test_create_tenant_label_fallback(
     mock_tenant_rec_instance.save.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+@patch("traction_innkeeper.v1_0.innkeeper.tenant_manager.WalletRecord", autospec=True)
+@patch("traction_innkeeper.v1_0.innkeeper.tenant_manager.TenantRecord", autospec=True)
+async def test_create_tenant_name_override(
+    MockTenantRecord: MagicMock,
+    MockWalletRecord: MagicMock,
+    tenant_manager: TenantManager,
+    mock_profile,
+):
+    """Test create_tenant uses a provided tenant_name over the wallet label."""
+    profile, session = mock_profile
+    wallet_id = "test-wallet-id"
+    tenant_email = "test@example.com"
+    tenant_name = "ProvidedTenantName"
+
+    # Setup mock WalletRecord with a default_label that should be ignored
+    mock_wallet_rec_instance = MagicMock(spec=WalletRecord)
+    mock_wallet_rec_instance.wallet_id = wallet_id
+    mock_wallet_rec_instance.wallet_name = "ActualWalletName"
+    mock_wallet_rec_instance.settings = {"default_label": "WalletLabel"}
+    MockWalletRecord.retrieve_by_id = AsyncMock(return_value=mock_wallet_rec_instance)
+
+    mock_tenant_rec_instance = AsyncMock(spec=TenantRecord)
+    MockTenantRecord.return_value = mock_tenant_rec_instance
+
+    await tenant_manager.create_tenant(
+        wallet_id=wallet_id,
+        email=tenant_email,
+        tenant_name=tenant_name,
+    )
+
+    # Assert TenantRecord called with the provided tenant_name
+    MockTenantRecord.assert_called_once_with(
+        tenant_id=None,  # Default
+        tenant_name=tenant_name,  # <<< Should use the provided name
+        contact_email=tenant_email,
+        wallet_id=wallet_id,
+        new_with_id=False,
+        connected_to_endorsers=[],
+        created_public_did=[],
+        enable_ledger_switch=False,
+        auto_issuer=False,
+    )
+    mock_tenant_rec_instance.save.assert_awaited_once()
+
+
 # --- Tests for create_innkeeper ---
 
 


### PR DESCRIPTION
See https://github.com/bcgov/DITP-DevOps/issues/354

Adds a POST `/innkeeper/tenants/adopt endpoint` that creates a tenant record over an existing wallet (e.g. one relocated via acapy-tools **tenant-import**), with 404/409 guards for missing wallets and already-adopted ones. Also accepts an optional tenant name override through tenant creation.