### PR TITLE
Reorder tenant-ui Dockerfile so dependency layers cache

### DIFF
--- a/services/tenant-ui/Dockerfile
+++ b/services/tenant-ui/Dockerfile
@@ -1,11 +1,20 @@
 FROM node:24-alpine
 
 WORKDIR /usr/src/app
-COPY . .
+
+# Copy only the dependency manifests first so the npm ci layers
+# stay cached as long as the lockfiles don't change
+COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json ./frontend/
+
 # install backend libs
-RUN npm cache clean --force && npm ci
+RUN npm ci
 # install frontend libs
-RUN cd frontend && npm cache clean --force && npm ci
+RUN cd frontend && npm ci
+
+# Copy in the source - code changes only invalidate layers from here down
+COPY . .
+
 # build backend
 RUN npm run build
 # build frontend

--- a/services/tenant-ui/Dockerfile
+++ b/services/tenant-ui/Dockerfile
@@ -7,10 +7,10 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 COPY frontend/package.json frontend/package-lock.json ./frontend/
 
-# install backend libs
-RUN npm ci
+# install backend libs (clean the npm cache in the same layer so it isn't committed to the image)
+RUN npm ci && npm cache clean --force
 # install frontend libs
-RUN cd frontend && npm ci
+RUN cd frontend && npm ci && npm cache clean --force
 
 # Copy in the source - code changes only invalidate layers from here down
 COPY . .


### PR DESCRIPTION
Traction PR setup is taking a bit too long and annoying me. Seems to be a slow Tenant UI build stage. Can adjust dockerfile to best-practice cache better

The Dockerfile did `COPY . .` before `npm ci`, so any source change invalidated the install layers and the buildx `type=gha` cache never got a hit, both installs re-ran on every PR push.

Switches to the standard Node pattern documented in ([Order your layers](https://docs.docker.com/build/cache/optimize/)): copy manifests, install, then copy source. Lockfiles unchanged → both `npm ci` layers cached. Also moves `npm cache clean --force` to after the install in the same RUN, so the npm download cache is never committed to a layer (cleaning before install, as the old code did, had no effect on size).
