### PR TITLE
 For PRs, skip the QEMU-emulated arm64 leg

### DIFF
--- a/.github/actions/build_acapy/action.yaml
+++ b/.github/actions/build_acapy/action.yaml
@@ -26,6 +26,11 @@ inputs:
     type: string
   registry_password:
     required: true
+  platforms:
+    description: 'Comma-separated target platforms for the image build'
+    required: false
+    type: string
+    default: 'linux/amd64,linux/arm64'
 
 outputs:
   image_tag:
@@ -76,7 +81,7 @@ runs:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ inputs.platforms }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/actions/build_ui/action.yaml
+++ b/.github/actions/build_ui/action.yaml
@@ -21,6 +21,11 @@ inputs:
     type: string
   registry_password:
     required: true
+  platforms:
+    description: "Comma-separated target platforms for the image build"
+    required: false
+    type: string
+    default: "linux/amd64,linux/arm64"
 
 outputs:
   image_tag:
@@ -113,7 +118,7 @@ runs:
       with:
         context: ${{ inputs.context }}
         push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ inputs.platforms }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -48,6 +48,8 @@ jobs:
           registry: ghcr.io
           registry_username: ${{ github.repository_owner}}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
+          # PR images only ever deploy to OpenShift (amd64); skip the slow QEMU-emulated arm64 build
+          platforms: linux/amd64
     outputs:
       image_tag: ${{ steps.builder.outputs.image_tag }}
       image_version: ${{ steps.builder.outputs.image_version }}
@@ -71,6 +73,7 @@ jobs:
           registry: ghcr.io
           registry_username: ${{ github.repository_owner}}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
+          platforms: linux/amd64
     outputs:
       image_tag: ${{ steps.builder.outputs.image_tag }}
 
@@ -92,6 +95,7 @@ jobs:
           registry: ghcr.io
           registry_username: ${{ github.repository_owner}}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
+          platforms: linux/amd64
     outputs:
       image_tag: ${{ steps.builder.outputs.image_tag }}
 


### PR DESCRIPTION
Traction PR env setup is taking a bit too long (Build Tenant UI alone was ~7m40s). Almost all of that time is building the `linux/arm64` image under QEMU emulation — the runner is x86, so every ARM instruction gets translated on the fly, making the same steps 5-10x slower (the frontend vite build goes from ~16s native to ~3m emulated).

PR images (`pr-N` tags) are only ever pulled by our OpenShift PR previews, which are amd64-only — the arm64 variant is built, pushed, and never used. So:

- `build_ui` and `build_acapy` actions get an optional `platforms` input, defaulting to the current `linux/amd64,linux/arm64`
- `on_pr_opened.yaml` passes `linux/amd64` for all three PR image builds (tenant-ui, plugins-acapy, tenant-proxy)
- Main and release builds don't pass the input, so they keep publishing multi-arch exactly as before

Should take the tenant-ui PR build from ~7m40s to ~2m, with similar savings on the acapy/proxy jobs.

**Things considered:**

- **"I pull PR images on my M1"** — main/release tags stay multi-arch, so only `pr-N` tags are affected. Docker Desktop on Apple Silicon will still run the amd64 image under emulation if you really need it, or you can build from the branch locally.
- **Early detection of arm64-only build failures** (e.g. a dep with no arm64/musl prebuilt binary) — those can only be introduced by dependency changes, so the arm64 leg is a no-op canary on code-only PRs anyway. Would be caught by merge to main on PR close early (IE, pre any release tag) as well so all good there.
